### PR TITLE
fix: dialog's button wrong order

### DIFF
--- a/app/src/main/res/layout/dialog_stub_textinput.xml
+++ b/app/src/main/res/layout/dialog_stub_textinput.xml
@@ -34,17 +34,17 @@
         android:gravity="end">
 
         <Button
+            android:id="@+id/negativeButton"
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <Button
             android:id="@+id/positiveButton"
             style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp" />
-
-        <Button
-            android:id="@+id/negativeButton"
-            style="?android:attr/buttonBarButtonStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
 
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
in manga's Edit Info's Add tag

close #210 