### PR TITLE
disable smart-update for individual & fix custom interval

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -595,6 +595,8 @@ private fun MangaScreenSmallImpl(
                             // SY <--
                             // KMK -->
                             status = state.manga.status,
+                            fetchInterval = 0,
+
                             // KMK <--
                         )
                     }
@@ -1000,6 +1002,7 @@ private fun MangaScreenLargeImpl(
                             // SY <--
                             // KMK -->
                             status = state.manga.status,
+                            fetchInterval = 0,
                             // KMK <--
                         )
                         // SY -->

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -595,7 +595,7 @@ private fun MangaScreenSmallImpl(
                             // SY <--
                             // KMK -->
                             status = state.manga.status,
-                            fetchInterval = 0,
+                            fetchInterval = -1,
 
                             // KMK <--
                         )
@@ -1002,7 +1002,7 @@ private fun MangaScreenLargeImpl(
                             // SY <--
                             // KMK -->
                             status = state.manga.status,
-                            fetchInterval = 0,
+                            fetchInterval = -1,
                             // KMK <--
                         )
                         // SY -->

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -595,8 +595,7 @@ private fun MangaScreenSmallImpl(
                             // SY <--
                             // KMK -->
                             status = state.manga.status,
-                            fetchInterval = -1,
-
+                            interval = state.manga.fetchInterval,
                             // KMK <--
                         )
                     }
@@ -1002,7 +1001,7 @@ private fun MangaScreenLargeImpl(
                             // SY <--
                             // KMK -->
                             status = state.manga.status,
-                            fetchInterval = -1,
+                            interval = state.manga.fetchInterval,
                             // KMK <--
                         )
                         // SY -->

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
@@ -117,12 +117,12 @@ fun SetIntervalDialog(
                         contentAlignment = Alignment.Center,
                     ) {
                         val size = DpSize(width = maxWidth / 2, height = 128.dp)
-                        val items = (0..FetchInterval.MAX_INTERVAL)
+                        val items = (-1..FetchInterval.MAX_INTERVAL)
                             .map {
-                                if (it == 0) {
-                                    stringResource(MR.strings.label_default)
-                                } else {
-                                    it.toString()
+                                when (it) {
+                                    -1 -> stringResource(MR.strings.not_applicable)
+                                    0 -> stringResource(MR.strings.label_default)
+                                    else -> it.toString()
                                 }
                             }
                             .toImmutableList()

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
@@ -127,7 +127,9 @@ fun SetIntervalDialog(
                             }
                             .toImmutableList()
                         WheelTextPicker(
-                            items = items,
+                            items = listOf(items[1], items[0])
+                                .plus(items.subList(2, items.size))
+                                .toImmutableList(),
                             size = size,
                             startIndex = selectedInterval,
                             onSelectionChanged = { selectedInterval = it },

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
@@ -117,22 +117,38 @@ fun SetIntervalDialog(
                         contentAlignment = Alignment.Center,
                     ) {
                         val size = DpSize(width = maxWidth / 2, height = 128.dp)
-                        val items = (-1..FetchInterval.MAX_INTERVAL)
-                            .map {
-                                when (it) {
-                                    -1 -> stringResource(MR.strings.not_applicable)
-                                    0 -> stringResource(MR.strings.label_default)
-                                    else -> it.toString()
-                                }
-                            }
-                            .toImmutableList()
+                        val items =
+                            // KMK -->
+                            (
+                                listOf(stringResource(MR.strings.action_disable)) +
+                                    // KMK <--
+                                    (0..FetchInterval.MAX_INTERVAL)
+                                        .map {
+                                            if (it == 0) {
+                                                stringResource(MR.strings.label_default)
+                                            } else {
+                                                it.toString()
+                                            }
+                                        }
+                                )
+                                .toImmutableList()
                         WheelTextPicker(
-                            items = listOf(items[1], items[0])
-                                .plus(items.subList(2, items.size))
-                                .toImmutableList(),
+                            items = items,
                             size = size,
-                            startIndex = selectedInterval,
-                            onSelectionChanged = { selectedInterval = it },
+                            startIndex = (
+                                selectedInterval +
+                                    // KMK -->
+                                    1
+                                ).takeIf { selectedInterval != FetchInterval.MANUAL_DISABLE } ?: 0,
+                            // KMK <--
+                            onSelectionChanged = { idx ->
+                                selectedInterval = (
+                                    idx -
+                                        // KMK -->
+                                        1
+                                    ).takeIf { idx != 0 } ?: FetchInterval.MANUAL_DISABLE
+                                // KMK <--
+                            },
                         )
                     }
                 }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -221,7 +221,7 @@ fun MangaActionRow(
 
     // TODO: show something better when using custom interval
     val nextUpdateDays = remember(nextUpdate) {
-        return@remember if (nextUpdate != null && isSkipCompleted && isNAInterval) {
+        return@remember if (nextUpdate != null && isSkipCompleted) {
             val now = Instant.now()
             now.until(nextUpdate, ChronoUnit.DAYS).toInt().coerceAtLeast(0)
         } else {
@@ -242,14 +242,17 @@ fun MangaActionRow(
             onLongClick = onEditCategory,
         )
         MangaActionButton(
-            title = when (nextUpdateDays) {
-                null -> stringResource(MR.strings.not_applicable)
-                0 -> stringResource(MR.strings.manga_interval_expected_update_soon)
-                else -> pluralStringResource(
-                    MR.plurals.day,
-                    count = nextUpdateDays,
-                    nextUpdateDays,
-                )
+            title = when (fetchInterval) {
+                -1 -> stringResource(MR.strings.not_applicable)
+                else -> when (nextUpdateDays) {
+                    null -> stringResource(MR.strings.not_applicable)
+                    0 -> stringResource(MR.strings.manga_interval_expected_update_soon)
+                    else -> pluralStringResource(
+                        MR.plurals.day,
+                        count = nextUpdateDays,
+                        nextUpdateDays,
+                    )
+                }
             },
             icon = Icons.Default.HourglassEmpty,
             color = if (isUserIntervalMode ||

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -240,6 +240,7 @@ fun MangaActionRow(
         MangaActionButton(
             title = when (nextUpdateDays) {
                 null -> stringResource(MR.strings.not_applicable)
+                -1 -> stringResource(MR.strings.not_applicable)
                 0 -> stringResource(MR.strings.manga_interval_expected_update_soon)
                 else -> pluralStringResource(
                     MR.plurals.day,

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -214,21 +214,20 @@ fun MangaActionRow(
     val libraryPreferences: LibraryPreferences = Injekt.get()
     val restrictions = libraryPreferences.autoUpdateMangaRestrictions().get()
     val isSkipCompleted = MANGA_NON_COMPLETED !in restrictions || status != SManga.COMPLETED.toLong()
-    val isNAInterval = fetchInterval < 0
-
     // KMK <--
     val defaultActionButtonColor = MaterialTheme.colorScheme.onSurface.copy(alpha = DISABLED_ALPHA)
 
     // TODO: show something better when using custom interval
-    val nextUpdateDays = remember(nextUpdate) {
-        return@remember if (nextUpdate != null && isSkipCompleted) {
+    val nextUpdateDays = remember(nextUpdate, fetchInterval, isSkipCompleted) {
+        if (fetchInterval < 0) {
+            null
+        } else if (nextUpdate != null && isSkipCompleted) {
             val now = Instant.now()
             now.until(nextUpdate, ChronoUnit.DAYS).toInt().coerceAtLeast(0)
         } else {
             null
         }
     }
-
     Row(modifier = modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp)) {
         MangaActionButton(
             title = if (favorite) {
@@ -242,17 +241,14 @@ fun MangaActionRow(
             onLongClick = onEditCategory,
         )
         MangaActionButton(
-            title = when (fetchInterval) {
-                -1 -> stringResource(MR.strings.not_applicable)
-                else -> when (nextUpdateDays) {
-                    null -> stringResource(MR.strings.not_applicable)
-                    0 -> stringResource(MR.strings.manga_interval_expected_update_soon)
-                    else -> pluralStringResource(
-                        MR.plurals.day,
-                        count = nextUpdateDays,
-                        nextUpdateDays,
-                    )
-                }
+            title = when (nextUpdateDays) {
+                null -> stringResource(MR.strings.not_applicable)
+                0 -> stringResource(MR.strings.manga_interval_expected_update_soon)
+                else -> pluralStringResource(
+                    MR.plurals.day,
+                    count = nextUpdateDays,
+                    nextUpdateDays,
+                )
             },
             icon = Icons.Default.HourglassEmpty,
             color = if (isUserIntervalMode ||

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -207,17 +207,21 @@ fun MangaActionRow(
     status: Long,
     // KMK <--
     modifier: Modifier = Modifier,
-) {
+    fetchInterval: Int,
+
+    ) {
     // KMK -->
     val libraryPreferences: LibraryPreferences = Injekt.get()
     val restrictions = libraryPreferences.autoUpdateMangaRestrictions().get()
     val isSkipCompleted = MANGA_NON_COMPLETED !in restrictions || status != SManga.COMPLETED.toLong()
+    val isNAInterval = fetchInterval < 0
+
     // KMK <--
     val defaultActionButtonColor = MaterialTheme.colorScheme.onSurface.copy(alpha = DISABLED_ALPHA)
 
     // TODO: show something better when using custom interval
     val nextUpdateDays = remember(nextUpdate) {
-        return@remember if (nextUpdate != null && isSkipCompleted) {
+        return@remember if (nextUpdate != null && isSkipCompleted && isNAInterval) {
             val now = Instant.now()
             now.until(nextUpdate, ChronoUnit.DAYS).toInt().coerceAtLeast(0)
         } else {
@@ -240,7 +244,6 @@ fun MangaActionRow(
         MangaActionButton(
             title = when (nextUpdateDays) {
                 null -> stringResource(MR.strings.not_applicable)
-                -1 -> stringResource(MR.strings.not_applicable)
                 0 -> stringResource(MR.strings.manga_interval_expected_update_soon)
                 else -> pluralStringResource(
                     MR.plurals.day,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -323,7 +323,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                             it.manga to
                                 context.stringResource(MR.strings.skipped_reason_not_in_release_period),
                         )
-                        true
+                        false
                     }
                     MANGA_NON_COMPLETED in restrictions &&
                         it.manga.status.toInt() == SManga.COMPLETED -> {
@@ -333,7 +333,6 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                         )
                         false
                     }
-
                     else -> true
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -317,17 +317,23 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                     MANGA_OUTSIDE_RELEASE_PERIOD in restrictions &&
                         (
                             it.manga.nextUpdate > fetchWindowUpperBound ||
-                                // KMK -->
-                                MANGA_NON_COMPLETED in restrictions &&
-                                it.manga.status.toInt() == SManga.COMPLETED
-                            // KMK <--
+                                it.manga.fetchInterval < 0
                             ) -> {
                         skippedUpdates.add(
                             it.manga to
                                 context.stringResource(MR.strings.skipped_reason_not_in_release_period),
                         )
+                        true
+                    }
+                    MANGA_NON_COMPLETED in restrictions &&
+                        it.manga.status.toInt() == SManga.COMPLETED -> {
+                        skippedUpdates.add(
+                            it.manga to
+                                context.stringResource(MR.strings.skipped_reason_completed),
+                        )
                         false
                     }
+
                     else -> true
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -317,19 +317,14 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                     MANGA_OUTSIDE_RELEASE_PERIOD in restrictions &&
                         (
                             it.manga.nextUpdate > fetchWindowUpperBound ||
-                                it.manga.fetchInterval < 0
+                                // KMK -->
+                                MANGA_NON_COMPLETED in restrictions &&
+                                it.manga.status.toInt() == SManga.COMPLETED
+                            // KMK <--
                             ) -> {
                         skippedUpdates.add(
                             it.manga to
                                 context.stringResource(MR.strings.skipped_reason_not_in_release_period),
-                        )
-                        false
-                    }
-                    MANGA_NON_COMPLETED in restrictions &&
-                        it.manga.status.toInt() == SManga.COMPLETED -> {
-                        skippedUpdates.add(
-                            it.manga to
-                                context.stringResource(MR.strings.skipped_reason_completed),
                         )
                         false
                     }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
@@ -107,7 +107,7 @@ class FetchInterval(
             interval.absoluteValue.takeIf { interval < 0 }
                 ?: increaseInterval(interval, timeSinceLatest, increaseWhenOver = 10),
         )
-        return latestDate.plusDays((cycle + 1) * interval.toLong()).toEpochSecond(dateTime.offset) * 1000
+        return latestDate.plusDays((cycle + 1) * interval.absoluteValue.toLong()).toEpochSecond(dateTime.offset) * 1000
     }
 
     private fun increaseInterval(delta: Int, timeSinceLatest: Int, increaseWhenOver: Int): Int {

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
@@ -8,7 +8,6 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
-import kotlin.math.absoluteValue
 
 class FetchInterval(
     private val getChaptersByMangaId: GetChaptersByMangaId,
@@ -92,6 +91,10 @@ class FetchInterval(
         dateTime: ZonedDateTime,
         window: Pair<Long, Long>,
     ): Long {
+        if (interval < 0) {
+            return 0L
+        }
+
         if (manga.nextUpdate in window.first.rangeTo(window.second + 1)) {
             return manga.nextUpdate
         }
@@ -104,8 +107,7 @@ class FetchInterval(
             .atStartOfDay()
         val timeSinceLatest = ChronoUnit.DAYS.between(latestDate, dateTime).toInt()
         val cycle = timeSinceLatest.floorDiv(
-            interval.absoluteValue.takeIf { interval < 0 }
-                ?: increaseInterval(interval, timeSinceLatest, increaseWhenOver = 10),
+            increaseInterval(interval, timeSinceLatest, increaseWhenOver = 10),
         )
         return latestDate.plusDays((cycle + 1) * interval.toLong()).toEpochSecond(dateTime.offset) * 1000
     }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
@@ -8,6 +8,7 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
+import kotlin.math.absoluteValue
 
 class FetchInterval(
     private val getChaptersByMangaId: GetChaptersByMangaId,
@@ -91,10 +92,6 @@ class FetchInterval(
         dateTime: ZonedDateTime,
         window: Pair<Long, Long>,
     ): Long {
-        if (interval < 0) {
-            return 0L
-        }
-
         if (manga.nextUpdate in window.first.rangeTo(window.second + 1)) {
             return manga.nextUpdate
         }
@@ -107,7 +104,8 @@ class FetchInterval(
             .atStartOfDay()
         val timeSinceLatest = ChronoUnit.DAYS.between(latestDate, dateTime).toInt()
         val cycle = timeSinceLatest.floorDiv(
-            increaseInterval(interval, timeSinceLatest, increaseWhenOver = 10),
+            interval.absoluteValue.takeIf { interval < 0 }
+                ?: increaseInterval(interval, timeSinceLatest, increaseWhenOver = 10),
         )
         return latestDate.plusDays((cycle + 1) * interval.toLong()).toEpochSecond(dateTime.offset) * 1000
     }
@@ -128,5 +126,9 @@ class FetchInterval(
         const val MAX_INTERVAL = 28
 
         private const val GRACE_PERIOD = 1L
+
+        // KMK -->
+        const val MANUAL_DISABLE = 99999 // 274 years in future
+        // KMK <--
     }
 }


### PR DESCRIPTION
eventually closes #306 when I figure this out
(it's so hard)
what is working:
N/A is being displayed as the second option and it looks like everything that has the N/A isn't updating while if it has default or any other thing it does update
what isn't working:
I tried making it so when an user chooses the N/A option, it will make the MangaInfoHeader appear as N/A as well on the hourglass. It kinda failed...? everything started appearing as N/A after that.