### PR TITLE
Improve Theme cover based

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -25,11 +25,9 @@ class UiPreferences(
 
     fun themeDarkAmoled() = preferenceStore.getBoolean("pref_theme_dark_amoled_key", false)
 
-    fun detailsPageThemeCoverBased() = preferenceStore.getBoolean("pref_details_page_theme_cover_based_key", true)
+    fun themeCoverBased() = preferenceStore.getBoolean("pref_theme_cover_based_key", true)
 
     fun themeCoverBasedStyle() = preferenceStore.getEnum("pref_theme_cover_based_style_key", PaletteStyle.Vibrant)
-
-    fun themeCoverBasedAnimate() = preferenceStore.getBoolean("pref_theme_cover_based_animate_key", true)
 
     fun relativeTime() = preferenceStore.getBoolean("relative_time_v2", true)
 

--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -29,7 +29,7 @@ class UiPreferences(
 
     fun themeCoverBasedStyle() = preferenceStore.getEnum("pref_theme_cover_based_style_key", PaletteStyle.Vibrant)
 
-    fun themeCoverBasedAnimate() = preferenceStore.getBoolean("pref_theme_cover_based_animate_key", false)
+    fun themeCoverBasedAnimate() = preferenceStore.getBoolean("pref_theme_cover_based_animate_key", true)
 
     fun relativeTime() = preferenceStore.getBoolean("relative_time_v2", true)
 

--- a/app/src/main/java/eu/kanade/presentation/history/components/HistoryItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/components/HistoryItem.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -48,10 +49,15 @@ fun HistoryItem(
             .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        val mangaCover = history.coverData
+        val bgColor = mangaCover.dominantCoverColors?.first?.let { Color(it) }
+        val onBgColor = mangaCover.dominantCoverColors?.second
         MangaCover.Book(
             modifier = Modifier.fillMaxHeight(),
-            data = history.coverData,
+            data = mangaCover,
             onClick = onClickCover,
+            bgColor = bgColor,
+            tint = onBgColor,
         )
         Column(
             modifier = Modifier

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -27,18 +27,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import eu.kanade.presentation.manga.components.CoverPlaceholderColor
 import eu.kanade.presentation.manga.components.MangaCover
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.BadgeGroup
@@ -74,7 +71,10 @@ fun MangaCompactGridItem(
     coverAlpha: Float = 1f,
     coverBadgeStart: @Composable (RowScope.() -> Unit)? = null,
     coverBadgeEnd: @Composable (RowScope.() -> Unit)? = null,
+    libraryColored: Boolean? = null,
 ) {
+    val bgColor = libraryColored?.let { coverData.dominantCoverColors?.first?.let { Color(it) } }
+    val onBgColor = libraryColored?.let { coverData.dominantCoverColors?.second }
     GridItemSelectable(
         isSelected = isSelected,
         onClick = onClick,
@@ -84,15 +84,11 @@ fun MangaCompactGridItem(
             cover = {
                 MangaCover.Book(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .background(
-                            color = DomainMangaCover.coverColorMap[coverData.mangaId]?.first?.let { Color(it) }
-                                ?: MaterialTheme.colorScheme.surface
-                        ),
+                        .fillMaxWidth(),
                     alpha = if (isSelected) GridSelectedCoverAlpha else coverAlpha,
                     data = coverData,
-                    tint = DomainMangaCover.coverColorMap[coverData.mangaId]?.second
-                        ?: MaterialTheme.colorScheme.onSurface.toArgb(),
+                    bgColor = bgColor,
+                    tint = onBgColor,
                 )
             },
             badgesStart = coverBadgeStart,
@@ -182,7 +178,10 @@ fun MangaComfortableGridItem(
     coverBadgeStart: (@Composable RowScope.() -> Unit)? = null,
     coverBadgeEnd: (@Composable RowScope.() -> Unit)? = null,
     onClickContinueReading: (() -> Unit)? = null,
+    libraryColored: Boolean? = null,
 ) {
+    val bgColor = libraryColored?.let { coverData.dominantCoverColors?.first?.let { Color(it) } }
+    val onBgColor = libraryColored?.let { coverData.dominantCoverColors?.second }
     GridItemSelectable(
         isSelected = isSelected,
         onClick = onClick,
@@ -193,15 +192,11 @@ fun MangaComfortableGridItem(
                 cover = {
                     MangaCover.Book(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .background(
-                                color = DomainMangaCover.coverColorMap[coverData.mangaId]?.first?.let { Color(it) }
-                                    ?: MaterialTheme.colorScheme.surface
-                            ),
+                            .fillMaxWidth(),
                         alpha = if (isSelected) GridSelectedCoverAlpha else coverAlpha,
                         data = coverData,
-                        tint = DomainMangaCover.coverColorMap[coverData.mangaId]?.second
-                            ?: MaterialTheme.colorScheme.onSurface.toArgb(),
+                        bgColor = bgColor,
+                        tint = onBgColor,
                     )
                 },
                 badgesStart = coverBadgeStart,
@@ -339,7 +334,10 @@ fun MangaListItem(
     isSelected: Boolean = false,
     coverAlpha: Float = 1f,
     onClickContinueReading: (() -> Unit)? = null,
+    libraryColored: Boolean? = null,
 ) {
+    val bgColor = libraryColored?.let { coverData.dominantCoverColors?.first?.let { Color(it) } }
+    val onBgColor = libraryColored?.let { coverData.dominantCoverColors?.second }
     Row(
         modifier = Modifier
             .selectedBackground(isSelected)
@@ -353,15 +351,11 @@ fun MangaListItem(
     ) {
         MangaCover.Square(
             modifier = Modifier
-                .fillMaxHeight()
-                .background(
-                    color = DomainMangaCover.coverColorMap[coverData.mangaId]?.first?.let { Color(it) }
-                        ?: MaterialTheme.colorScheme.surface
-                ),
+                .fillMaxHeight(),
             alpha = coverAlpha,
             data = coverData,
-            tint = DomainMangaCover.coverColorMap[coverData.mangaId]?.second
-                ?: MaterialTheme.colorScheme.onSurface.toArgb(),
+            bgColor = bgColor,
+            tint = onBgColor,
         )
         Text(
             text = title,

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryComfortableGrid.kt
@@ -61,6 +61,7 @@ internal fun LibraryComfortableGrid(
                 } else {
                     null
                 },
+                libraryColored = true,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryCompactGrid.kt
@@ -62,6 +62,7 @@ internal fun LibraryCompactGrid(
                 } else {
                     null
                 },
+                libraryColored = true,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryList.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryList.kt
@@ -69,6 +69,7 @@ internal fun LibraryList(
                 } else {
                     null
                 },
+                libraryColored = true,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -185,6 +185,7 @@ fun MangaScreen(
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
     onCoverLoaded: (MangaCover) -> Unit,
+    onPaletteScreenClick: () -> Unit,
     // KMK <--
 ) {
     val context = LocalContext.current
@@ -246,6 +247,7 @@ fun MangaScreen(
             onRelatedMangaLongClick = onRelatedMangaLongClick,
             onSourceClick = onSourceClick,
             onCoverLoaded = onCoverLoaded,
+            onPaletteScreenClick = onPaletteScreenClick,
             // KMK <--
         )
     } else {
@@ -300,6 +302,7 @@ fun MangaScreen(
             onRelatedMangaLongClick = onRelatedMangaLongClick,
             onSourceClick = onSourceClick,
             onCoverLoaded = onCoverLoaded,
+            onPaletteScreenClick = onPaletteScreenClick,
             // KMK <--
         )
     }
@@ -371,6 +374,7 @@ private fun MangaScreenSmallImpl(
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
     onCoverLoaded: (MangaCover) -> Unit,
+    onPaletteScreenClick: () -> Unit,
     // KMK <--
 ) {
     val chapterListState = rememberLazyListState()
@@ -442,6 +446,7 @@ private fun MangaScreenSmallImpl(
                 actionModeCounter = selectedChapterCount,
                 onSelectAll = { onAllChapterSelected(true) },
                 onInvertSelection = { onInvertSelection() },
+                onPaletteScreenClick = onPaletteScreenClick,
             )
         },
         bottomBar = {
@@ -754,6 +759,7 @@ private fun MangaScreenLargeImpl(
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
     onCoverLoaded: (MangaCover) -> Unit,
+    onPaletteScreenClick: () -> Unit,
     // KMK <--
 ) {
     val layoutDirection = LocalLayoutDirection.current
@@ -816,6 +822,7 @@ private fun MangaScreenLargeImpl(
                 actionModeCounter = selectedChapterCount,
                 onSelectAll = { onAllChapterSelected(true) },
                 onInvertSelection = { onInvertSelection() },
+                onPaletteScreenClick = onPaletteScreenClick,
             )
         },
         bottomBar = {

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -183,6 +183,7 @@ fun MangaScreen(
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
+    onCoverLoaded: (Manga) -> Unit,
     // KMK <--
 ) {
     val context = LocalContext.current
@@ -243,6 +244,7 @@ fun MangaScreen(
             onRelatedMangaClick = onRelatedMangaClick,
             onRelatedMangaLongClick = onRelatedMangaLongClick,
             onSourceClick = onSourceClick,
+            onCoverLoaded = onCoverLoaded,
             // KMK <--
         )
     } else {
@@ -296,6 +298,7 @@ fun MangaScreen(
             onRelatedMangaClick = onRelatedMangaClick,
             onRelatedMangaLongClick = onRelatedMangaLongClick,
             onSourceClick = onSourceClick,
+            onCoverLoaded = onCoverLoaded,
             // KMK <--
         )
     }
@@ -366,6 +369,7 @@ private fun MangaScreenSmallImpl(
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
+    onCoverLoaded: (Manga) -> Unit,
     // KMK <--
 ) {
     val chapterListState = rememberLazyListState()
@@ -520,6 +524,7 @@ private fun MangaScreenSmallImpl(
                             doSearch = onSearch,
                             // KMK -->
                             onSourceClick = onSourceClick,
+                            onCoverLoaded = onCoverLoaded,
                             // KMK <--
                         )
                     }
@@ -747,6 +752,7 @@ private fun MangaScreenLargeImpl(
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
+    onCoverLoaded: (Manga) -> Unit,
     // KMK <--
 ) {
     val layoutDirection = LocalLayoutDirection.current
@@ -893,6 +899,7 @@ private fun MangaScreenLargeImpl(
                             doSearch = onSearch,
                             // KMK -->
                             onSourceClick = onSourceClick,
+                            onCoverLoaded = onCoverLoaded,
                             // KMK <--
                         )
                         MangaActionRow(

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -101,6 +101,7 @@ import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.service.missingChaptersCount
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.MangaCover
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.kmk.KMR
@@ -183,7 +184,7 @@ fun MangaScreen(
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
-    onCoverLoaded: (Manga) -> Unit,
+    onCoverLoaded: (MangaCover) -> Unit,
     // KMK <--
 ) {
     val context = LocalContext.current
@@ -369,7 +370,7 @@ private fun MangaScreenSmallImpl(
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
-    onCoverLoaded: (Manga) -> Unit,
+    onCoverLoaded: (MangaCover) -> Unit,
     // KMK <--
 ) {
     val chapterListState = rememberLazyListState()
@@ -752,7 +753,7 @@ private fun MangaScreenLargeImpl(
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
     onSourceClick: () -> Unit,
-    onCoverLoaded: (Manga) -> Unit,
+    onCoverLoaded: (MangaCover) -> Unit,
     // KMK <--
 ) {
     val layoutDirection = LocalLayoutDirection.current

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ChapterDownloadIndicator.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ChapterDownloadIndicator.kt
@@ -102,7 +102,7 @@ private fun NotDownloadedIndicator(
             painter = painterResource(R.drawable.ic_download_chapter_24dp),
             contentDescription = stringResource(MR.strings.manga_download),
             modifier = Modifier.size(IndicatorSize),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            tint = MaterialTheme.colorScheme.primary,
         )
     }
 }
@@ -128,7 +128,7 @@ private fun DownloadingIndicator(
         contentAlignment = Alignment.Center,
     ) {
         val arrowColor: Color
-        val strokeColor = MaterialTheme.colorScheme.onSurfaceVariant
+        val strokeColor = MaterialTheme.colorScheme.primary
         val downloadProgress = downloadProgressProvider()
         val indeterminate = downloadState == Download.State.QUEUE ||
             (downloadState == Download.State.DOWNLOADING && downloadProgress == 0)
@@ -208,7 +208,7 @@ private fun DownloadedIndicator(
             imageVector = Icons.Filled.CheckCircle,
             contentDescription = null,
             modifier = Modifier.size(IndicatorSize),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            tint = MaterialTheme.colorScheme.primary,
         )
         DropdownMenu(expanded = isMenuExpanded, onDismissRequest = { isMenuExpanded = false }) {
             DropdownMenuItem(

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ChapterHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ChapterHeader.kt
@@ -3,11 +3,16 @@ package eu.kanade.presentation.manga.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FilterList
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -25,7 +30,7 @@ fun ChapterHeader(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    Row(
         modifier = modifier
             .fillMaxWidth()
             .clickable(
@@ -33,19 +38,30 @@ fun ChapterHeader(
                 onClick = onClick,
             )
             .padding(horizontal = 16.dp, vertical = 4.dp),
-        verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = if (chapterCount == null) {
-                stringResource(MR.strings.chapters)
-            } else {
-                pluralStringResource(MR.plurals.manga_num_chapters, count = chapterCount, chapterCount)
-            },
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onBackground,
-        )
+        Column(
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+        ) {
+            Text(
+                text = if (chapterCount == null) {
+                    stringResource(MR.strings.chapters)
+                } else {
+                    pluralStringResource(MR.plurals.manga_num_chapters, count = chapterCount, chapterCount)
+                },
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
 
-        MissingChaptersWarning(missingChapterCount)
+            MissingChaptersWarning(missingChapterCount)
+        }
+
+        Icon(
+            imageVector = Icons.Outlined.FilterList,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+        )
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaCover.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaCover.kt
@@ -4,6 +4,7 @@ import androidx.annotation.ColorInt
 import androidx.compose.animation.graphics.res.animatedVectorResource
 import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
 import androidx.compose.animation.graphics.vector.AnimatedImageVector
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.material3.MaterialTheme
@@ -16,6 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.Role
@@ -24,6 +26,8 @@ import eu.kanade.presentation.util.rememberResourceBitmapPainter
 import eu.kanade.tachiyomi.R
 import kotlinx.coroutines.delay
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.asMangaCover
+import tachiyomi.domain.manga.model.MangaCover as DomainMangaCover
 
 enum class MangaCover(val ratio: Float) {
     Square(1f / 1f),
@@ -37,9 +41,10 @@ enum class MangaCover(val ratio: Float) {
         contentDescription: String = "",
         shape: Shape = MaterialTheme.shapes.extraSmall,
         onClick: (() -> Unit)? = null,
-        @ColorInt tint: Int = CoverPlaceholderColor,
         alpha: Float = 1f,
-        onCoverLoaded: ((Manga) -> Unit)? = null,
+        bgColor: Color? = null,
+        @ColorInt tint: Int? = null,
+        onCoverLoaded: ((DomainMangaCover) -> Unit)? = null,
     ) {
         val animatedImageVector = AnimatedImageVector.animatedVectorResource(R.drawable.anim_waiting)
         var atEnd by remember { mutableStateOf(false) }
@@ -64,13 +69,19 @@ enum class MangaCover(val ratio: Float) {
             fallback = rememberResourceBitmapPainter(id = R.drawable.cover_error, tint),
             onSuccess = {
                 succeed = true
-                if (onCoverLoaded != null && data is Manga) onCoverLoaded(data)
+                if (onCoverLoaded != null) {
+                    when (data) {
+                        is Manga -> onCoverLoaded(data.asMangaCover())
+                        is DomainMangaCover -> onCoverLoaded(data)
+                    }
+                }
             },
             contentDescription = contentDescription,
             modifier = modifier
                 .aspectRatio(ratio)
                 .clip(shape)
                 .alpha(if (succeed) alpha else 1f)
+                .background(bgColor ?: Color.Transparent)
                 .then(
                     if (onClick != null) {
                         Modifier.clickable(
@@ -86,6 +97,4 @@ enum class MangaCover(val ratio: Float) {
     }
 }
 
-@ColorInt
-internal val CoverPlaceholderColor = 0x7F888888
 const val LoadingAnimatedDuration = 600L

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaCover.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaCover.kt
@@ -23,6 +23,7 @@ import coil3.compose.AsyncImage
 import eu.kanade.presentation.util.rememberResourceBitmapPainter
 import eu.kanade.tachiyomi.R
 import kotlinx.coroutines.delay
+import tachiyomi.domain.manga.model.Manga
 
 enum class MangaCover(val ratio: Float) {
     Square(1f / 1f),
@@ -38,6 +39,7 @@ enum class MangaCover(val ratio: Float) {
         onClick: (() -> Unit)? = null,
         @ColorInt tint: Int = CoverPlaceholderColor,
         alpha: Float = 1f,
+        onCoverLoaded: ((Manga) -> Unit)? = null,
     ) {
         val animatedImageVector = AnimatedImageVector.animatedVectorResource(R.drawable.anim_waiting)
         var atEnd by remember { mutableStateOf(false) }
@@ -60,7 +62,10 @@ enum class MangaCover(val ratio: Float) {
             placeholder = rememberAnimatedVectorPainter(animatedImageVector = animatedImageVector, atEnd = atEnd),
             error = rememberResourceBitmapPainter(id = R.drawable.cover_error, tint),
             fallback = rememberResourceBitmapPainter(id = R.drawable.cover_error, tint),
-            onSuccess = { succeed = true },
+            onSuccess = {
+                succeed = true
+                if (onCoverLoaded != null && data is Manga) onCoverLoaded(data)
+            },
             contentDescription = contentDescription,
             modifier = modifier
                 .aspectRatio(ratio)

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -89,6 +89,7 @@ import tachiyomi.presentation.core.util.secondaryItemAlpha
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.math.roundToInt
+import tachiyomi.domain.manga.model.MangaCover as DomainMangaCover
 
 private val whitespaceLineRegex = Regex("[\\r\\n]{2,}", setOf(RegexOption.MULTILINE))
 
@@ -108,7 +109,7 @@ fun MangaInfoBox(
     modifier: Modifier = Modifier,
     // KMK -->
     onSourceClick: () -> Unit,
-    onCoverLoaded: (Manga) -> Unit,
+    onCoverLoaded: (DomainMangaCover) -> Unit,
     // KMK <--
 ) {
     Box(modifier = modifier) {
@@ -401,7 +402,7 @@ private fun MangaAndSourceTitlesLarge(
     isStubSource: Boolean,
     // KMK -->
     onSourceClick: () -> Unit,
-    onCoverLoaded: (Manga) -> Unit,
+    onCoverLoaded: (DomainMangaCover) -> Unit,
     // KMK <--
 ) {
     Column(
@@ -415,7 +416,7 @@ private fun MangaAndSourceTitlesLarge(
             data = coverDataProvider(),
             contentDescription = stringResource(MR.strings.manga_cover),
             onClick = onCoverClick,
-            onCoverLoaded = { manga -> onCoverLoaded(manga) },
+            onCoverLoaded = { mangaCover -> onCoverLoaded(mangaCover) },
         )
         Spacer(modifier = Modifier.height(16.dp))
         MangaContentInfo(
@@ -448,7 +449,7 @@ private fun MangaAndSourceTitlesSmall(
     isStubSource: Boolean,
     // KMK -->
     onSourceClick: () -> Unit,
-    onCoverLoaded: (Manga) -> Unit,
+    onCoverLoaded: (DomainMangaCover) -> Unit,
     // KMK <--
 ) {
     Row(
@@ -465,7 +466,7 @@ private fun MangaAndSourceTitlesSmall(
             data = coverDataProvider(),
             contentDescription = stringResource(MR.strings.manga_cover),
             onClick = onCoverClick,
-            onCoverLoaded = { manga -> onCoverLoaded(manga) },
+            onCoverLoaded = { mangaCover -> onCoverLoaded(mangaCover) },
         )
         Column(
             verticalArrangement = Arrangement.spacedBy(2.dp),

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
+import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.components.DropdownMenu
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.source.model.SManga
@@ -86,6 +87,8 @@ import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.clickableNoIndication
 import tachiyomi.presentation.core.util.secondaryItemAlpha
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import kotlin.math.roundToInt
@@ -280,6 +283,8 @@ fun ExpandableMangaDescription(
     // SY <--
     modifier: Modifier = Modifier,
 ) {
+    val uiPreferences = Injekt.get<UiPreferences>()
+    val pureDarkMode = uiPreferences.themeDarkAmoled().get()
     Column(modifier = modifier) {
         val (expanded, onExpanded) = rememberSaveable {
             mutableStateOf(defaultExpandState)
@@ -347,6 +352,7 @@ fun ExpandableMangaDescription(
                                 tagSelected = it
                                 showMenu = true
                             },
+                            pureDarkMode = pureDarkMode,
                         )
                     } else {
                         // SY <--
@@ -362,6 +368,7 @@ fun ExpandableMangaDescription(
                                         tagSelected = it
                                         showMenu = true
                                     },
+                                    pureDarkMode = pureDarkMode,
                                 )
                             }
                         }
@@ -379,6 +386,7 @@ fun ExpandableMangaDescription(
                                     tagSelected = it
                                     showMenu = true
                                 },
+                                pureDarkMode = pureDarkMode,
                             )
                         }
                     }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -130,11 +130,14 @@ fun MangaInfoBox(
                 .drawWithContent {
                     drawContent()
                     drawRect(
-                        brush = Brush.verticalGradient(colors = backdropGradientColors),
+                        brush = Brush.verticalGradient(
+                            colors = backdropGradientColors,
+                            startY = size.height / 2,
+                        ),
                     )
                 }
-                .background(MaterialTheme.colorScheme.inversePrimary.copy(alpha = 0.2f))
-                .blur(4.dp)
+                .background(MaterialTheme.colorScheme.surfaceTint.copy(alpha = 0.4f))
+                .blur(7.dp)
                 .alpha(0.2f),
         )
 

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -108,6 +108,7 @@ fun MangaInfoBox(
     modifier: Modifier = Modifier,
     // KMK -->
     onSourceClick: () -> Unit,
+    onCoverLoaded: (Manga) -> Unit,
     // KMK <--
 ) {
     Box(modifier = modifier) {
@@ -149,6 +150,7 @@ fun MangaInfoBox(
                     isStubSource = isStubSource,
                     // KMK -->
                     onSourceClick = onSourceClick,
+                    onCoverLoaded = onCoverLoaded,
                     // KMK <--
                 )
             } else {
@@ -165,6 +167,7 @@ fun MangaInfoBox(
                     isStubSource = isStubSource,
                     // KMK -->
                     onSourceClick = onSourceClick,
+                    onCoverLoaded = onCoverLoaded,
                     // KMK <--
                 )
             }
@@ -398,6 +401,7 @@ private fun MangaAndSourceTitlesLarge(
     isStubSource: Boolean,
     // KMK -->
     onSourceClick: () -> Unit,
+    onCoverLoaded: (Manga) -> Unit,
     // KMK <--
 ) {
     Column(
@@ -411,6 +415,7 @@ private fun MangaAndSourceTitlesLarge(
             data = coverDataProvider(),
             contentDescription = stringResource(MR.strings.manga_cover),
             onClick = onCoverClick,
+            onCoverLoaded = { manga -> onCoverLoaded(manga) },
         )
         Spacer(modifier = Modifier.height(16.dp))
         MangaContentInfo(
@@ -443,6 +448,7 @@ private fun MangaAndSourceTitlesSmall(
     isStubSource: Boolean,
     // KMK -->
     onSourceClick: () -> Unit,
+    onCoverLoaded: (Manga) -> Unit,
     // KMK <--
 ) {
     Row(
@@ -459,6 +465,7 @@ private fun MangaAndSourceTitlesSmall(
             data = coverDataProvider(),
             contentDescription = stringResource(MR.strings.manga_cover),
             onClick = onCoverClick,
+            onCoverLoaded = { manga -> onCoverLoaded(manga) },
         )
         Column(
             verticalArrangement = Arrangement.spacedBy(2.dp),

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -32,7 +32,6 @@ import androidx.compose.material.icons.filled.PersonOutline
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material.icons.outlined.AttachMoney
 import androidx.compose.material.icons.outlined.Block
-import androidx.compose.material.icons.outlined.CallMerge
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Done
 import androidx.compose.material.icons.outlined.DoneAll
@@ -74,7 +73,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
-import com.materialkolor.ktx.blend
 import eu.kanade.presentation.components.DropdownMenu
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.source.model.SManga
@@ -226,7 +224,11 @@ fun MangaActionRow(
                 )
             },
             icon = Icons.Default.HourglassEmpty,
-            color = if (isUserIntervalMode) MaterialTheme.colorScheme.primary else defaultActionButtonColor,
+            color = if (isUserIntervalMode || nextUpdateDays?.let { it <= 1 } == true) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                defaultActionButtonColor
+            },
             onClick = { onEditIntervalClicked?.invoke() },
         )
         MangaActionButton(
@@ -674,7 +676,7 @@ private fun MangaSummary(
                         contentDescription = stringResource(
                             if (expanded) MR.strings.manga_info_collapse else MR.strings.manga_info_expand,
                         ),
-                        tint = MaterialTheme.colorScheme.onBackground,
+                        tint = MaterialTheme.colorScheme.primary,
                         modifier = Modifier.background(Brush.radialGradient(colors = colors.asReversed())),
                     )
                 }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import dev.icerock.moko.graphics.BuildConfig
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.DownloadDropdownMenu
@@ -59,6 +60,7 @@ fun MangaToolbar(
 
     modifier: Modifier = Modifier,
     backgroundAlphaProvider: () -> Float = titleAlphaProvider,
+    onPaletteScreenClick: () -> Unit,
 ) {
     Column(
         modifier = modifier,
@@ -191,6 +193,14 @@ fun MangaToolbar(
                                 }
                                 // SY <--
                                 // KMK -->
+                                if (BuildConfig.DEBUG) {
+                                    add(
+                                        AppBar.OverflowAction(
+                                            title = "Colors Palette",
+                                            onClick = onPaletteScreenClick,
+                                        ),
+                                    )
+                                }
 //                                add(
 //                                    AppBar.OverflowAction(
 //                                        title = stringResource(MR.strings.pref_invalidate_download_cache),
@@ -204,7 +214,6 @@ fun MangaToolbar(
 //                                    ),
 //                                )
                                 // KMK <--
-
                             }
                             .build(),
                     )

--- a/app/src/main/java/eu/kanade/presentation/manga/components/NamespaceTags.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/NamespaceTags.kt
@@ -177,9 +177,6 @@ fun TagsChip(
                     ),
                 )
             } else {
-                val elevatedSuggestionChipColors = SuggestionChipDefaultsM3.elevatedSuggestionChipColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                )
                 ElevatedSuggestionChip(
                     modifier = modifier,
                     onClick = onClick,
@@ -191,7 +188,9 @@ fun TagsChip(
                             overflow = TextOverflow.Ellipsis,
                         )
                     },
-                    colors = elevatedSuggestionChipColors,
+                    colors = SuggestionChipDefaultsM3.elevatedSuggestionChipColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    ),
                 )
             }
         } else {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/NamespaceTags.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/NamespaceTags.kt
@@ -99,6 +99,7 @@ value class SearchMetadataChips(
 fun NamespaceTags(
     tags: SearchMetadataChips,
     onClick: (item: String) -> Unit,
+    pureDarkMode: Boolean = false,
 ) {
     Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
         tags.tags.forEach { (namespace, tags) ->
@@ -108,6 +109,7 @@ fun NamespaceTags(
                         modifier = Modifier.padding(top = 4.dp),
                         text = namespace,
                         onClick = null,
+                        pureDarkMode = pureDarkMode,
                     )
                 }
                 FlowRow(
@@ -121,11 +123,23 @@ fun NamespaceTags(
                             text = text,
                             onClick = { onClick(search) },
                             border = borderDp?.let {
-                                SuggestionChipDefaults.suggestionChipBorder(borderWidth = it)
-                            } ?: SuggestionChipDefaults.suggestionChipBorder(),
+                                SuggestionChipDefaults.suggestionChipBorder(
+                                    borderWidth = it,
+                                    borderColor = MaterialTheme.colorScheme.primary,
+                                )
+                            } ?: SuggestionChipDefaults.suggestionChipBorder(
+                                borderColor = MaterialTheme.colorScheme.primary,
+                            ),
                             borderM3 = borderDp?.let {
-                                SuggestionChipDefaultsM3.suggestionChipBorder(enabled = true, borderWidth = it)
-                            } ?: SuggestionChipDefaultsM3.suggestionChipBorder(enabled = true),
+                                SuggestionChipDefaultsM3.suggestionChipBorder(
+                                    enabled = true,
+                                    borderWidth = it,
+                                    borderColor = MaterialTheme.colorScheme.primary,
+                                )
+                            } ?: SuggestionChipDefaultsM3.suggestionChipBorder(
+                                enabled = true,
+                                borderColor = MaterialTheme.colorScheme.primary,
+                            ),
                         )
                     }
                 }
@@ -141,13 +155,11 @@ fun TagsChip(
     modifier: Modifier = Modifier,
     border: ChipBorder? = SuggestionChipDefaults.suggestionChipBorder(),
     borderM3: BorderStroke? = null,
+    pureDarkMode: Boolean = false,
 ) {
     CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 0.dp) {
         if (onClick != null) {
-            val elevatedSuggestionChipColors = SuggestionChipDefaultsM3.elevatedSuggestionChipColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            )
-            if (borderM3 != null) {
+            if (borderM3 != null || pureDarkMode) {
                 SuggestionChip(
                     modifier = modifier,
                     onClick = onClick,
@@ -159,10 +171,15 @@ fun TagsChip(
                             overflow = TextOverflow.Ellipsis,
                         )
                     },
-                    colors = elevatedSuggestionChipColors,
-                    border = borderM3,
+                    border = borderM3 ?: SuggestionChipDefaultsM3.suggestionChipBorder(
+                        enabled = true,
+                        borderColor = MaterialTheme.colorScheme.primary,
+                    ),
                 )
             } else {
+                val elevatedSuggestionChipColors = SuggestionChipDefaultsM3.elevatedSuggestionChipColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                )
                 ElevatedSuggestionChip(
                     modifier = modifier,
                     onClick = onClick,

--- a/app/src/main/java/eu/kanade/presentation/manga/components/NamespaceTags.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/NamespaceTags.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ElevatedSuggestionChip
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SuggestionChip
@@ -139,23 +140,43 @@ fun TagsChip(
     onClick: (() -> Unit)?,
     modifier: Modifier = Modifier,
     border: ChipBorder? = SuggestionChipDefaults.suggestionChipBorder(),
-    borderM3: BorderStroke? = SuggestionChipDefaultsM3.suggestionChipBorder(enabled = true),
+    borderM3: BorderStroke? = null,
 ) {
     CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 0.dp) {
         if (onClick != null) {
-            SuggestionChip(
-                modifier = modifier,
-                onClick = onClick,
-                label = {
-                    Text(
-                        text = text,
-                        style = MaterialTheme.typography.bodySmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                },
-                border = borderM3,
+            val elevatedSuggestionChipColors = SuggestionChipDefaultsM3.elevatedSuggestionChipColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
             )
+            if (borderM3 != null) {
+                SuggestionChip(
+                    modifier = modifier,
+                    onClick = onClick,
+                    label = {
+                        Text(
+                            text = text,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
+                    colors = elevatedSuggestionChipColors,
+                    border = borderM3,
+                )
+            } else {
+                ElevatedSuggestionChip(
+                    modifier = modifier,
+                    onClick = onClick,
+                    label = {
+                        Text(
+                            text = text,
+                            style = MaterialTheme.typography.bodySmall,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
+                    colors = elevatedSuggestionChipColors,
+                )
+            }
         } else {
             SuggestionChip(
                 modifier = modifier,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -112,14 +112,14 @@ object SettingsAppearanceScreen : SearchableSettings {
     ): Preference.PreferenceGroup {
         val scope = rememberCoroutineScope()
         val detailsPageThemeCoverBased by remember {
-            Injekt.get<UiPreferences>().detailsPageThemeCoverBased().asState(scope)
+            Injekt.get<UiPreferences>().themeCoverBased().asState(scope)
         }
         return Preference.PreferenceGroup(
             title = stringResource(KMR.strings.pref_details_page_theme),
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.SwitchPreference(
-                    pref = uiPreferences.detailsPageThemeCoverBased(),
-                    title = stringResource(KMR.strings.pref_details_page_theme_cover_based),
+                    pref = uiPreferences.themeCoverBased(),
+                    title = stringResource(KMR.strings.pref_theme_cover_based),
                 ),
                 Preference.PreferenceItem.ListPreference(
                     pref = uiPreferences.themeCoverBasedStyle(),
@@ -128,11 +128,6 @@ object SettingsAppearanceScreen : SearchableSettings {
                     entries = PaletteStyle.entries
                         .associateWith { it.name }
                         .toImmutableMap(),
-                ),
-                Preference.PreferenceItem.SwitchPreference(
-                    pref = uiPreferences.themeCoverBasedAnimate(),
-                    title = stringResource(KMR.strings.pref_theme_cover_based_animate),
-                    enabled = detailsPageThemeCoverBased,
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -168,12 +169,17 @@ private fun UpdatesUiItem(
             .padding(horizontal = MaterialTheme.padding.medium),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        val mangaCover = update.coverData
+        val bgColor = mangaCover.dominantCoverColors?.first?.let { Color(it) }
+        val onBgColor = mangaCover.dominantCoverColors?.second
         MangaCover.Square(
             modifier = Modifier
                 .padding(vertical = 6.dp)
                 .fillMaxHeight(),
-            data = update.coverData,
+            data = mangaCover,
             onClick = onClickCover,
+            bgColor = bgColor,
+            tint = onBgColor,
         )
 
         Column(

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -42,6 +42,7 @@ import eu.kanade.tachiyomi.crash.GlobalExceptionHandler
 import eu.kanade.tachiyomi.data.coil.BufferedSourceFetcher
 import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher
 import eu.kanade.tachiyomi.data.coil.MangaCoverKeyer
+import eu.kanade.tachiyomi.data.coil.MangaCoverMetadata
 import eu.kanade.tachiyomi.data.coil.MangaKeyer
 import eu.kanade.tachiyomi.data.coil.PagePreviewFetcher
 import eu.kanade.tachiyomi.data.coil.PagePreviewKeyer
@@ -54,7 +55,6 @@ import eu.kanade.tachiyomi.di.SYPreferenceModule
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.ui.base.delegate.SecureActivityDelegate
-import eu.kanade.tachiyomi.data.coil.MangaCoverMetadata
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.WebViewUtil
 import eu.kanade.tachiyomi.util.system.animatorDurationScale

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -321,14 +321,13 @@ class MangaCoverFetcher(
      * @param bufferedSource if not null then it will load bitmap from [BufferedSource], regardless of [ogFile]
      * @param ogFile if not null then it will load bitmap from [File]. If it's null then it will try to load bitmap
      *  from [CoverCache] using either [CoverCache.customCoverCacheDir] or [CoverCache.cacheDir]
-     * @param force if true (default) then it will always re-calculate ratio & color for favorite mangas.
-     *  This is useful when a favorite manga updates/changes its cover. If false then it will only update ratio.
+     * @param force if true then it will always re-calculate ratio & color for favorite mangas.
      */
     private fun setRatioAndColorsInScope(
         mangaCover: MangaCover,
         bufferedSource: BufferedSource? = null,
         ogFile: File? = null,
-        force: Boolean = true
+        force: Boolean = false
     ) {
         fileScope.launch {
             MangaCoverMetadata.setRatioAndColors(mangaCover, bufferedSource, ogFile, force)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -12,7 +12,6 @@ import coil3.fetch.SourceFetchResult
 import coil3.getOrDefault
 import coil3.request.Options
 import com.hippo.unifile.UniFile
-import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher.Companion.USE_CUSTOM_COVER_KEY
 import eu.kanade.tachiyomi.network.await
@@ -38,8 +37,6 @@ import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaCover
 import tachiyomi.domain.manga.model.asMangaCover
 import tachiyomi.domain.source.service.SourceManager
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.io.File
 import java.io.IOException
@@ -68,8 +65,7 @@ class MangaCoverFetcher(
     private val imageLoader: ImageLoader,
 ) : Fetcher {
 
-    private val uiPreferences: UiPreferences = Injekt.get()
-    private val fileScope = CoroutineScope(Job() + Dispatchers.IO)
+    private val fileScope by lazy { CoroutineScope(Job() + Dispatchers.IO) }
 
     private val diskCacheKey: String
         get() = diskCacheKeyLazy.value
@@ -334,7 +330,6 @@ class MangaCoverFetcher(
         ogFile: File? = null,
         force: Boolean = true
     ) {
-        if (!uiPreferences.detailsPageThemeCoverBased().get()) return
         fileScope.launch {
             MangaCoverMetadata.setRatioAndColors(mangaCover, bufferedSource, ogFile, force)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -331,7 +331,7 @@ class MangaCoverFetcher(
         mangaCover: MangaCover,
         bufferedSource: BufferedSource? = null,
         ogFile: File? = null,
-        onlyFavorite: Boolean = !uiPreferences.detailsPageThemeCoverBased().get(),
+        onlyFavorite: Boolean = !uiPreferences.themeCoverBased().get(),
         force: Boolean = false,
     ) {
         fileScope.launch {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -12,6 +12,7 @@ import coil3.fetch.SourceFetchResult
 import coil3.getOrDefault
 import coil3.request.Options
 import com.hippo.unifile.UniFile
+import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher.Companion.USE_CUSTOM_COVER_KEY
 import eu.kanade.tachiyomi.network.await
@@ -37,6 +38,8 @@ import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaCover
 import tachiyomi.domain.manga.model.asMangaCover
 import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.io.File
 import java.io.IOException
@@ -66,6 +69,7 @@ class MangaCoverFetcher(
 ) : Fetcher {
 
     private val fileScope by lazy { CoroutineScope(Job() + Dispatchers.IO) }
+    private val uiPreferences = Injekt.get<UiPreferences>()
 
     private val diskCacheKey: String
         get() = diskCacheKeyLazy.value
@@ -327,10 +331,11 @@ class MangaCoverFetcher(
         mangaCover: MangaCover,
         bufferedSource: BufferedSource? = null,
         ogFile: File? = null,
-        force: Boolean = false
+        onlyFavorite: Boolean = !uiPreferences.detailsPageThemeCoverBased().get(),
+        force: Boolean = false,
     ) {
         fileScope.launch {
-            MangaCoverMetadata.setRatioAndColors(mangaCover, bufferedSource, ogFile, force)
+            MangaCoverMetadata.setRatioAndColors(mangaCover, bufferedSource, ogFile, onlyFavorite, force)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverMetadata.kt
@@ -78,10 +78,9 @@ object MangaCoverMetadata {
     ) {
         if (!mangaCover.isMangaFavorite) {
             mangaCover.remove()
+            // For browsing mangas, it will only load color once.
+            if (mangaCover.vibrantCoverColor != null) return
         }
-        val file = ogFile
-            ?: coverCache.getCustomCoverFile(mangaCover.mangaId).takeIf { it.exists() }
-            ?: coverCache.getCoverFile(mangaCover.url)
 
         val options = BitmapFactory.Options()
         val hasVibrantColor = if (mangaCover.isMangaFavorite) mangaCover.vibrantCoverColor != null else true
@@ -92,9 +91,15 @@ object MangaCoverMetadata {
             // Just trying to update ratio without actual reading bitmap (bitmap will be null)
             // This is often when open a favorite manga
             options.inJustDecodeBounds = true
+            // Don't even need to update ratio because we don't use it yet.
+            return
         } else {
             options.inSampleSize = 4
         }
+
+        val file = ogFile
+            ?: coverCache.getCustomCoverFile(mangaCover.mangaId).takeIf { it.exists() }
+            ?: coverCache.getCoverFile(mangaCover.url)
 
         val bitmap = when {
             bufferedSource != null -> BitmapFactory.decodeStream(bufferedSource.inputStream(), null, options)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverMetadata.kt
@@ -65,8 +65,7 @@ object MangaCoverMetadata {
      * @param bufferedSource if not null then it will load bitmap from [BufferedSource], regardless of [ogFile]
      * @param ogFile if not null then it will load bitmap from [File]. If it's null then it will try to load bitmap
      *  from [CoverCache] using either [CoverCache.customCoverCacheDir] or [CoverCache.cacheDir]
-     * @param force if true (default) then it will always re-calculate ratio & color for favorite mangas.
-     *  This is useful when a favorite manga updates/changes its cover. If false then it will only update ratio.
+     * @param force if true then it will always re-calculate ratio & color for favorite mangas.
      *
      * @author Jays2Kings
      */
@@ -74,7 +73,7 @@ object MangaCoverMetadata {
         mangaCover: MangaCover,
         bufferedSource: BufferedSource? = null,
         ogFile: File? = null,
-        force: Boolean = true,
+        force: Boolean = false,
     ) {
         if (!mangaCover.isMangaFavorite) {
             mangaCover.remove()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverMetadata.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.data.coil
 import android.graphics.BitmapFactory
 import androidx.palette.graphics.Palette
 import eu.kanade.tachiyomi.data.cache.CoverCache
+import eu.kanade.tachiyomi.ui.manga.MangaScreenModel
 import okio.BufferedSource
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.model.MangaCover
@@ -67,33 +68,49 @@ object MangaCoverMetadata {
      *  from [CoverCache] using either [CoverCache.customCoverCacheDir] or [CoverCache.cacheDir]
      * @param force if true then it will always re-calculate ratio & color for favorite mangas.
      *
-     * @author Jays2Kings
+     * This is only for loading color first time it appears on Library/Browse. Any new colors caused by loading new
+     * cover when open a manga detail or change cover will be updated separately on [MangaScreenModel.setPaletteColor].
      */
     fun setRatioAndColors(
         mangaCover: MangaCover,
         bufferedSource: BufferedSource? = null,
         ogFile: File? = null,
+        onlyDominantColor: Boolean = true,
         force: Boolean = false,
     ) {
         if (!mangaCover.isMangaFavorite) {
             mangaCover.remove()
-            // For browsing mangas, it will only load color once.
             if (mangaCover.vibrantCoverColor != null) return
         }
 
+        if (mangaCover.isMangaFavorite && onlyDominantColor && mangaCover.dominantCoverColors != null) return
+
         val options = BitmapFactory.Options()
-        val hasVibrantColor = if (mangaCover.isMangaFavorite) mangaCover.vibrantCoverColor != null else true
-        // If dominantCoverColors is not null, it means that color is restored from Prefs
-        // and also has vibrantCoverColor (e.g. new color caused by updated cover)
-        val updateRatioOnly = mangaCover.dominantCoverColors != null && hasVibrantColor && !force
-        if (updateRatioOnly) {
+
+        val updateColors = mangaCover.isMangaFavorite && mangaCover.dominantCoverColors == null ||
+            !onlyDominantColor && mangaCover.vibrantCoverColor == null || force
+
+        if (updateColors) {
+            /**
+             * + Manga is Favorite & doesn't have dominant color
+             *   For non-favorite, it doesn't care if dominant is there or not, if it has vibrant color then it will
+             *   already be returned from beginning.
+             * + [onlyDominantColor] = false
+             *   - Manga doesn't have vibrant color
+             */
+            options.inSampleSize = 4
+        } else {
+            /**
+             * + [onlyDominantColor] = true
+             *   - Manga is Favorite & already have dominant color
+             * + [onlyDominantColor] = false
+             *   - Manga is Favorite & already have dominant color & vibrant color
+             *   - Manga is not Favorite & already have vibrant color (already skip at beginning)
+             */
             // Just trying to update ratio without actual reading bitmap (bitmap will be null)
-            // This is often when open a favorite manga
             options.inJustDecodeBounds = true
             // Don't even need to update ratio because we don't use it yet.
             return
-        } else {
-            options.inSampleSize = 4
         }
 
         val file = ogFile

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -83,7 +83,6 @@ fun EditMangaDialog(
         textHighlightColor = MaterialTheme.colorScheme.outline.toArgb(),
         iconColor = MaterialTheme.colorScheme.primary.toArgb(),
         tagColor = MaterialTheme.colorScheme.outlineVariant.toArgb(),
-        tagFocusColor = MaterialTheme.colorScheme.outline.toArgb(),
         tagTextColor = MaterialTheme.colorScheme.onSurfaceVariant.toArgb(),
         btnTextColor = MaterialTheme.colorScheme.onPrimary.toArgb(),
         btnBgColor = MaterialTheme.colorScheme.surfaceTint.toArgb(),
@@ -160,7 +159,6 @@ class EditMangaDialogColors(
     @ColorInt val textHighlightColor: Int,
     @ColorInt val iconColor: Int,
     @ColorInt val tagColor: Int,
-    @ColorInt val tagFocusColor: Int,
     @ColorInt val tagTextColor: Int,
     @ColorInt val btnTextColor: Int,
     @ColorInt val btnBgColor: Int,
@@ -355,18 +353,7 @@ private fun ChipGroup.setChips(
 ) {
     removeAllViews()
 
-    val colorStateList = ColorStateList(
-        arrayOf(
-            intArrayOf(android.R.attr.state_focused),
-            intArrayOf(android.R.attr.state_pressed),
-            intArrayOf(-android.R.attr.state_active),
-        ),
-        intArrayOf(
-            colors.tagFocusColor,
-            colors.tagFocusColor,
-            colors.tagColor,
-        ),
-    )
+    val colorStateList = ColorStateList.valueOf(colors.tagColor)
 
     items.asSequence().map { item ->
         Chip(context).apply {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.TextView
 import androidx.annotation.ColorInt
@@ -205,6 +206,14 @@ private fun onViewCreated(
                 else -> 0
             },
         )
+    }
+
+    // Set Spinner's selected item's background color to transparent
+    binding.status.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        override fun onItemSelected(parent: AdapterView<*>, view: View?, pos: Int, id: Long) {
+            if (view != null) (view as TextView).setBackgroundColor(0x00000000)
+        }
+        override fun onNothingSelected(parent: AdapterView<*>?) = Unit
     }
 
     // Set Spinner's dropdown caret color

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -139,13 +139,17 @@ class MangaScreen(
         val seedColorState = rememberUpdatedState(newValue = successState.seedColor)
         val uiPreferences = remember { Injekt.get<UiPreferences>() }
 
-        DynamicMaterialTheme(
-            seedColor = seedColorState.value ?: MaterialTheme.colorScheme.primary,
-            useDarkTheme = isSystemInDarkTheme(),
-            style = uiPreferences.themeCoverBasedStyle().get(),
-            animate = uiPreferences.themeCoverBasedAnimate().get(),
-            content = { MaterialThemeContent(context, screenModel, successState) },
-        )
+        if (uiPreferences.detailsPageThemeCoverBased().get()) {
+            DynamicMaterialTheme(
+                seedColor = seedColorState.value ?: MaterialTheme.colorScheme.primary,
+                useDarkTheme = isSystemInDarkTheme(),
+                style = uiPreferences.themeCoverBasedStyle().get(),
+                animate = uiPreferences.themeCoverBasedAnimate().get(),
+                content = { MaterialThemeContent(context, screenModel, successState) },
+            )
+        } else {
+            MaterialThemeContent(context, screenModel, successState)
+        }
     }
 
     @Composable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -143,6 +143,7 @@ class MangaScreen(
             DynamicMaterialTheme(
                 seedColor = seedColorState.value ?: MaterialTheme.colorScheme.primary,
                 useDarkTheme = isSystemInDarkTheme(),
+                withAmoled = uiPreferences.themeDarkAmoled().get(),
                 style = uiPreferences.themeCoverBasedStyle().get(),
                 animate = uiPreferences.themeCoverBasedAnimate().get(),
                 content = { MaterialThemeContent(context, screenModel, successState) },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -304,7 +304,8 @@ class MangaScreen(
                     navigator.push(ExtensionsScreen(searchSource = successState.source.name))
                 }
             },
-            onCoverLoaded = screenModel::setPaletteColor
+            onCoverLoaded = screenModel::setPaletteColor,
+            onPaletteScreenClick = { navigator.push(PaletteScreen(successState.seedColor)) }
             // KMK <--
         )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -304,6 +304,7 @@ class MangaScreen(
                     navigator.push(ExtensionsScreen(searchSource = successState.source.name))
                 }
             },
+            onCoverLoaded = screenModel::setPaletteColor
             // KMK <--
         )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -139,13 +139,13 @@ class MangaScreen(
         val seedColorState = rememberUpdatedState(newValue = successState.seedColor)
         val uiPreferences = remember { Injekt.get<UiPreferences>() }
 
-        if (uiPreferences.detailsPageThemeCoverBased().get()) {
+        if (uiPreferences.themeCoverBased().get()) {
             DynamicMaterialTheme(
                 seedColor = seedColorState.value ?: MaterialTheme.colorScheme.primary,
                 useDarkTheme = isSystemInDarkTheme(),
                 withAmoled = uiPreferences.themeDarkAmoled().get(),
                 style = uiPreferences.themeCoverBasedStyle().get(),
-                animate = uiPreferences.themeCoverBasedAnimate().get(),
+                animate = true,
                 content = { MaterialThemeContent(context, screenModel, successState) },
             )
         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -29,7 +29,6 @@ import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.materialkolor.DynamicMaterialTheme
-import com.materialkolor.rememberDynamicColorScheme
 import eu.kanade.domain.manga.model.hasCustomCover
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.ui.UiPreferences
@@ -140,25 +139,13 @@ class MangaScreen(
         val seedColorState = rememberUpdatedState(newValue = successState.seedColor)
         val uiPreferences = remember { Injekt.get<UiPreferences>() }
 
-        if (uiPreferences.themeCoverBasedAnimate().get()) {
-            DynamicMaterialTheme(
-                seedColor = seedColorState.value ?: MaterialTheme.colorScheme.primary,
-                useDarkTheme = isSystemInDarkTheme(),
-                style = uiPreferences.themeCoverBasedStyle().get(),
-                animate = uiPreferences.themeCoverBasedAnimate().get(),
-                content = { MaterialThemeContent(context, screenModel, successState) },
-            )
-        } else {
-            val colorScheme = rememberDynamicColorScheme(
-                seedColor = seedColorState.value ?: MaterialTheme.colorScheme.primary,
-                isDark = isSystemInDarkTheme(),
-                style = uiPreferences.themeCoverBasedStyle().get(),
-            )
-            MaterialTheme(
-                colorScheme = colorScheme,
-                content = { MaterialThemeContent(context, screenModel, successState) },
-            )
-        }
+        DynamicMaterialTheme(
+            seedColor = seedColorState.value ?: MaterialTheme.colorScheme.primary,
+            useDarkTheme = isSystemInDarkTheme(),
+            style = uiPreferences.themeCoverBasedStyle().get(),
+            animate = uiPreferences.themeCoverBasedAnimate().get(),
+            content = { MaterialThemeContent(context, screenModel, successState) },
+        )
     }
 
     @Composable
@@ -262,7 +249,7 @@ class MangaScreen(
             previewsRowCount = successState.previewsRowCount,
             // SY -->
             onMigrateClicked = { migrateManga(navigator, screenModel.manga!!) }.takeIf { successState.manga.favorite },
-            onMetadataViewerClicked = { openMetadataViewer(navigator, successState.manga) },
+            onMetadataViewerClicked = { openMetadataViewer(navigator, successState.manga, successState.seedColor) },
             onEditInfoClicked = screenModel::showEditMangaInfoDialog,
             onRecommendClicked = { openRecommends(context, navigator, screenModel.source?.getMainSource(), successState.manga) },
             onMergedSettingsClicked = screenModel::showEditMergedSettingsDialog,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/PaletteScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/PaletteScreen.kt
@@ -36,13 +36,13 @@ class PaletteScreen(
     override fun Content() {
         val uiPreferences = remember { Injekt.get<UiPreferences>() }
 
-        if (uiPreferences.detailsPageThemeCoverBased().get()) {
+        if (uiPreferences.themeCoverBased().get()) {
             DynamicMaterialTheme(
                 seedColor = seedColor ?: MaterialTheme.colorScheme.primary,
                 useDarkTheme = isSystemInDarkTheme(),
                 withAmoled = uiPreferences.themeDarkAmoled().get(),
                 style = uiPreferences.themeCoverBasedStyle().get(),
-                animate = uiPreferences.themeCoverBasedAnimate().get(),
+                animate = true,
                 content = { MaterialThemeContent() },
             )
         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/PaletteScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/PaletteScreen.kt
@@ -1,0 +1,196 @@
+package eu.kanade.tachiyomi.ui.manga
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import com.materialkolor.DynamicMaterialTheme
+import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.util.Screen
+import tachiyomi.presentation.core.components.material.Button
+import tachiyomi.presentation.core.components.material.ButtonDefaults
+import tachiyomi.presentation.core.components.material.Scaffold
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+/**
+ * A screen that displays a colors palette of current theme.
+ */
+class PaletteScreen(
+    private val seedColor: Color?,
+) : Screen() {
+
+    @Composable
+    override fun Content() {
+        val uiPreferences = remember { Injekt.get<UiPreferences>() }
+
+        if (uiPreferences.detailsPageThemeCoverBased().get()) {
+            DynamicMaterialTheme(
+                seedColor = seedColor ?: MaterialTheme.colorScheme.primary,
+                useDarkTheme = isSystemInDarkTheme(),
+                style = uiPreferences.themeCoverBasedStyle().get(),
+                animate = uiPreferences.themeCoverBasedAnimate().get(),
+                content = { MaterialThemeContent() },
+            )
+        } else {
+            MaterialThemeContent()
+        }
+    }
+
+    @Composable
+    fun MaterialThemeContent() {
+        val navigator = LocalNavigator.currentOrThrow
+
+        Scaffold(
+            topBar = { scrollBehavior ->
+                AppBar(
+                    title = "Colors Palette",
+                    navigateUp = navigator::pop,
+                    scrollBehavior = scrollBehavior,
+                )
+            },
+        ) { contentPadding ->
+            Column(
+                modifier = Modifier.padding(contentPadding),
+            ) {
+                ButtonsColor(
+                    "accent & onPrimary",
+                    seedColor ?: MaterialTheme.colorScheme.primary,
+                    "accent & contentColor",
+                    seedColor ?: MaterialTheme.colorScheme.primary,
+                    MaterialTheme.colorScheme.onPrimary,
+                )
+
+                ButtonsColor(
+                    "primary",
+                    MaterialTheme.colorScheme.primary,
+                    "primaryContainer",
+                    MaterialTheme.colorScheme.primaryContainer
+                )
+                ButtonsColor(
+                    "secondary",
+                    MaterialTheme.colorScheme.secondary,
+                    "secondaryContainer",
+                    MaterialTheme.colorScheme.secondaryContainer
+                )
+                ButtonsColor(
+                    "tertiary",
+                    MaterialTheme.colorScheme.tertiary,
+                    "tertiaryContainer",
+                    MaterialTheme.colorScheme.tertiaryContainer
+                )
+                ButtonsColor(
+                    "surface",
+                    MaterialTheme.colorScheme.surface,
+                    "surfaceVariant",
+                    MaterialTheme.colorScheme.surfaceVariant
+                )
+                ButtonsColor(
+                    "inverseSurface",
+                    MaterialTheme.colorScheme.inverseSurface,
+                    "surfaceTint",
+                    MaterialTheme.colorScheme.surfaceTint
+                )
+                ButtonsColor(
+                    "inversePrimary",
+                    MaterialTheme.colorScheme.inversePrimary,
+                    "background",
+                    MaterialTheme.colorScheme.background
+                )
+                ButtonsColor(
+                    "error",
+                    MaterialTheme.colorScheme.error,
+                    "errorContainer",
+                    MaterialTheme.colorScheme.errorContainer
+                )
+                ButtonsColor(
+                    "outline",
+                    MaterialTheme.colorScheme.outline,
+                    "outlineVariant",
+                    MaterialTheme.colorScheme.outlineVariant
+                )
+                ButtonsColor(
+                    "scrim",
+                    MaterialTheme.colorScheme.scrim,
+                    "surfaceBright",
+                    MaterialTheme.colorScheme.surfaceBright
+                )
+                ButtonsColor(
+                    "surfaceDim",
+                    MaterialTheme.colorScheme.surfaceDim,
+                    "surfaceContainer",
+                    MaterialTheme.colorScheme.surfaceContainer
+                )
+                ButtonsColor(
+                    "surfaceContainerHigh",
+                    MaterialTheme.colorScheme.surfaceContainerHigh,
+                    "surfaceContainerHighest",
+                    MaterialTheme.colorScheme.surfaceContainerHighest
+                )
+                ButtonsColor(
+                    "surfaceContainerLow",
+                    MaterialTheme.colorScheme.surfaceContainerLow,
+                    "surfaceContainerLowest",
+                    MaterialTheme.colorScheme.surfaceContainerLowest
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ButtonsColor(
+    name1: String,
+    color1: Color,
+    name2: String,
+    color2: Color,
+    contentColor1: Color = contentColorFor(backgroundColor = color1),
+    contentColor2: Color = contentColorFor(backgroundColor = color2),
+) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .fillMaxWidth()
+    ) {
+        Button(
+            onClick = { },
+            Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = color1,
+                contentColor = contentColor1,
+            )
+        ) {
+            Text(
+                text = name1,
+            )
+        }
+        Button(
+            onClick = { },
+            Modifier
+                .weight(1f)
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = color2,
+                contentColor = contentColor2,
+            ),
+        ) {
+            Text(
+                text = name2
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/PaletteScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/PaletteScreen.kt
@@ -40,6 +40,7 @@ class PaletteScreen(
             DynamicMaterialTheme(
                 seedColor = seedColor ?: MaterialTheme.colorScheme.primary,
                 useDarkTheme = isSystemInDarkTheme(),
+                withAmoled = uiPreferences.themeDarkAmoled().get(),
                 style = uiPreferences.themeCoverBasedStyle().get(),
                 animate = uiPreferences.themeCoverBasedAnimate().get(),
                 content = { MaterialThemeContent() },

--- a/app/src/main/java/exh/ui/metadata/MetadataViewScreen.kt
+++ b/app/src/main/java/exh/ui/metadata/MetadataViewScreen.kt
@@ -115,6 +115,7 @@ class MetadataViewScreen(
             DynamicMaterialTheme(
                 seedColor = seedColor ?: MaterialTheme.colorScheme.primary,
                 useDarkTheme = isSystemInDarkTheme(),
+                withAmoled = uiPreferences.themeDarkAmoled().get(),
                 style = uiPreferences.themeCoverBasedStyle().get(),
                 animate = uiPreferences.themeCoverBasedAnimate().get(),
                 content = { content() },

--- a/app/src/main/java/exh/ui/metadata/MetadataViewScreen.kt
+++ b/app/src/main/java/exh/ui/metadata/MetadataViewScreen.kt
@@ -111,12 +111,16 @@ class MetadataViewScreen(
 
         val uiPreferences = remember { Injekt.get<UiPreferences>() }
 
-        DynamicMaterialTheme(
-            seedColor = seedColor ?: MaterialTheme.colorScheme.primary,
-            useDarkTheme = isSystemInDarkTheme(),
-            style = uiPreferences.themeCoverBasedStyle().get(),
-            animate = uiPreferences.themeCoverBasedAnimate().get(),
-            content = { content() }
-        )
+        if (uiPreferences.detailsPageThemeCoverBased().get()) {
+            DynamicMaterialTheme(
+                seedColor = seedColor ?: MaterialTheme.colorScheme.primary,
+                useDarkTheme = isSystemInDarkTheme(),
+                style = uiPreferences.themeCoverBasedStyle().get(),
+                animate = uiPreferences.themeCoverBasedAnimate().get(),
+                content = { content() },
+            )
+        } else {
+            content()
+        }
     }
 }

--- a/app/src/main/java/exh/ui/metadata/MetadataViewScreen.kt
+++ b/app/src/main/java/exh/ui/metadata/MetadataViewScreen.kt
@@ -111,13 +111,13 @@ class MetadataViewScreen(
 
         val uiPreferences = remember { Injekt.get<UiPreferences>() }
 
-        if (uiPreferences.detailsPageThemeCoverBased().get()) {
+        if (uiPreferences.themeCoverBased().get()) {
             DynamicMaterialTheme(
                 seedColor = seedColor ?: MaterialTheme.colorScheme.primary,
                 useDarkTheme = isSystemInDarkTheme(),
                 withAmoled = uiPreferences.themeDarkAmoled().get(),
                 style = uiPreferences.themeCoverBasedStyle().get(),
-                animate = uiPreferences.themeCoverBasedAnimate().get(),
+                animate = true,
                 content = { content() },
             )
         } else {

--- a/app/src/main/java/exh/ui/metadata/MetadataViewScreen.kt
+++ b/app/src/main/java/exh/ui/metadata/MetadataViewScreen.kt
@@ -24,7 +24,7 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import com.materialkolor.DynamicMaterialTheme
-import com.materialkolor.PaletteStyle
+import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.util.system.copyToClipboard
@@ -36,6 +36,8 @@ import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
 import tachiyomi.presentation.core.util.clickableNoIndication
 import tachiyomi.presentation.core.util.plus
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 class MetadataViewScreen(
     private val mangaId: Long,
@@ -107,11 +109,13 @@ class MetadataViewScreen(
             }
         }
 
+        val uiPreferences = remember { Injekt.get<UiPreferences>() }
+
         DynamicMaterialTheme(
             seedColor = seedColor ?: MaterialTheme.colorScheme.primary,
             useDarkTheme = isSystemInDarkTheme(),
-            style = PaletteStyle.Vibrant,
-            animate = true,
+            style = uiPreferences.themeCoverBasedStyle().get(),
+            animate = uiPreferences.themeCoverBasedAnimate().get(),
             content = { content() }
         )
     }

--- a/app/src/main/java/exh/ui/metadata/adapters/EHentaiDescriptionAdapter.kt
+++ b/app/src/main/java/exh/ui/metadata/adapters/EHentaiDescriptionAdapter.kt
@@ -29,8 +29,8 @@ fun EHentaiDescription(
     search: (String) -> Unit,
 ) {
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onBackground.toArgb()
-    val iconColor = MaterialTheme.colorScheme.secondary.toArgb()
+    val textColor = MaterialTheme.colorScheme.secondary.toArgb()
+    val iconColor = MaterialTheme.colorScheme.primary.toArgb()
     val ratingBarSecondaryColor = MaterialTheme.colorScheme.outlineVariant.toArgb()
     AndroidView(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/exh/ui/metadata/adapters/EightMusesDescriptionAdapter.kt
+++ b/app/src/main/java/exh/ui/metadata/adapters/EightMusesDescriptionAdapter.kt
@@ -20,7 +20,7 @@ import tachiyomi.i18n.MR
 @Composable
 fun EightMusesDescription(state: State.Success, openMetadataViewer: () -> Unit) {
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onBackground.toArgb()
+    val textColor = MaterialTheme.colorScheme.secondary.toArgb()
     val iconColor = MaterialTheme.colorScheme.primary.toArgb()
     AndroidView(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/exh/ui/metadata/adapters/HBrowseDescriptionAdapter.kt
+++ b/app/src/main/java/exh/ui/metadata/adapters/HBrowseDescriptionAdapter.kt
@@ -20,7 +20,7 @@ import tachiyomi.i18n.sy.SYMR
 @Composable
 fun HBrowseDescription(state: State.Success, openMetadataViewer: () -> Unit) {
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onBackground.toArgb()
+    val textColor = MaterialTheme.colorScheme.secondary.toArgb()
     val iconColor = MaterialTheme.colorScheme.primary.toArgb()
     AndroidView(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/exh/ui/metadata/adapters/MangaDexDescriptionAdapter.kt
+++ b/app/src/main/java/exh/ui/metadata/adapters/MangaDexDescriptionAdapter.kt
@@ -23,7 +23,7 @@ import kotlin.math.round
 @Composable
 fun MangaDexDescription(state: State.Success, openMetadataViewer: () -> Unit) {
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onBackground.toArgb()
+    val textColor = MaterialTheme.colorScheme.secondary.toArgb()
     val iconColor = MaterialTheme.colorScheme.primary.toArgb()
     val ratingBarSecondaryColor = MaterialTheme.colorScheme.outlineVariant.toArgb()
     AndroidView(

--- a/app/src/main/java/exh/ui/metadata/adapters/NHentaiDescriptionAdapter.kt
+++ b/app/src/main/java/exh/ui/metadata/adapters/NHentaiDescriptionAdapter.kt
@@ -27,7 +27,7 @@ import java.time.ZonedDateTime
 @Composable
 fun NHentaiDescription(state: State.Success, openMetadataViewer: () -> Unit) {
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onBackground.toArgb()
+    val textColor = MaterialTheme.colorScheme.secondary.toArgb()
     val iconColor = MaterialTheme.colorScheme.primary.toArgb()
     AndroidView(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/exh/ui/metadata/adapters/PururinDescriptionAdapter.kt
+++ b/app/src/main/java/exh/ui/metadata/adapters/PururinDescriptionAdapter.kt
@@ -25,7 +25,7 @@ import kotlin.math.round
 @Composable
 fun PururinDescription(state: State.Success, openMetadataViewer: () -> Unit) {
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onBackground.toArgb()
+    val textColor = MaterialTheme.colorScheme.secondary.toArgb()
     val iconColor = MaterialTheme.colorScheme.primary.toArgb()
     val ratingBarSecondaryColor = MaterialTheme.colorScheme.outlineVariant.toArgb()
     AndroidView(

--- a/app/src/main/java/exh/ui/metadata/adapters/TsuminoDescriptionAdapter.kt
+++ b/app/src/main/java/exh/ui/metadata/adapters/TsuminoDescriptionAdapter.kt
@@ -26,7 +26,7 @@ import kotlin.math.round
 @Composable
 fun TsuminoDescription(state: State.Success, openMetadataViewer: () -> Unit) {
     val context = LocalContext.current
-    val textColor = MaterialTheme.colorScheme.onBackground.toArgb()
+    val textColor = MaterialTheme.colorScheme.secondary.toArgb()
     val iconColor = MaterialTheme.colorScheme.primary.toArgb()
     val ratingBarSecondaryColor = MaterialTheme.colorScheme.outlineVariant.toArgb()
     AndroidView(

--- a/app/src/main/java/mihon/feature/upcoming/components/UpcomingItem.kt
+++ b/app/src/main/java/mihon/feature/upcoming/components/UpcomingItem.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -38,9 +39,14 @@ fun UpcomingItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.large),
     ) {
+        val mangaCover = upcoming.asMangaCover()
+        val bgColor = mangaCover.dominantCoverColors?.first?.let { Color(it) }
+        val onBgColor = mangaCover.dominantCoverColors?.second
         MangaCover.Book(
             modifier = Modifier.fillMaxHeight(),
-            data = upcoming.asMangaCover(),
+            data = mangaCover,
+            bgColor = bgColor,
+            tint = onBgColor,
         )
         Text(
             modifier = Modifier.weight(1f),

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -35,9 +35,15 @@ class LibraryPreferences(
     fun lastUpdatedTimestamp() = preferenceStore.getLong(Preference.appStateKey("library_update_last_timestamp"), 0L)
     fun autoUpdateInterval() = preferenceStore.getInt("pref_library_update_interval_key", 0)
 
-    fun coverRatios() = preferenceStore.getStringSet("pref_library_cover_ratios_key", emptySet())
+    fun coverRatios() = preferenceStore.getStringSet(
+        Preference.appStateKey("pref_library_cover_ratios_key"),
+        emptySet(),
+    )
 
-    fun coverColors() = preferenceStore.getStringSet("pref_library_cover_colors_key", emptySet())
+    fun coverColors() = preferenceStore.getStringSet(
+        Preference.appStateKey("pref_library_cover_colors_key"),
+        emptySet(),
+    )
 
     fun autoUpdateDeviceRestrictions() = preferenceStore.getStringSet(
         "library_update_restriction",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,6 @@ sqlite = "2.4.0"
 voyager = "1.0.0"
 detekt = "1.23.6"
 detektCompose = "0.3.12"
-paletteKtxVersion = "1.0.0"
-materialKolorVersion = "1.6.1"
 
 [libraries]
 desugar = "com.android.tools:desugar_jdk_libs:2.0.4"
@@ -70,8 +68,8 @@ insetter = "dev.chrisbanes.insetter:insetter:0.6.1"
 compose-materialmotion = "io.github.fornewid:material-motion-compose-core:2.0.0"
 compose-webview = "io.github.kevinnzou:compose-webview:0.33.6"
 compose-grid = "io.woong.compose.grid:grid:1.2.2"
-palette-ktx = { group = "androidx.palette", name = "palette-ktx", version.ref = "paletteKtxVersion" }
-material-kolor = { module = "com.materialkolor:material-kolor", version.ref = "materialKolorVersion" }
+palette-ktx = "androidx.palette:palette-ktx:1.0.0"
+material-kolor = "com.materialkolor:material-kolor:1.6.2"
 
 swipe = "me.saket.swipe:swipe:1.3.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ compose-materialmotion = "io.github.fornewid:material-motion-compose-core:2.0.0"
 compose-webview = "io.github.kevinnzou:compose-webview:0.33.6"
 compose-grid = "io.woong.compose.grid:grid:1.2.2"
 palette-ktx = "androidx.palette:palette-ktx:1.0.0"
-material-kolor = "com.materialkolor:material-kolor:1.6.2"
+material-kolor = "com.materialkolor:material-kolor:1.7.0"
 
 swipe = "me.saket.swipe:swipe:1.3.0"
 

--- a/i18n-kmk/src/commonMain/resources/MR/ar/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ar/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">وضع التحديد بالجملة</string>
   <string name="action_faq_and_guides">الأسئلة الشائعة والأدلة</string>
   <string name="pref_details_page_theme">صفحة التفاصيل</string>
-  <string name="pref_details_page_theme_cover_based">تفاصيل سمة الصفحة استنادًا إلى الغلاف</string>
+  <string name="pref_theme_cover_based">تفاصيل سمة الصفحة استنادًا إلى الغلاف</string>
   <string name="pref_theme_cover_based_style">نمط السمة</string>
-  <string name="pref_theme_cover_based_animate">الرسوم المتحركة للسمة</string>
   <string name="ext_unofficial">غير رسمي</string>
   <string name="unofficial_extension_message">وهذا التمديد ليس من المستودع الرسمي.</string>
   <string name="download_cache_renew_interval">الفاصل الزمني لتجديد التحميل</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ar/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ar/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">وضع التحديد بالجملة</string>
   <string name="action_faq_and_guides">الأسئلة الشائعة والأدلة</string>
   <string name="pref_details_page_theme">صفحة التفاصيل</string>
-  <string name="pref_theme_cover_based">تفاصيل سمة الصفحة استنادًا إلى الغلاف</string>
+  <string name="pref_theme_cover_based">السمة المبنية على الغلاف</string>
   <string name="pref_theme_cover_based_style">نمط السمة</string>
   <string name="ext_unofficial">غير رسمي</string>
   <string name="unofficial_extension_message">وهذا التمديد ليس من المستودع الرسمي.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/base/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/base/strings.xml
@@ -9,9 +9,8 @@
     <!-- Preferences -->
       <!-- General section -->
     <string name="pref_details_page_theme">Details page</string>
-    <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+    <string name="pref_theme_cover_based">Theme based on cover</string>
     <string name="pref_theme_cover_based_style">Theme style</string>
-    <string name="pref_theme_cover_based_animate">Theme animate</string>
     <string name="pref_expand_related_titles">Expand Related titles</string>
     <string name="pref_expand_related_titles_summary">If turned off, related titles won\'t automatically load &amp; show expanded</string>
 

--- a/i18n-kmk/src/commonMain/resources/MR/ca/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ca/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ca/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ca/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/cs/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/cs/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Režim hromadného výběru</string>
   <string name="action_faq_and_guides">FAQ a návody</string>
   <string name="pref_details_page_theme">Stránka s podrobnostmi</string>
-  <string name="pref_theme_cover_based">Šablona stránky s podrobnostmi na základě obalu</string>
+  <string name="pref_theme_cover_based">Šablona založená na obálce</string>
   <string name="pref_theme_cover_based_style">Styl motivu</string>
   <string name="ext_unofficial">Neoficiální</string>
   <string name="unofficial_extension_message">Toto rozšíření není z oficiálního repozitáře.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/cs/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/cs/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Režim hromadného výběru</string>
   <string name="action_faq_and_guides">FAQ a návody</string>
   <string name="pref_details_page_theme">Stránka s podrobnostmi</string>
-  <string name="pref_details_page_theme_cover_based">Šablona stránky s podrobnostmi na základě obalu</string>
+  <string name="pref_theme_cover_based">Šablona stránky s podrobnostmi na základě obalu</string>
   <string name="pref_theme_cover_based_style">Styl motivu</string>
-  <string name="pref_theme_cover_based_animate">Animace motivu</string>
   <string name="ext_unofficial">Neoficiální</string>
   <string name="unofficial_extension_message">Toto rozšíření není z oficiálního repozitáře.</string>
   <string name="download_cache_renew_interval">Interval obnovení mezipaměti</string>

--- a/i18n-kmk/src/commonMain/resources/MR/da/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/da/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Masse valg tilstand</string>
   <string name="action_faq_and_guides">Ofte stillede spørgsmål og vejledninger</string>
   <string name="pref_details_page_theme">Detaljer side</string>
-  <string name="pref_details_page_theme_cover_based">Detaljer sidetema baseret på omslag</string>
+  <string name="pref_theme_cover_based">Detaljer sidetema baseret på omslag</string>
   <string name="pref_theme_cover_based_style">Tema stil</string>
-  <string name="pref_theme_cover_based_animate">Tema animere</string>
   <string name="ext_unofficial">Uofficiel</string>
   <string name="unofficial_extension_message">Denne udvidelse er ikke fra den officielle repo.</string>
   <string name="download_cache_renew_interval">Download cache forny interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/da/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/da/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Masse valg tilstand</string>
   <string name="action_faq_and_guides">Ofte stillede spørgsmål og vejledninger</string>
   <string name="pref_details_page_theme">Detaljer side</string>
-  <string name="pref_theme_cover_based">Detaljer sidetema baseret på omslag</string>
+  <string name="pref_theme_cover_based">Tema baseret på omslag</string>
   <string name="pref_theme_cover_based_style">Tema stil</string>
   <string name="ext_unofficial">Uofficiel</string>
   <string name="unofficial_extension_message">Denne udvidelse er ikke fra den officielle repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/de/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/de/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Massenauswahlmodus</string>
   <string name="action_faq_and_guides">FAQ und Anleitungen</string>
   <string name="pref_details_page_theme">Detailseite</string>
-  <string name="pref_details_page_theme_cover_based">Detailseitenthema basierend auf Cover</string>
+  <string name="pref_theme_cover_based">Detailseitenthema basierend auf Cover</string>
   <string name="pref_theme_cover_based_style">Design-Stil</string>
-  <string name="pref_theme_cover_based_animate">Theme animieren</string>
   <string name="ext_unofficial">Ungültig</string>
   <string name="unofficial_extension_message">Diese Erweiterung ist nicht vom offiziellen Repo.</string>
   <string name="download_cache_renew_interval">Download-Cache Erneuerungsintervall</string>

--- a/i18n-kmk/src/commonMain/resources/MR/de/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/de/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Massenauswahlmodus</string>
   <string name="action_faq_and_guides">FAQ und Anleitungen</string>
   <string name="pref_details_page_theme">Detailseite</string>
-  <string name="pref_theme_cover_based">Detailseitenthema basierend auf Cover</string>
+  <string name="pref_theme_cover_based">Theme basierend auf Cover</string>
   <string name="pref_theme_cover_based_style">Design-Stil</string>
   <string name="ext_unofficial">Ungültig</string>
   <string name="unofficial_extension_message">Diese Erweiterung ist nicht vom offiziellen Repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/el/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/el/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Λειτουργία μαζικής επιλογής</string>
   <string name="action_faq_and_guides">Συχνές ερωτήσεις και οδηγοί</string>
   <string name="pref_details_page_theme">Σελίδα λεπτομερειών</string>
-  <string name="pref_theme_cover_based">Θέμα λεπτομερειών σελίδας με βάση το εξώφυλλο</string>
+  <string name="pref_theme_cover_based">Θέμα βασισμένο στο εξώφυλλο</string>
   <string name="pref_theme_cover_based_style">Στυλ θέματος</string>
   <string name="ext_unofficial">Ανεπίσημη</string>
   <string name="unofficial_extension_message">Η επέκταση αυτή δεν προέρχεται από την επίσημη αποχώρηση.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/el/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/el/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Λειτουργία μαζικής επιλογής</string>
   <string name="action_faq_and_guides">Συχνές ερωτήσεις και οδηγοί</string>
   <string name="pref_details_page_theme">Σελίδα λεπτομερειών</string>
-  <string name="pref_details_page_theme_cover_based">Θέμα λεπτομερειών σελίδας με βάση το εξώφυλλο</string>
+  <string name="pref_theme_cover_based">Θέμα λεπτομερειών σελίδας με βάση το εξώφυλλο</string>
   <string name="pref_theme_cover_based_style">Στυλ θέματος</string>
-  <string name="pref_theme_cover_based_animate">Εφέ κίνησης θέματος</string>
   <string name="ext_unofficial">Ανεπίσημη</string>
   <string name="unofficial_extension_message">Η επέκταση αυτή δεν προέρχεται από την επίσημη αποχώρηση.</string>
   <string name="download_cache_renew_interval">Χρονικό διάστημα ανανέωσης προσωρινής μνήμης</string>

--- a/i18n-kmk/src/commonMain/resources/MR/es/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/es/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Modo de selección masiva</string>
   <string name="action_faq_and_guides">Preguntas frecuentes y guías</string>
   <string name="pref_details_page_theme">Página de detalles</string>
-  <string name="pref_theme_cover_based">Tema de página de detalles basado en portada</string>
+  <string name="pref_theme_cover_based">Tema basado en portada</string>
   <string name="pref_theme_cover_based_style">Estilo del tema</string>
   <string name="ext_unofficial">No oficial</string>
   <string name="unofficial_extension_message">Esta extensión no es del repositorio oficial.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/es/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/es/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Modo de selección masiva</string>
   <string name="action_faq_and_guides">Preguntas frecuentes y guías</string>
   <string name="pref_details_page_theme">Página de detalles</string>
-  <string name="pref_details_page_theme_cover_based">Tema de página de detalles basado en portada</string>
+  <string name="pref_theme_cover_based">Tema de página de detalles basado en portada</string>
   <string name="pref_theme_cover_based_style">Estilo del tema</string>
-  <string name="pref_theme_cover_based_animate">Animar tema</string>
   <string name="ext_unofficial">No oficial</string>
   <string name="unofficial_extension_message">Esta extensión no es del repositorio oficial.</string>
   <string name="download_cache_renew_interval">Descargar el intervalo de renovación de caché</string>

--- a/i18n-kmk/src/commonMain/resources/MR/fi/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/fi/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk valintatila</string>
   <string name="action_faq_and_guides">UKK ja oppaat</string>
   <string name="pref_details_page_theme">Yksityiskohdat sivu</string>
-  <string name="pref_details_page_theme_cover_based">Yksityiskohtaiset tiedot sivun teema kannen perusteella</string>
+  <string name="pref_theme_cover_based">Yksityiskohtaiset tiedot sivun teema kannen perusteella</string>
   <string name="pref_theme_cover_based_style">Teeman tyyli</string>
-  <string name="pref_theme_cover_based_animate">Teema animoitu</string>
   <string name="ext_unofficial">Epävirallinen</string>
   <string name="unofficial_extension_message">Tämä laajennus ei ole virallisesta reposta.</string>
   <string name="download_cache_renew_interval">Lataa välimuistin uusimisväli</string>

--- a/i18n-kmk/src/commonMain/resources/MR/fi/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/fi/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk valintatila</string>
   <string name="action_faq_and_guides">UKK ja oppaat</string>
   <string name="pref_details_page_theme">Yksityiskohdat sivu</string>
-  <string name="pref_theme_cover_based">Yksityiskohtaiset tiedot sivun teema kannen perusteella</string>
+  <string name="pref_theme_cover_based">Teema perustuu kanteen</string>
   <string name="pref_theme_cover_based_style">Teeman tyyli</string>
   <string name="ext_unofficial">Epävirallinen</string>
   <string name="unofficial_extension_message">Tämä laajennus ei ole virallisesta reposta.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/fil/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/fil/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/fil/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/fil/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/fr/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/fr/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Mode de sélection en bloc</string>
   <string name="action_faq_and_guides">FAQ et tutoriels</string>
   <string name="pref_details_page_theme">Page de détails</string>
-  <string name="pref_details_page_theme_cover_based">Thème de la page de détails basé sur la couverture</string>
+  <string name="pref_theme_cover_based">Thème de la page de détails basé sur la couverture</string>
   <string name="pref_theme_cover_based_style">Style du thème</string>
-  <string name="pref_theme_cover_based_animate">Animation du thème</string>
   <string name="ext_unofficial">Non officiel</string>
   <string name="unofficial_extension_message">Cette extension ne provient pas du dépôt officiel.</string>
   <string name="download_cache_renew_interval">Intervalle de renouvellement du cache de téléchargement</string>

--- a/i18n-kmk/src/commonMain/resources/MR/fr/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/fr/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Mode de sélection en bloc</string>
   <string name="action_faq_and_guides">FAQ et tutoriels</string>
   <string name="pref_details_page_theme">Page de détails</string>
-  <string name="pref_theme_cover_based">Thème de la page de détails basé sur la couverture</string>
+  <string name="pref_theme_cover_based">Thème basé sur la couverture</string>
   <string name="pref_theme_cover_based_style">Style du thème</string>
   <string name="ext_unofficial">Non officiel</string>
   <string name="unofficial_extension_message">Cette extension ne provient pas du dépôt officiel.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/he/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/he/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/he/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/he/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/hi/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/hi/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/hi/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/hi/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/hu/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/hu/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/hu/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/hu/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/id/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/id/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/id/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/id/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/it/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/it/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Modalità selezione Bulk</string>
   <string name="action_faq_and_guides">FAQ e guide</string>
   <string name="pref_details_page_theme">Pagina dettagli</string>
-  <string name="pref_theme_cover_based">Dettagli tema pagina basato sulla copertina</string>
+  <string name="pref_theme_cover_based">Tema basato sulla copertina</string>
   <string name="pref_theme_cover_based_style">Stile tema</string>
   <string name="ext_unofficial">Non Ufficiale</string>
   <string name="unofficial_extension_message">Questa estensione non proviene dal repo ufficiale.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/it/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/it/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Modalità selezione Bulk</string>
   <string name="action_faq_and_guides">FAQ e guide</string>
   <string name="pref_details_page_theme">Pagina dettagli</string>
-  <string name="pref_details_page_theme_cover_based">Dettagli tema pagina basato sulla copertina</string>
+  <string name="pref_theme_cover_based">Dettagli tema pagina basato sulla copertina</string>
   <string name="pref_theme_cover_based_style">Stile tema</string>
-  <string name="pref_theme_cover_based_animate">Animazione tema</string>
   <string name="ext_unofficial">Non Ufficiale</string>
   <string name="unofficial_extension_message">Questa estensione non proviene dal repo ufficiale.</string>
   <string name="download_cache_renew_interval">Intervallo di rinnovo download cache</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ja/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ja/strings.xml
@@ -5,10 +5,9 @@
   <string name="action_bulk_select">一括選択モード</string>
   <string name="action_faq_and_guides">FAQ とガイド</string>
   <string name="pref_details_page_theme">詳細ページ</string>
-  <string name="pref_details_page_theme_cover_based">カバーに基づく詳細ページのテーマ</string>
+  <string name="pref_theme_cover_based">カバーに基づく詳細ページのテーマ</string>
   <string name="pref_theme_cover_based_style">テーマのスタイル</string>
-  <string name="pref_theme_cover_based_animate">テーマのアニメーション</string>
-  <string name="ext_unofficial">&lt;unk&gt;</string>
+  <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">この拡張機能は公式リポジトリからのものではありません。</string>
   <string name="download_cache_renew_interval">キャッシュの更新間隔をダウンロード</string>
   <string name="download_cache_renew_interval_manual">マニュアル</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ja/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ja/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">一括選択モード</string>
   <string name="action_faq_and_guides">FAQ とガイド</string>
   <string name="pref_details_page_theme">詳細ページ</string>
-  <string name="pref_theme_cover_based">カバーに基づく詳細ページのテーマ</string>
+  <string name="pref_theme_cover_based">カバーに基づくテーマ</string>
   <string name="pref_theme_cover_based_style">テーマのスタイル</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">この拡張機能は公式リポジトリからのものではありません。</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ko/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ko/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ko/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ko/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/nl/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/nl/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selectiemodus</string>
   <string name="action_faq_and_guides">FAQ en handleidingen</string>
   <string name="pref_details_page_theme">Details pagina</string>
-  <string name="pref_theme_cover_based">Details pagina thema gebaseerd op cover</string>
+  <string name="pref_theme_cover_based">Thema gebaseerd op cover</string>
   <string name="pref_theme_cover_based_style">Thema stijl</string>
   <string name="ext_unofficial">Onofficiële</string>
   <string name="unofficial_extension_message">Deze uitbreiding komt niet uit de officiële repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/nl/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/nl/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selectiemodus</string>
   <string name="action_faq_and_guides">FAQ en handleidingen</string>
   <string name="pref_details_page_theme">Details pagina</string>
-  <string name="pref_details_page_theme_cover_based">Details pagina thema gebaseerd op cover</string>
+  <string name="pref_theme_cover_based">Details pagina thema gebaseerd op cover</string>
   <string name="pref_theme_cover_based_style">Thema stijl</string>
-  <string name="pref_theme_cover_based_animate">Thema animeren</string>
   <string name="ext_unofficial">Onofficiële</string>
   <string name="unofficial_extension_message">Deze uitbreiding komt niet uit de officiële repo.</string>
   <string name="download_cache_renew_interval">Download de cache vernieuwingsinterval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/pl/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/pl/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Tryb masowego zaznaczenia</string>
   <string name="action_faq_and_guides">FAQ i przewodniki</string>
   <string name="pref_details_page_theme">Strona szczegółów</string>
-  <string name="pref_theme_cover_based">Szczegółowy motyw strony oparty na okładce</string>
+  <string name="pref_theme_cover_based">Motyw oparty na okładce</string>
   <string name="pref_theme_cover_based_style">Styl motywu</string>
   <string name="ext_unofficial">Nieoficjalne</string>
   <string name="unofficial_extension_message">To rozszerzenie nie pochodzi z oficjalnego repozytorium.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/pl/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/pl/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Tryb masowego zaznaczenia</string>
   <string name="action_faq_and_guides">FAQ i przewodniki</string>
   <string name="pref_details_page_theme">Strona szczegółów</string>
-  <string name="pref_details_page_theme_cover_based">Szczegółowy motyw strony oparty na okładce</string>
+  <string name="pref_theme_cover_based">Szczegółowy motyw strony oparty na okładce</string>
   <string name="pref_theme_cover_based_style">Styl motywu</string>
-  <string name="pref_theme_cover_based_animate">Animacja motywu</string>
   <string name="ext_unofficial">Nieoficjalne</string>
   <string name="unofficial_extension_message">To rozszerzenie nie pochodzi z oficjalnego repozytorium.</string>
   <string name="download_cache_renew_interval">Częstotliwość odnawiania pamięci podręcznej pobierania</string>

--- a/i18n-kmk/src/commonMain/resources/MR/pt-rBR/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/pt-rBR/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Modo de seleção em massa</string>
   <string name="action_faq_and_guides">FAQ e Guias</string>
   <string name="pref_details_page_theme">Página de detalhes</string>
-  <string name="pref_details_page_theme_cover_based">Detalhe o tema da página baseado na capa</string>
+  <string name="pref_theme_cover_based">Detalhe o tema da página baseado na capa</string>
   <string name="pref_theme_cover_based_style">Estilo do tema</string>
-  <string name="pref_theme_cover_based_animate">Animação do tema</string>
   <string name="ext_unofficial">Não-oficial</string>
   <string name="unofficial_extension_message">Essa extensão não é do repositório oficial.</string>
   <string name="download_cache_renew_interval">Baixar intervalo de renovação do cache</string>

--- a/i18n-kmk/src/commonMain/resources/MR/pt-rBR/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/pt-rBR/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Modo de seleção em massa</string>
   <string name="action_faq_and_guides">FAQ e Guias</string>
   <string name="pref_details_page_theme">Página de detalhes</string>
-  <string name="pref_theme_cover_based">Detalhe o tema da página baseado na capa</string>
+  <string name="pref_theme_cover_based">Tema baseado na capa</string>
   <string name="pref_theme_cover_based_style">Estilo do tema</string>
   <string name="ext_unofficial">Não-oficial</string>
   <string name="unofficial_extension_message">Essa extensão não é do repositório oficial.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/pt/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/pt/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Modo de seleção em massa</string>
   <string name="action_faq_and_guides">FAQ e Guias</string>
   <string name="pref_details_page_theme">Página de detalhes</string>
-  <string name="pref_details_page_theme_cover_based">Detalhe o tema da página baseado na capa</string>
+  <string name="pref_theme_cover_based">Detalhe o tema da página baseado na capa</string>
   <string name="pref_theme_cover_based_style">Estilo do tema</string>
-  <string name="pref_theme_cover_based_animate">Animação do tema</string>
   <string name="ext_unofficial">Não-oficial</string>
   <string name="unofficial_extension_message">Essa extensão não é do repositório oficial.</string>
   <string name="download_cache_renew_interval">Baixar intervalo de renovação do cache</string>

--- a/i18n-kmk/src/commonMain/resources/MR/pt/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/pt/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Modo de seleção em massa</string>
   <string name="action_faq_and_guides">FAQ e Guias</string>
   <string name="pref_details_page_theme">Página de detalhes</string>
-  <string name="pref_theme_cover_based">Detalhe o tema da página baseado na capa</string>
+  <string name="pref_theme_cover_based">Tema baseado na capa</string>
   <string name="pref_theme_cover_based_style">Estilo do tema</string>
   <string name="ext_unofficial">Não-oficial</string>
   <string name="unofficial_extension_message">Essa extensão não é do repositório oficial.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ro/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ro/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Mod selecţie în masă</string>
   <string name="action_faq_and_guides">Întrebări frecvente și ghiduri</string>
   <string name="pref_details_page_theme">Pagina de detalii</string>
-  <string name="pref_details_page_theme_cover_based">Tema paginii cu detalii bazate pe copertă</string>
+  <string name="pref_theme_cover_based">Tema paginii cu detalii bazate pe copertă</string>
   <string name="pref_theme_cover_based_style">Stil temă</string>
-  <string name="pref_theme_cover_based_animate">Animare temă</string>
   <string name="ext_unofficial">Neoficial.</string>
   <string name="unofficial_extension_message">Această extensie nu este din repo-ul oficial.</string>
   <string name="download_cache_renew_interval">Interval reînnoire descărcare geocutie</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ro/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ro/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Mod selecţie în masă</string>
   <string name="action_faq_and_guides">Întrebări frecvente și ghiduri</string>
   <string name="pref_details_page_theme">Pagina de detalii</string>
-  <string name="pref_theme_cover_based">Tema paginii cu detalii bazate pe copertă</string>
+  <string name="pref_theme_cover_based">Temă bazată pe copertă</string>
   <string name="pref_theme_cover_based_style">Stil temă</string>
   <string name="ext_unofficial">Neoficial.</string>
   <string name="unofficial_extension_message">Această extensie nu este din repo-ul oficial.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ru/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ru/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Режим массового выбора</string>
   <string name="action_faq_and_guides">FAQ и руководства</string>
   <string name="pref_details_page_theme">Детали</string>
-  <string name="pref_details_page_theme_cover_based">Детали темы на основе обложки</string>
+  <string name="pref_theme_cover_based">Детали темы на основе обложки</string>
   <string name="pref_theme_cover_based_style">Стиль темы</string>
-  <string name="pref_theme_cover_based_animate">Тема анимации</string>
   <string name="ext_unofficial">Неофициальный</string>
   <string name="unofficial_extension_message">Это расширение не из официального репозитория.</string>
   <string name="download_cache_renew_interval">Загрузить интервал обновления кэша</string>

--- a/i18n-kmk/src/commonMain/resources/MR/ru/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/ru/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Режим массового выбора</string>
   <string name="action_faq_and_guides">FAQ и руководства</string>
   <string name="pref_details_page_theme">Детали</string>
-  <string name="pref_theme_cover_based">Детали темы на основе обложки</string>
+  <string name="pref_theme_cover_based">Тема на основе обложки</string>
   <string name="pref_theme_cover_based_style">Стиль темы</string>
   <string name="ext_unofficial">Неофициальный</string>
   <string name="unofficial_extension_message">Это расширение не из официального репозитория.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/sr/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/sr/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/sr/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/sr/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/sv/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/sv/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk markeringsläge</string>
   <string name="action_faq_and_guides">Vanliga frågor och guider</string>
   <string name="pref_details_page_theme">Detaljer sida</string>
-  <string name="pref_details_page_theme_cover_based">Detaljer sida tema baserat på omslag</string>
+  <string name="pref_theme_cover_based">Detaljer sida tema baserat på omslag</string>
   <string name="pref_theme_cover_based_style">Tema stil</string>
-  <string name="pref_theme_cover_based_animate">Tema animerat</string>
   <string name="ext_unofficial">Inofficiellt</string>
   <string name="unofficial_extension_message">Denna förlängning kommer inte från den officiella rapo.</string>
   <string name="download_cache_renew_interval">Hämta cache förnyelseintervall</string>

--- a/i18n-kmk/src/commonMain/resources/MR/sv/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/sv/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk markeringsläge</string>
   <string name="action_faq_and_guides">Vanliga frågor och guider</string>
   <string name="pref_details_page_theme">Detaljer sida</string>
-  <string name="pref_theme_cover_based">Detaljer sida tema baserat på omslag</string>
+  <string name="pref_theme_cover_based">Tema baserat på omslag</string>
   <string name="pref_theme_cover_based_style">Tema stil</string>
   <string name="ext_unofficial">Inofficiellt</string>
   <string name="unofficial_extension_message">Denna förlängning kommer inte från den officiella rapo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/th/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/th/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/th/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/th/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/tr/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/tr/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/tr/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/tr/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/uk/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/uk/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Масовий режим вибору</string>
   <string name="action_faq_and_guides">ЧаПи та керівництва</string>
   <string name="pref_details_page_theme">Сторінка подробиць</string>
-  <string name="pref_theme_cover_based">Тема сторінки подробиць на основі обкладинки</string>
+  <string name="pref_theme_cover_based">Тему на основі обкладинки</string>
   <string name="pref_theme_cover_based_style">Стиль теми</string>
   <string name="ext_unofficial">Неофіційна</string>
   <string name="unofficial_extension_message">Це розширення не з офіційного репозиторію.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/uk/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/uk/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Масовий режим вибору</string>
   <string name="action_faq_and_guides">ЧаПи та керівництва</string>
   <string name="pref_details_page_theme">Сторінка подробиць</string>
-  <string name="pref_details_page_theme_cover_based">Тема сторінки подробиць на основі обкладинки</string>
+  <string name="pref_theme_cover_based">Тема сторінки подробиць на основі обкладинки</string>
   <string name="pref_theme_cover_based_style">Стиль теми</string>
-  <string name="pref_theme_cover_based_animate">Анімація теми</string>
   <string name="ext_unofficial">Неофіційна</string>
   <string name="unofficial_extension_message">Це розширення не з офіційного репозиторію.</string>
   <string name="download_cache_renew_interval">Завантажити інтервал оновлення кешу</string>

--- a/i18n-kmk/src/commonMain/resources/MR/vi/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/vi/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>

--- a/i18n-kmk/src/commonMain/resources/MR/vi/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/vi/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">Bulk selection mode</string>
   <string name="action_faq_and_guides">FAQ and Guides</string>
   <string name="pref_details_page_theme">Details page</string>
-  <string name="pref_details_page_theme_cover_based">Details page theme based on cover</string>
+  <string name="pref_theme_cover_based">Details page theme based on cover</string>
   <string name="pref_theme_cover_based_style">Theme style</string>
-  <string name="pref_theme_cover_based_animate">Theme animate</string>
   <string name="ext_unofficial">Unofficial</string>
   <string name="unofficial_extension_message">This extension is not from the official repo.</string>
   <string name="download_cache_renew_interval">Download cache renew interval</string>

--- a/i18n-kmk/src/commonMain/resources/MR/zh-rCN/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/zh-rCN/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">批量选择模式</string>
   <string name="action_faq_and_guides">常见问题和指南</string>
   <string name="pref_details_page_theme">详细信息页面</string>
-  <string name="pref_theme_cover_based">基于封面的详细页面主题</string>
+  <string name="pref_theme_cover_based">基于封面的主题</string>
   <string name="pref_theme_cover_based_style">主题样式</string>
   <string name="ext_unofficial">非官方的</string>
   <string name="unofficial_extension_message">这个扩展不是官方仓库的扩展。</string>

--- a/i18n-kmk/src/commonMain/resources/MR/zh-rCN/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/zh-rCN/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">批量选择模式</string>
   <string name="action_faq_and_guides">常见问题和指南</string>
   <string name="pref_details_page_theme">详细信息页面</string>
-  <string name="pref_details_page_theme_cover_based">基于封面的详细页面主题</string>
+  <string name="pref_theme_cover_based">基于封面的详细页面主题</string>
   <string name="pref_theme_cover_based_style">主题样式</string>
-  <string name="pref_theme_cover_based_animate">主题动画</string>
   <string name="ext_unofficial">非官方的</string>
   <string name="unofficial_extension_message">这个扩展不是官方仓库的扩展。</string>
   <string name="download_cache_renew_interval">下载缓存续间隔</string>

--- a/i18n-kmk/src/commonMain/resources/MR/zh-rTW/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/zh-rTW/strings.xml
@@ -5,9 +5,8 @@
   <string name="action_bulk_select">批量選擇模式</string>
   <string name="action_faq_and_guides">常見問題和指南</string>
   <string name="pref_details_page_theme">詳情頁面</string>
-  <string name="pref_details_page_theme_cover_based">基於封面的詳細資訊頁面主題</string>
+  <string name="pref_theme_cover_based">基於封面的詳細資訊頁面主題</string>
   <string name="pref_theme_cover_based_style">主題風格</string>
-  <string name="pref_theme_cover_based_animate">主題動畫</string>
   <string name="ext_unofficial">非官方版本</string>
   <string name="unofficial_extension_message">此擴充功能不是來自官方儲存庫</string>
   <string name="download_cache_renew_interval">下載快取更新間隔</string>

--- a/i18n-kmk/src/commonMain/resources/MR/zh-rTW/strings.xml
+++ b/i18n-kmk/src/commonMain/resources/MR/zh-rTW/strings.xml
@@ -5,7 +5,7 @@
   <string name="action_bulk_select">批量選擇模式</string>
   <string name="action_faq_and_guides">常見問題和指南</string>
   <string name="pref_details_page_theme">詳情頁面</string>
-  <string name="pref_theme_cover_based">基於封面的詳細資訊頁面主題</string>
+  <string name="pref_theme_cover_based">基於封面的主題</string>
   <string name="pref_theme_cover_based_style">主題風格</string>
   <string name="ext_unofficial">非官方版本</string>
   <string name="unofficial_extension_message">此擴充功能不是來自官方儲存庫</string>


### PR DESCRIPTION
- Support Pure dark mode
- Tag using elevated style (non pure-dark-mode) and more vibrant outline color (pure-dark-mode)
- More color for various icons
- Color theme for Metadata screen
- Always animated color change
- Always/Only use dominant color for library/update/upcoming cover's background
- Don't always generate color each time cover loaded (library/browse), only update color when new cover changed on detail page
- Fix the spinner background in Edit Manga Info
- Improve manga's backdrop color