### PR TITLE
Error screen improve

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -37,9 +37,6 @@ import mihon.domain.upcoming.interactor.GetUpcomingManga
 import tachiyomi.data.category.CategoryRepositoryImpl
 import tachiyomi.data.chapter.ChapterRepositoryImpl
 import tachiyomi.data.history.HistoryRepositoryImpl
-import tachiyomi.data.libraryUpdateError.LibraryUpdateErrorRepositoryImpl
-import tachiyomi.data.libraryUpdateError.LibraryUpdateErrorWithRelationsRepositoryImpl
-import tachiyomi.data.libraryUpdateErrorMessage.LibraryUpdateErrorMessageRepositoryImpl
 import tachiyomi.data.manga.MangaRepositoryImpl
 import tachiyomi.data.release.ReleaseServiceImpl
 import tachiyomi.data.source.SourceRepositoryImpl
@@ -70,16 +67,6 @@ import tachiyomi.domain.history.interactor.GetTotalReadDuration
 import tachiyomi.domain.history.interactor.RemoveHistory
 import tachiyomi.domain.history.interactor.UpsertHistory
 import tachiyomi.domain.history.repository.HistoryRepository
-import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors
-import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrorWithRelations
-import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrors
-import tachiyomi.domain.libraryUpdateError.interactor.InsertLibraryUpdateErrors
-import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
-import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorWithRelationsRepository
-import tachiyomi.domain.libraryUpdateErrorMessage.interactor.DeleteLibraryUpdateErrorMessages
-import tachiyomi.domain.libraryUpdateErrorMessage.interactor.GetLibraryUpdateErrorMessages
-import tachiyomi.domain.libraryUpdateErrorMessage.interactor.InsertLibraryUpdateErrorMessages
-import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorMessageRepository
 import tachiyomi.domain.manga.interactor.FetchInterval
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
 import tachiyomi.domain.manga.interactor.GetFavorites
@@ -182,21 +169,6 @@ class DomainModule : InjektModule {
 
         addSingletonFactory<UpdatesRepository> { UpdatesRepositoryImpl(get()) }
         addFactory { GetUpdates(get()) }
-
-        addSingletonFactory<LibraryUpdateErrorWithRelationsRepository> {
-            LibraryUpdateErrorWithRelationsRepositoryImpl(get())
-        }
-        addFactory { GetLibraryUpdateErrorWithRelations(get()) }
-
-        addSingletonFactory<LibraryUpdateErrorMessageRepository> { LibraryUpdateErrorMessageRepositoryImpl(get()) }
-        addFactory { GetLibraryUpdateErrorMessages(get()) }
-        addFactory { DeleteLibraryUpdateErrorMessages(get()) }
-        addFactory { InsertLibraryUpdateErrorMessages(get()) }
-
-        addSingletonFactory<LibraryUpdateErrorRepository> { LibraryUpdateErrorRepositoryImpl(get()) }
-        addFactory { GetLibraryUpdateErrors(get()) }
-        addFactory { DeleteLibraryUpdateErrors(get()) }
-        addFactory { InsertLibraryUpdateErrors(get()) }
 
         addSingletonFactory<SourceRepository> { SourceRepositoryImpl(get(), get()) }
         addSingletonFactory<StubSourceRepository> { StubSourceRepositoryImpl(get()) }

--- a/app/src/main/java/eu/kanade/domain/KMKDomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/KMKDomainModule.kt
@@ -1,0 +1,40 @@
+package eu.kanade.domain
+
+import tachiyomi.data.libraryUpdateError.LibraryUpdateErrorRepositoryImpl
+import tachiyomi.data.libraryUpdateError.LibraryUpdateErrorWithRelationsRepositoryImpl
+import tachiyomi.data.libraryUpdateErrorMessage.LibraryUpdateErrorMessageRepositoryImpl
+import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors
+import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrorWithRelations
+import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrors
+import tachiyomi.domain.libraryUpdateError.interactor.InsertLibraryUpdateErrors
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
+import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorWithRelationsRepository
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.DeleteLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.GetLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.interactor.InsertLibraryUpdateErrorMessages
+import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorMessageRepository
+import uy.kohesive.injekt.api.InjektModule
+import uy.kohesive.injekt.api.InjektRegistrar
+import uy.kohesive.injekt.api.addFactory
+import uy.kohesive.injekt.api.addSingletonFactory
+import uy.kohesive.injekt.api.get
+
+class KMKDomainModule : InjektModule {
+
+    override fun InjektRegistrar.registerInjectables() {
+        addSingletonFactory<LibraryUpdateErrorWithRelationsRepository> {
+            LibraryUpdateErrorWithRelationsRepositoryImpl(get())
+        }
+        addFactory { GetLibraryUpdateErrorWithRelations(get()) }
+
+        addSingletonFactory<LibraryUpdateErrorMessageRepository> { LibraryUpdateErrorMessageRepositoryImpl(get()) }
+        addFactory { GetLibraryUpdateErrorMessages(get()) }
+        addFactory { DeleteLibraryUpdateErrorMessages(get()) }
+        addFactory { InsertLibraryUpdateErrorMessages(get()) }
+
+        addSingletonFactory<LibraryUpdateErrorRepository> { LibraryUpdateErrorRepositoryImpl(get()) }
+        addFactory { GetLibraryUpdateErrors(get()) }
+        addFactory { DeleteLibraryUpdateErrors(get()) }
+        addFactory { InsertLibraryUpdateErrors(get()) }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material.icons.outlined.FindReplace
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll
@@ -36,9 +38,11 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -94,6 +98,21 @@ fun LibraryUpdateErrorScreen(
         }
     }
 
+    val headerIndexes = remember { mutableStateOf<List<Int>>(emptyList()) }
+    LaunchedEffect(state) {
+        headerIndexes.value = state.getHeaderIndexes()
+    }
+    val enableScrollToPrevious by remember {
+        derivedStateOf {
+            headerIndexes.value.any { it < listState.firstVisibleItemIndex }
+        }
+    }
+    val enableScrollToNext by remember {
+        derivedStateOf {
+            headerIndexes.value.any { it > listState.firstVisibleItemIndex }
+        }
+    }
+
     BackHandler(enabled = state.selectionMode, onBack = { onSelectAll(false) })
 
     Scaffold(
@@ -127,6 +146,26 @@ fun LibraryUpdateErrorScreen(
                 scrollToBottom = {
                     scope.launch {
                         listState.scrollToItem(state.items.size - 1)
+                    }
+                },
+                enableScrollToPrevious = enableScrollToTop && enableScrollToPrevious,
+                enableScrollToNext = enableScrollToBottom && enableScrollToNext,
+                scrollToPrevious = {
+                    scope.launch {
+                        listState.scrollToItem(
+                            state.getHeaderIndexes()
+                                .filter { it < listState.firstVisibleItemIndex }
+                                .maxOrNull() ?: 0,
+                        )
+                    }
+                },
+                scrollToNext = {
+                    scope.launch {
+                        listState.scrollToItem(
+                            state.getHeaderIndexes()
+                                .filter { it > listState.firstVisibleItemIndex }
+                                .minOrNull() ?: 0,
+                        )
                     }
                 },
             )
@@ -167,6 +206,10 @@ private fun LibraryUpdateErrorsBottomBar(
     enableScrollToBottom: Boolean,
     scrollToTop: () -> Unit,
     scrollToBottom: () -> Unit,
+    enableScrollToPrevious: Boolean,
+    enableScrollToNext: Boolean,
+    scrollToPrevious: () -> Unit,
+    scrollToNext: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     Surface(
@@ -178,11 +221,11 @@ private fun LibraryUpdateErrorsBottomBar(
         color = MaterialTheme.colorScheme.surfaceContainerHigh,
     ) {
         val haptic = LocalHapticFeedback.current
-        val confirm = remember { mutableStateListOf(false, false, false) }
+        val confirm = remember { mutableStateListOf(false, false, false, false, false) }
         var resetJob: Job? = remember { null }
         val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-            (0 until 3).forEach { i -> confirm[i] = i == toConfirmIndex }
+            (0 until 5).forEach { i -> confirm[i] = i == toConfirmIndex }
             resetJob?.cancel()
             resetJob = scope.launch {
                 delay(1.seconds)
@@ -211,10 +254,22 @@ private fun LibraryUpdateErrorsBottomBar(
                 enabled = enableScrollToTop,
             )
             Button(
-                title = stringResource(MR.strings.migrate),
-                icon = Icons.Outlined.FindReplace,
+                title = stringResource(KMR.strings.action_scroll_to_previous),
+                icon = Icons.Outlined.ArrowUpward,
                 toConfirm = confirm[1],
                 onLongClick = { onLongClickItem(1) },
+                onClick = if (enableScrollToPrevious) {
+                    scrollToPrevious
+                } else {
+                    {}
+                },
+                enabled = enableScrollToPrevious,
+            )
+            Button(
+                title = stringResource(MR.strings.migrate),
+                icon = Icons.Outlined.FindReplace,
+                toConfirm = confirm[2],
+                onLongClick = { onLongClickItem(2) },
                 onClick = if (selected.isNotEmpty()) {
                     onMultiMigrateClicked
                 } else {
@@ -223,10 +278,22 @@ private fun LibraryUpdateErrorsBottomBar(
                 enabled = selected.isNotEmpty(),
             )
             Button(
+                title = stringResource(KMR.strings.action_scroll_to_next),
+                icon = Icons.Outlined.ArrowDownward,
+                toConfirm = confirm[3],
+                onLongClick = { onLongClickItem(3) },
+                onClick = if (enableScrollToNext) {
+                    scrollToNext
+                } else {
+                    {}
+                },
+                enabled = enableScrollToNext,
+            )
+            Button(
                 title = stringResource(KMR.strings.action_scroll_to_bottom),
                 icon = Icons.Outlined.VerticalAlignBottom,
-                toConfirm = confirm[2],
-                onLongClick = { onLongClickItem(2) },
+                toConfirm = confirm[4],
+                onLongClick = { onLongClickItem(4) },
                 onClick = if (enableScrollToBottom) {
                     scrollToBottom
                 } else {

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -3,7 +3,6 @@ package eu.kanade.presentation.libraryUpdateError
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -25,22 +24,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.ArrowBack
-import androidx.compose.material.icons.outlined.ArrowDownward
-import androidx.compose.material.icons.outlined.ArrowUpward
-import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.FindReplace
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll
+import androidx.compose.material.icons.outlined.VerticalAlignBottom
+import androidx.compose.material.icons.outlined.VerticalAlignTop
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.ripple
-import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -54,11 +48,12 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import eu.kanade.presentation.components.AppBarTitle
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.libraryUpdateError.components.libraryUpdateErrorUiItems
-import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorScreenState
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -108,7 +103,12 @@ fun LibraryUpdateErrorScreen(
                     KMR.strings.label_library_update_errors,
                     state.items.size,
                 ),
-                actionModeCounter = state.selected.size,
+                itemCnt = state.items.size,
+                navigateUp = navigateUp,
+                selectedCount = state.selected.size,
+                onClickUnselectAll = { onSelectAll(false) },
+                onClickSelectAll = { onSelectAll(true) },
+                onClickInvertSelection = onInvertSelection,
                 scrollBehavior = scrollBehavior,
             )
         },
@@ -116,14 +116,9 @@ fun LibraryUpdateErrorScreen(
             LibraryUpdateErrorsBottomBar(
                 modifier = modifier,
                 selected = state.selected,
-                itemCount = state.items.size,
+                onMultiMigrateClicked = onMultiMigrateClicked,
                 enableScrollToTop = enableScrollToTop,
                 enableScrollToBottom = enableScrollToBottom,
-                onMultiMigrateClicked = onMultiMigrateClicked,
-                onSelectAll = { onSelectAll(true) },
-                onInvertSelection = onInvertSelection,
-                onCancelActionMode = { onSelectAll(false) },
-                navigateUp = navigateUp,
                 scrollToTop = {
                     scope.launch {
                         listState.scrollToItem(0)
@@ -166,35 +161,27 @@ fun LibraryUpdateErrorScreen(
 private fun LibraryUpdateErrorsBottomBar(
     modifier: Modifier = Modifier,
     selected: List<LibraryUpdateErrorItem>,
-    itemCount: Int,
+    onMultiMigrateClicked: (() -> Unit),
     enableScrollToTop: Boolean,
     enableScrollToBottom: Boolean,
-    onMultiMigrateClicked: (() -> Unit),
-    onSelectAll: () -> Unit,
-    onInvertSelection: () -> Unit,
-    onCancelActionMode: () -> Unit,
-    navigateUp: () -> Unit,
     scrollToTop: () -> Unit,
     scrollToBottom: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
-    val animatedElevation by animateDpAsState(if (selected.isNotEmpty()) 3.dp else 0.dp)
     Surface(
         modifier = modifier,
         shape = MaterialTheme.shapes.large.copy(
             bottomEnd = ZeroCornerSize,
             bottomStart = ZeroCornerSize,
         ),
-        color = MaterialTheme.colorScheme.surfaceColorAtElevation(
-            elevation = animatedElevation,
-        ),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
     ) {
         val haptic = LocalHapticFeedback.current
-        val confirm = remember { mutableStateListOf(false, false, false, false, false, false) }
+        val confirm = remember { mutableStateListOf(false, false, false) }
         var resetJob: Job? = remember { null }
         val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-            (0 until 6).forEach { i -> confirm[i] = i == toConfirmIndex }
+            (0 until 3).forEach { i -> confirm[i] = i == toConfirmIndex }
             resetJob?.cancel()
             resetJob = scope.launch {
                 delay(1.seconds)
@@ -210,54 +197,11 @@ private fun LibraryUpdateErrorsBottomBar(
                 )
                 .padding(horizontal = 8.dp, vertical = 12.dp),
         ) {
-            if (selected.isNotEmpty()) {
-                Button(
-                    title = stringResource(MR.strings.action_cancel),
-                    icon = Icons.Outlined.Close,
-                    toConfirm = confirm[0],
-                    onLongClick = { onLongClickItem(0) },
-                    onClick = onCancelActionMode,
-                    enabled = true,
-                )
-            } else {
-                Button(
-                    title = androidx.compose.ui.res.stringResource(R.string.abc_action_bar_up_description),
-                    icon = Icons.AutoMirrored.Outlined.ArrowBack,
-                    toConfirm = confirm[0],
-                    onLongClick = { onLongClickItem(0) },
-                    onClick = navigateUp,
-                    enabled = true,
-                )
-            }
-            Button(
-                title = stringResource(MR.strings.action_select_all),
-                icon = Icons.Outlined.SelectAll,
-                toConfirm = confirm[1],
-                onLongClick = { onLongClickItem(1) },
-                onClick = if (selected.isEmpty() or (selected.size != itemCount)) {
-                    onSelectAll
-                } else {
-                    {}
-                },
-                enabled = selected.isEmpty() or (selected.size != itemCount),
-            )
-            Button(
-                title = stringResource(MR.strings.action_select_inverse),
-                icon = Icons.Outlined.FlipToBack,
-                toConfirm = confirm[2],
-                onLongClick = { onLongClickItem(2) },
-                onClick = if (selected.isNotEmpty()) {
-                    onInvertSelection
-                } else {
-                    {}
-                },
-                enabled = selected.isNotEmpty(),
-            )
             Button(
                 title = stringResource(KMR.strings.action_scroll_to_top),
-                icon = Icons.Outlined.ArrowUpward,
-                toConfirm = confirm[3],
-                onLongClick = { onLongClickItem(3) },
+                icon = Icons.Outlined.VerticalAlignTop,
+                toConfirm = confirm[0],
+                onLongClick = { onLongClickItem(0) },
                 onClick = if (enableScrollToTop) {
                     scrollToTop
                 } else {
@@ -266,28 +210,28 @@ private fun LibraryUpdateErrorsBottomBar(
                 enabled = enableScrollToTop,
             )
             Button(
-                title = stringResource(KMR.strings.action_scroll_to_bottom),
-                icon = Icons.Outlined.ArrowDownward,
-                toConfirm = confirm[4],
-                onLongClick = { onLongClickItem(4) },
-                onClick = if (enableScrollToBottom) {
-                    scrollToBottom
-                } else {
-                    {}
-                },
-                enabled = enableScrollToBottom,
-            )
-            Button(
                 title = stringResource(MR.strings.migrate),
                 icon = Icons.Outlined.FindReplace,
-                toConfirm = confirm[5],
-                onLongClick = { onLongClickItem(5) },
+                toConfirm = confirm[1],
+                onLongClick = { onLongClickItem(1) },
                 onClick = if (selected.isNotEmpty()) {
                     onMultiMigrateClicked
                 } else {
                     {}
                 },
                 enabled = selected.isNotEmpty(),
+            )
+            Button(
+                title = stringResource(KMR.strings.action_scroll_to_bottom),
+                icon = Icons.Outlined.VerticalAlignBottom,
+                toConfirm = confirm[2],
+                onLongClick = { onLongClickItem(2) },
+                onClick = if (enableScrollToBottom) {
+                    scrollToBottom
+                } else {
+                    {}
+                },
+                enabled = enableScrollToBottom,
             )
         }
     }
@@ -350,33 +294,49 @@ private fun RowScope.Button(
 
 @Composable
 private fun LibraryUpdateErrorsAppBar(
-    modifier: Modifier = Modifier,
     title: String,
-    actionModeCounter: Int,
+    itemCnt: Int,
+    navigateUp: () -> Unit,
+    selectedCount: Int,
+    onClickUnselectAll: () -> Unit,
+    onClickSelectAll: () -> Unit,
+    onClickInvertSelection: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
-    val isActionMode by remember(actionModeCounter) {
-        derivedStateOf { actionModeCounter > 0 }
-    }
-
-    Column(
-        modifier = modifier,
-    ) {
-        TopAppBar(
-            title = {
-                if (isActionMode) {
-                    AppBarTitle("$actionModeCounter selected")
-                } else {
-                    AppBarTitle(title)
-                }
-            },
-            actions = {},
-            colors = TopAppBarDefaults.topAppBarColors(
-                containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
-                    elevation = if (isActionMode) 3.dp else 0.dp,
+    AppBar(
+        title = title,
+        navigateUp = navigateUp,
+        actions = {
+            if (itemCnt > 0) {
+                AppBarActions(
+                    persistentListOf(
+                        AppBar.Action(
+                            title = stringResource(MR.strings.action_select_all),
+                            icon = Icons.Outlined.SelectAll,
+                            onClick = onClickSelectAll,
+                        ),
+                    ),
+                )
+            }
+        },
+        actionModeCounter = selectedCount,
+        onCancelActionMode = onClickUnselectAll,
+        actionModeActions = {
+            AppBarActions(
+                persistentListOf(
+                    AppBar.Action(
+                        title = stringResource(MR.strings.action_select_all),
+                        icon = Icons.Outlined.SelectAll,
+                        onClick = onClickSelectAll,
+                    ),
+                    AppBar.Action(
+                        title = stringResource(MR.strings.action_select_inverse),
+                        icon = Icons.Outlined.FlipToBack,
+                        onClick = onClickInvertSelection,
+                    ),
                 ),
-            ),
-            scrollBehavior = scrollBehavior,
-        )
-    }
+            )
+        },
+        scrollBehavior = scrollBehavior,
+    )
 }

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -2,6 +2,8 @@ package eu.kanade.presentation.libraryUpdateError
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
@@ -20,19 +22,27 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.FindReplace
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.ripple
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
@@ -44,8 +54,9 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarTitle
 import eu.kanade.presentation.libraryUpdateError.components.libraryUpdateErrorUiItems
+import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorScreenState
 import kotlinx.coroutines.Job
@@ -73,6 +84,21 @@ fun LibraryUpdateErrorScreen(
     onErrorSelected: (LibraryUpdateErrorItem, Boolean, Boolean, Boolean) -> Unit,
     navigateUp: () -> Unit,
 ) {
+    val listState = rememberLazyListState()
+    val scope = rememberCoroutineScope()
+
+    val enableScrollToTop by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex > 0
+        }
+    }
+
+    val enableScrollToBottom by remember {
+        derivedStateOf {
+            listState.canScrollForward
+        }
+    }
+
     BackHandler(enabled = state.selectionMode, onBack = { onSelectAll(false) })
 
     Scaffold(
@@ -83,59 +109,32 @@ fun LibraryUpdateErrorScreen(
                     state.items.size,
                 ),
                 actionModeCounter = state.selected.size,
-                onSelectAll = { onSelectAll(true) },
-                onInvertSelection = onInvertSelection,
-                onCancelActionMode = { onSelectAll(false) },
                 scrollBehavior = scrollBehavior,
-                navigateUp = navigateUp,
             )
         },
         bottomBar = {
-            AnimatedVisibility(
-                visible = state.selected.isNotEmpty(),
-                enter = expandVertically(expandFrom = Alignment.Bottom),
-                exit = shrinkVertically(shrinkTowards = Alignment.Bottom),
-            ) {
-                val scope = rememberCoroutineScope()
-                Surface(
-                    modifier = modifier,
-                    shape = MaterialTheme.shapes.large.copy(
-                        bottomEnd = ZeroCornerSize,
-                        bottomStart = ZeroCornerSize,
-                    ),
-                    tonalElevation = 3.dp,
-                ) {
-                    val haptic = LocalHapticFeedback.current
-                    val confirm = remember { mutableStateListOf(false) }
-                    var resetJob: Job? = remember { null }
-                    val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                        (0 until 1).forEach { i -> confirm[i] = i == toConfirmIndex }
-                        resetJob?.cancel()
-                        resetJob = scope.launch {
-                            delay(1.seconds)
-                            if (isActive) confirm[toConfirmIndex] = false
-                        }
+            LibraryUpdateErrorsBottomBar(
+                modifier = modifier,
+                selected = state.selected,
+                itemCount = state.items.size,
+                enableScrollToTop = enableScrollToTop,
+                enableScrollToBottom = enableScrollToBottom,
+                onMultiMigrateClicked = onMultiMigrateClicked,
+                onSelectAll = { onSelectAll(true) },
+                onInvertSelection = onInvertSelection,
+                onCancelActionMode = { onSelectAll(false) },
+                navigateUp = navigateUp,
+                scrollToTop = {
+                    scope.launch {
+                        listState.scrollToItem(0)
                     }
-                    Row(
-                        modifier = Modifier
-                            .padding(
-                                WindowInsets.navigationBars
-                                    .only(WindowInsetsSides.Bottom)
-                                    .asPaddingValues(),
-                            )
-                            .padding(horizontal = 8.dp, vertical = 12.dp),
-                    ) {
-                        Button(
-                            title = stringResource(MR.strings.migrate),
-                            icon = Icons.Outlined.FindReplace,
-                            toConfirm = confirm[0],
-                            onLongClick = { onLongClickItem(0) },
-                            onClick = onMultiMigrateClicked,
-                        )
+                },
+                scrollToBottom = {
+                    scope.launch {
+                        listState.scrollToItem(state.items.size - 1)
                     }
-                }
-            }
+                },
+            )
         },
     ) { paddingValues ->
         when {
@@ -148,6 +147,7 @@ fun LibraryUpdateErrorScreen(
             else -> {
                 FastScrollLazyColumn(
                     contentPadding = paddingValues,
+                    state = listState,
                 ) {
                     libraryUpdateErrorUiItems(
                         uiModels = state.getUiModel(),
@@ -163,15 +163,156 @@ fun LibraryUpdateErrorScreen(
 }
 
 @Composable
+private fun LibraryUpdateErrorsBottomBar(
+    modifier: Modifier = Modifier,
+    selected: List<LibraryUpdateErrorItem>,
+    itemCount: Int,
+    enableScrollToTop: Boolean,
+    enableScrollToBottom: Boolean,
+    onMultiMigrateClicked: (() -> Unit),
+    onSelectAll: () -> Unit,
+    onInvertSelection: () -> Unit,
+    onCancelActionMode: () -> Unit,
+    navigateUp: () -> Unit,
+    scrollToTop: () -> Unit,
+    scrollToBottom: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val animatedElevation by animateDpAsState(if (selected.isNotEmpty()) 3.dp else 0.dp)
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large.copy(
+            bottomEnd = ZeroCornerSize,
+            bottomStart = ZeroCornerSize,
+        ),
+        color = MaterialTheme.colorScheme.surfaceColorAtElevation(
+            elevation = animatedElevation,
+        ),
+    ) {
+        val haptic = LocalHapticFeedback.current
+        val confirm = remember { mutableStateListOf(false, false, false, false, false, false) }
+        var resetJob: Job? = remember { null }
+        val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
+            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+            (0 until 6).forEach { i -> confirm[i] = i == toConfirmIndex }
+            resetJob?.cancel()
+            resetJob = scope.launch {
+                delay(1.seconds)
+                if (isActive) confirm[toConfirmIndex] = false
+            }
+        }
+        Row(
+            modifier = Modifier
+                .padding(
+                    WindowInsets.navigationBars
+                        .only(WindowInsetsSides.Bottom)
+                        .asPaddingValues(),
+                )
+                .padding(horizontal = 8.dp, vertical = 12.dp),
+        ) {
+            if (selected.isNotEmpty()) {
+                Button(
+                    title = stringResource(MR.strings.action_cancel),
+                    icon = Icons.Outlined.Close,
+                    toConfirm = confirm[0],
+                    onLongClick = { onLongClickItem(0) },
+                    onClick = onCancelActionMode,
+                    enabled = true,
+                )
+            } else {
+                Button(
+                    title = androidx.compose.ui.res.stringResource(R.string.abc_action_bar_up_description),
+                    icon = Icons.AutoMirrored.Outlined.ArrowBack,
+                    toConfirm = confirm[0],
+                    onLongClick = { onLongClickItem(0) },
+                    onClick = navigateUp,
+                    enabled = true,
+                )
+            }
+            Button(
+                title = stringResource(MR.strings.action_select_all),
+                icon = Icons.Outlined.SelectAll,
+                toConfirm = confirm[1],
+                onLongClick = { onLongClickItem(1) },
+                onClick = if (selected.isEmpty() or (selected.size != itemCount)) {
+                    onSelectAll
+                } else {
+                    {}
+                },
+                enabled = selected.isEmpty() or (selected.size != itemCount),
+            )
+            Button(
+                title = stringResource(MR.strings.action_select_inverse),
+                icon = Icons.Outlined.FlipToBack,
+                toConfirm = confirm[2],
+                onLongClick = { onLongClickItem(2) },
+                onClick = if (selected.isNotEmpty()) {
+                    onInvertSelection
+                } else {
+                    {}
+                },
+                enabled = selected.isNotEmpty(),
+            )
+            Button(
+                title = stringResource(KMR.strings.action_scroll_to_top),
+                icon = Icons.Outlined.ArrowUpward,
+                toConfirm = confirm[3],
+                onLongClick = { onLongClickItem(3) },
+                onClick = if (enableScrollToTop) {
+                    scrollToTop
+                } else {
+                    {}
+                },
+                enabled = enableScrollToTop,
+            )
+            Button(
+                title = stringResource(KMR.strings.action_scroll_to_bottom),
+                icon = Icons.Outlined.ArrowDownward,
+                toConfirm = confirm[4],
+                onLongClick = { onLongClickItem(4) },
+                onClick = if (enableScrollToBottom) {
+                    scrollToBottom
+                } else {
+                    {}
+                },
+                enabled = enableScrollToBottom,
+            )
+            Button(
+                title = stringResource(MR.strings.migrate),
+                icon = Icons.Outlined.FindReplace,
+                toConfirm = confirm[5],
+                onLongClick = { onLongClickItem(5) },
+                onClick = if (selected.isNotEmpty()) {
+                    onMultiMigrateClicked
+                } else {
+                    {}
+                },
+                enabled = selected.isNotEmpty(),
+            )
+        }
+    }
+}
+
+@Composable
 private fun RowScope.Button(
     title: String,
     icon: ImageVector,
     toConfirm: Boolean,
+    enabled: Boolean,
     onLongClick: () -> Unit,
     onClick: (() -> Unit),
     content: (@Composable () -> Unit)? = null,
 ) {
     val animatedWeight by animateFloatAsState(if (toConfirm) 2f else 1f)
+    val animatedColor by animateColorAsState(
+        if (enabled) {
+            MaterialTheme.colorScheme.onSurface
+        } else {
+            MaterialTheme.colorScheme.onSurface.copy(
+                alpha = 0.38f,
+            )
+        },
+    )
     Column(
         modifier = Modifier
             .size(48.dp)
@@ -188,6 +329,7 @@ private fun RowScope.Button(
         Icon(
             imageVector = icon,
             contentDescription = title,
+            tint = animatedColor,
         )
         AnimatedVisibility(
             visible = toConfirm,
@@ -199,6 +341,7 @@ private fun RowScope.Button(
                 overflow = TextOverflow.Visible,
                 maxLines = 1,
                 style = MaterialTheme.typography.labelSmall,
+                color = animatedColor,
             )
         }
         content?.invoke()
@@ -210,32 +353,30 @@ private fun LibraryUpdateErrorsAppBar(
     modifier: Modifier = Modifier,
     title: String,
     actionModeCounter: Int,
-    onSelectAll: () -> Unit,
-    onInvertSelection: () -> Unit,
-    onCancelActionMode: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
-    navigateUp: () -> Unit,
 ) {
-    AppBar(
+    val isActionMode by remember(actionModeCounter) {
+        derivedStateOf { actionModeCounter > 0 }
+    }
+
+    Column(
         modifier = modifier,
-        title = title,
-        scrollBehavior = scrollBehavior,
-        actionModeCounter = actionModeCounter,
-        onCancelActionMode = onCancelActionMode,
-        actionModeActions = {
-            IconButton(onClick = onSelectAll) {
-                Icon(
-                    imageVector = Icons.Outlined.SelectAll,
-                    contentDescription = stringResource(MR.strings.action_select_all),
-                )
-            }
-            IconButton(onClick = onInvertSelection) {
-                Icon(
-                    imageVector = Icons.Outlined.FlipToBack,
-                    contentDescription = stringResource(MR.strings.action_select_inverse),
-                )
-            }
-        },
-        navigateUp = navigateUp,
-    )
+    ) {
+        TopAppBar(
+            title = {
+                if (isActionMode) {
+                    AppBarTitle("$actionModeCounter selected")
+                } else {
+                    AppBarTitle(title)
+                }
+            },
+            actions = {},
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(
+                    elevation = if (isActionMode) 3.dp else 0.dp,
+                ),
+            ),
+            scrollBehavior = scrollBehavior,
+        )
+    }
 }

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -131,17 +131,18 @@ fun LibraryUpdateErrorScreen(
                 },
             )
         },
-    ) { paddingValues ->
+    ) { contentPadding ->
         when {
-            state.isLoading -> LoadingScreen(modifier = Modifier.padding(paddingValues))
+            state.isLoading -> LoadingScreen(modifier = Modifier.padding(contentPadding))
             state.items.isEmpty() -> EmptyScreen(
                 message = stringResource(KMR.strings.info_empty_library_update_errors),
-                modifier = Modifier.padding(paddingValues),
+                modifier = Modifier.padding(contentPadding),
             )
 
             else -> {
                 FastScrollLazyColumn(
-                    contentPadding = paddingValues,
+                    // Using modifier instead of contentPadding so we can use stickyHeader
+                    modifier = Modifier.padding(contentPadding),
                     state = listState,
                 ) {
                     libraryUpdateErrorUiItems(

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -3,7 +3,6 @@ package eu.kanade.presentation.libraryUpdateError.components
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
@@ -18,11 +17,13 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.manga.components.MangaCover
+import eu.kanade.presentation.util.animateItemFastScroll
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.presentation.core.components.ListGroupHeader
 import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.util.secondaryItemAlpha
 import tachiyomi.presentation.core.util.selectedBackground
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -52,7 +53,7 @@ internal fun LazyListScope.libraryUpdateErrorUiItems(
         when (item) {
             is LibraryUpdateErrorUiModel.Header -> {
                 ListGroupHeader(
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier.animateItemFastScroll(),
                     text = item.errorMessage,
                 )
             }
@@ -60,7 +61,7 @@ internal fun LazyListScope.libraryUpdateErrorUiItems(
             is LibraryUpdateErrorUiModel.Item -> {
                 val libraryUpdateErrorItem = item.item
                 LibraryUpdateErrorUiItem(
-                    modifier = Modifier.animateItemPlacement(),
+                    modifier = Modifier.animateItemFastScroll(),
                     error = libraryUpdateErrorItem.error,
                     selected = libraryUpdateErrorItem.selected,
                     onClick = {
@@ -111,37 +112,36 @@ private fun LibraryUpdateErrorUiItem(
                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 },
             )
-            .height(56.dp)
             .padding(horizontal = MaterialTheme.padding.medium),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.Top,
     ) {
         MangaCover.Square(
             modifier = Modifier
                 .padding(vertical = 6.dp)
-                .fillMaxHeight(),
+                .height(48.dp),
             data = error.mangaCover,
             onClick = onClickCover,
         )
 
         Column(
             modifier = Modifier
-                .padding(horizontal = MaterialTheme.padding.medium)
+                .padding(horizontal = MaterialTheme.padding.medium, vertical = 5.dp)
                 .weight(1f),
         ) {
             Text(
                 text = error.mangaTitle,
                 style = MaterialTheme.typography.bodyMedium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                overflow = TextOverflow.Visible,
             )
 
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            Row(modifier = Modifier.padding(vertical = 4.dp), verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = Injekt.get<SourceManager>().getOrStub(error.mangaSource).name,
                     style = MaterialTheme.typography.bodySmall,
-                    overflow = TextOverflow.Ellipsis,
+                    overflow = TextOverflow.Visible,
                     maxLines = 1,
                     modifier = Modifier
+                        .secondaryItemAlpha()
                         .weight(weight = 1f, fill = false),
                 )
             }

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,6 +21,7 @@ import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.presentation.core.components.ListGroupHeader
+import tachiyomi.presentation.core.components.Scroller.STICKY_HEADER_KEY_PREFIX
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.util.secondaryItemAlpha
 import tachiyomi.presentation.core.util.selectedBackground
@@ -35,57 +35,52 @@ internal fun LazyListScope.libraryUpdateErrorUiItems(
     onClick: (LibraryUpdateErrorItem) -> Unit,
     onClickCover: (LibraryUpdateErrorItem) -> Unit,
 ) {
-    items(
-        items = uiModels,
-        contentType = {
-            when (it) {
-                is LibraryUpdateErrorUiModel.Header -> "header"
-                is LibraryUpdateErrorUiModel.Item -> "item"
-            }
-        },
-        key = {
-            when (it) {
-                is LibraryUpdateErrorUiModel.Header -> "sticky:errorHeader-${it.hashCode()}"
-                is LibraryUpdateErrorUiModel.Item -> "error-${it.item.error.errorId}-${it.item.error.mangaId}"
-            }
-        },
-    ) { item ->
-        when (item) {
+    uiModels.forEach {
+        when (it) {
             is LibraryUpdateErrorUiModel.Header -> {
-                ListGroupHeader(
-                    modifier = Modifier.animateItemFastScroll(),
-                    text = item.errorMessage,
-                )
+                stickyHeader(
+                    key = "$STICKY_HEADER_KEY_PREFIX-errorHeader-${it.hashCode()}",
+                    contentType = "header",
+                ) {
+                    ListGroupHeader(
+                        modifier = Modifier.animateItemFastScroll(),
+                        text = it.errorMessage,
+                    )
+                }
             }
-
             is LibraryUpdateErrorUiModel.Item -> {
-                val libraryUpdateErrorItem = item.item
-                LibraryUpdateErrorUiItem(
-                    modifier = Modifier.animateItemFastScroll(),
-                    error = libraryUpdateErrorItem.error,
-                    selected = libraryUpdateErrorItem.selected,
-                    onClick = {
-                        when {
-                            selectionMode -> onErrorSelected(
+                item(
+                    key = "error-${it.item.error.errorId}-${it.item.error.mangaId}",
+                    contentType = "item",
+                ) {
+                    val libraryUpdateErrorItem = it.item
+                    LibraryUpdateErrorUiItem(
+                        modifier = Modifier.animateItemFastScroll(),
+                        error = libraryUpdateErrorItem.error,
+                        selected = libraryUpdateErrorItem.selected,
+                        onClick = {
+                            when {
+                                selectionMode -> onErrorSelected(
+                                    libraryUpdateErrorItem,
+                                    !libraryUpdateErrorItem.selected,
+                                    true,
+                                    false,
+                                )
+
+                                else -> onClick(libraryUpdateErrorItem)
+                            }
+                        },
+                        onLongClick = {
+                            onErrorSelected(
                                 libraryUpdateErrorItem,
                                 !libraryUpdateErrorItem.selected,
                                 true,
-                                false,
+                                true,
                             )
-
-                            else -> onClick(libraryUpdateErrorItem)
-                        }
-                    },
-                    onLongClick = {
-                        onErrorSelected(
-                            libraryUpdateErrorItem,
-                            !libraryUpdateErrorItem.selected,
-                            true,
-                            true,
-                        )
-                    },
-                    onClickCover = { onClickCover(libraryUpdateErrorItem) }.takeIf { !selectionMode },
-                )
+                        },
+                        onClickCover = { onClickCover(libraryUpdateErrorItem) }.takeIf { !selectionMode },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/more/MoreScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/MoreScreen.kt
@@ -54,13 +54,15 @@ fun MoreScreen(
     onClickDownloadQueue: () -> Unit,
     onClickCategories: () -> Unit,
     onClickStats: () -> Unit,
-    onClickLibraryUpdateErrors: () -> Unit,
     onClickDataAndStorage: () -> Unit,
     onClickSettings: () -> Unit,
     onClickAbout: () -> Unit,
     onClickBatchAdd: () -> Unit,
     onClickUpdates: () -> Unit,
     onClickHistory: () -> Unit,
+    // KMK -->
+    onClickLibraryUpdateErrors: () -> Unit,
+    // KMK <--
 ) {
     val uriHandler = LocalUriHandler.current
 
@@ -176,6 +178,15 @@ fun MoreScreen(
                     onPreferenceClick = onClickStats,
                 )
             }
+            // KMK -->
+            item {
+                TextPreferenceWidget(
+                    title = stringResource(KMR.strings.option_label_library_update_errors),
+                    icon = Icons.Outlined.NewReleases,
+                    onPreferenceClick = onClickLibraryUpdateErrors,
+                )
+            }
+            // KMK <--
             item {
                 TextPreferenceWidget(
                     title = stringResource(KMR.strings.option_label_library_update_errors),

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -30,6 +30,7 @@ import com.elvishew.xlog.printer.file.backup.NeverBackupStrategy
 import com.elvishew.xlog.printer.file.naming.DateFileNameGenerator
 import dev.mihon.injekt.patchInjekt
 import eu.kanade.domain.DomainModule
+import eu.kanade.domain.KMKDomainModule
 import eu.kanade.domain.SYDomainModule
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.sync.SyncPreferences
@@ -125,6 +126,9 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         Injekt.importModule(SYPreferenceModule(this))
         Injekt.importModule(SYDomainModule())
         // SY <--
+        // KMK -->
+        Injekt.importModule(KMKDomainModule())
+        // KMK <--
 
         setupExhLogging() // EXH logging
         LogcatLogger.install(XLogLogcatLogger()) // SY Redirect Logcat to XLog

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -35,7 +35,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import eu.kanade.tachiyomi.source.online.all.MergedSource
 import eu.kanade.tachiyomi.util.prepUpdateCover
-import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import eu.kanade.tachiyomi.util.system.isConnectedToWifi
 import eu.kanade.tachiyomi.util.system.isRunning
 import eu.kanade.tachiyomi.util.system.setForegroundSafely
@@ -99,7 +98,6 @@ import tachiyomi.domain.track.interactor.InsertTrack
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.io.File
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.util.concurrent.CopyOnWriteArrayList
@@ -137,10 +135,10 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
     private val notifier = LibraryUpdateNotifier(context)
 
     // KMK -->
+    private val libraryUpdateStatus: LibraryUpdateStatus = Injekt.get()
     private val deleteLibraryUpdateErrors: DeleteLibraryUpdateErrors = Injekt.get()
     private val insertLibraryUpdateErrors: InsertLibraryUpdateErrors = Injekt.get()
     private val insertLibraryUpdateErrorMessages: InsertLibraryUpdateErrorMessages = Injekt.get()
-    private val libraryUpdateStatus: LibraryUpdateStatus = Injekt.get()
     // KMK <--
 
     private var mangaToUpdate: List<LibraryManga> = mutableListOf()
@@ -495,14 +493,8 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         }
 
         if (failedUpdates.isNotEmpty()) {
-            // KMK -->
-            // val errorFile = writeErrorFile(failedUpdates)
-            // KMK <--
             notifier.showUpdateErrorNotification(
                 failedUpdates.size,
-                // KMK -->
-                // errorFile.getUriCompat(context),
-                // KMK <--
             )
         }
     }
@@ -719,36 +711,6 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         )
     }
 
-    /**
-     * Writes basic file of update errors to cache dir.
-     */
-    private fun writeErrorFile(errors: List<Pair<Manga, String?>>): File {
-        try {
-            if (errors.isNotEmpty()) {
-                val file = context.createFileInCacheDir("komikku_update_errors.txt")
-                file.bufferedWriter().use { out ->
-                    out.write(context.stringResource(MR.strings.library_errors_help, ERROR_LOG_HELP_URL) + "\n\n")
-                    // Error file format:
-                    // ! Error
-                    //   # Source
-                    //     - Manga
-                    errors.groupBy({ it.second }, { it.first }).forEach { (error, mangas) ->
-                        out.write("\n! ${error}\n")
-                        mangas.groupBy { it.source }.forEach { (srcId, mangas) ->
-                            val source = sourceManager.getOrStub(srcId)
-                            out.write("  # $source\n")
-                            mangas.forEach {
-                                out.write("    - ${it.title}\n")
-                            }
-                        }
-                    }
-                }
-                return file
-            }
-        } catch (_: Exception) {}
-        return File("")
-    }
-
     // KMK -->
     private suspend fun clearErrorFromDB(mangaId: Long) {
         deleteLibraryUpdateErrors.deleteMangaError(mangaId = mangaId)
@@ -766,7 +728,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         )
     }
 
-    private suspend fun writeErrorToDB(errors: List<Pair<Manga, String?>>) {
+    private suspend fun writeErrorsToDB(errors: List<Pair<Manga, String?>>) {
         val libraryErrors = errors.groupBy({ it.second }, { it.first })
         val errorMessages = insertLibraryUpdateErrorMessages.insertAll(
             libraryUpdateErrorMessages = libraryErrors.keys.map { errorMessage ->

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -35,7 +35,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import eu.kanade.tachiyomi.source.online.all.MergedSource
 import eu.kanade.tachiyomi.util.prepUpdateCover
-import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import eu.kanade.tachiyomi.util.system.isConnectedToWifi
 import eu.kanade.tachiyomi.util.system.isRunning
@@ -496,11 +495,13 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         if (failedUpdates.isNotEmpty()) {
             // KMK -->
             writeErrorsToDB(failedUpdates)
+            // val errorFile = writeErrorFile(failedUpdates)
             // KMK <--
-            val errorFile = writeErrorFile(failedUpdates)
             notifier.showUpdateErrorNotification(
                 failedUpdates.size,
-                errorFile.getUriCompat(context),
+                // KMK -->
+                // errorFile.getUriCompat(context),
+                // KMK <--
             )
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -120,10 +120,6 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
     private val getManga: GetManga = Injekt.get()
     private val updateManga: UpdateManga = Injekt.get()
     private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get()
-    private val deleteLibraryUpdateErrorMessages: DeleteLibraryUpdateErrorMessages = Injekt.get()
-    private val deleteLibraryUpdateErrors: DeleteLibraryUpdateErrors = Injekt.get()
-    private val insertLibraryUpdateErrors: InsertLibraryUpdateErrors = Injekt.get()
-    private val insertLibraryUpdateErrorMessages: InsertLibraryUpdateErrorMessages = Injekt.get()
     private val fetchInterval: FetchInterval = Injekt.get()
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get()
 
@@ -143,6 +139,10 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
     private val notifier = LibraryUpdateNotifier(context)
 
     // KMK -->
+    private val deleteLibraryUpdateErrorMessages: DeleteLibraryUpdateErrorMessages = Injekt.get()
+    private val deleteLibraryUpdateErrors: DeleteLibraryUpdateErrors = Injekt.get()
+    private val insertLibraryUpdateErrors: InsertLibraryUpdateErrors = Injekt.get()
+    private val insertLibraryUpdateErrorMessages: InsertLibraryUpdateErrorMessages = Injekt.get()
     private val libraryUpdateStatus: LibraryUpdateStatus = Injekt.get()
     // KMK <--
 
@@ -494,7 +494,9 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         }
 
         if (failedUpdates.isNotEmpty()) {
+            // KMK -->
             writeErrorsToDB(failedUpdates)
+            // KMK <--
             val errorFile = writeErrorFile(failedUpdates)
             notifier.showUpdateErrorNotification(
                 failedUpdates.size,
@@ -745,6 +747,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         return File("")
     }
 
+    // KMK -->
     private suspend fun writeErrorsToDB(errors: List<Pair<Manga, String?>>) {
         deleteLibraryUpdateErrorMessages.await()
         deleteLibraryUpdateErrors.await()
@@ -762,6 +765,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         }
         insertLibraryUpdateErrors.insertAll(errorList)
     }
+    // KMK <--
 
     /**
      * Defines what should be updated within a service execution.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -161,6 +161,8 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
 
         // KMK -->
         libraryUpdateStatus.start()
+
+        deleteLibraryUpdateErrors.cleanUnrelevantMangaErrors()
         // KMK <--
 
         setForegroundSafely()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -152,12 +152,7 @@ class LibraryUpdateNotifier(
      *
      * @param failed Number of entries that failed to update.
      */
-    fun showUpdateErrorNotification(
-        failed: Int,
-        // KMK -->
-        // uri: Uri,
-        // KMK <--
-    ) {
+    fun showUpdateErrorNotification(failed: Int) {
         if (failed == 0) {
             return
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import coil3.asDrawable
@@ -152,9 +151,13 @@ class LibraryUpdateNotifier(
      * Shows notification containing update entries that failed with action to open full log.
      *
      * @param failed Number of entries that failed to update.
-     * @param uri Uri for error log file containing all titles that failed.
      */
-    fun showUpdateErrorNotification(failed: Int, uri: Uri) {
+    fun showUpdateErrorNotification(
+        failed: Int,
+        // KMK -->
+        // uri: Uri,
+        // KMK <--
+    ) {
         if (failed == 0) {
             return
         }
@@ -167,7 +170,7 @@ class LibraryUpdateNotifier(
             setContentText(context.stringResource(MR.strings.action_show_errors))
             setSmallIcon(R.drawable.ic_komikku)
 
-            setContentIntent(NotificationReceiver.openErrorLogPendingActivity(context, uri))
+            setContentIntent(NotificationReceiver.openErrorLogPendingActivity(context))
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -634,6 +634,22 @@ class NotificationReceiver : BroadcastReceiver() {
             return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
         }
 
+        // KMK -->
+        /**
+         * Returns [PendingIntent] that opens the error log file in an external viewer
+         *
+         * @param context context of application
+         * @return [PendingIntent]
+         */
+        internal fun openErrorLogPendingActivity(context: Context): PendingIntent {
+            val intent = Intent(context, MainActivity::class.java).apply {
+                action = Constants.SHORTCUT_LIBRARY_UPDATE_ERRORS
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+        // KMK <--
+
         /**
          * Returns [PendingIntent] that cancels a backup restore job.
          *

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -646,7 +646,12 @@ class NotificationReceiver : BroadcastReceiver() {
                 action = Constants.SHORTCUT_LIBRARY_UPDATE_ERRORS
                 flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
-            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+            return PendingIntent.getActivity(
+                context,
+                0,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
         }
         // KMK <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -45,6 +45,7 @@ import eu.kanade.tachiyomi.ui.browse.BrowseTab
 import eu.kanade.tachiyomi.ui.download.DownloadQueueScreen
 import eu.kanade.tachiyomi.ui.history.HistoryTab
 import eu.kanade.tachiyomi.ui.library.LibraryTab
+import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.more.MoreTab
 import eu.kanade.tachiyomi.ui.updates.UpdatesTab
@@ -188,8 +189,14 @@ object HomeScreen : Screen() {
                         if (it is Tab.Library && it.mangaIdToOpen != null) {
                             navigator.push(MangaScreen(it.mangaIdToOpen))
                         }
-                        if (it is Tab.More && it.toDownloads) {
-                            navigator.push(DownloadQueueScreen)
+                        if (it is Tab.More) {
+                            if (it.toDownloads) {
+                                navigator.push(DownloadQueueScreen)
+                                // KMK -->
+                            } else if (it.toLibraryUpdateErrors) {
+                                navigator.push(LibraryUpdateErrorScreen())
+                                // KMK <--
+                            }
                         }
                     }
                 }
@@ -339,6 +346,11 @@ object HomeScreen : Screen() {
         data object Updates : Tab
         data object History : Tab
         data class Browse(val toExtensions: Boolean = false) : Tab
-        data class More(val toDownloads: Boolean) : Tab
+        data class More(
+            val toDownloads: Boolean,
+            // KMK -->
+            val toLibraryUpdateErrors: Boolean = false,
+            // KMK <--
+        ) : Tab
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -159,6 +159,11 @@ data class LibraryUpdateErrorScreenState(
         }
         return uiModels
     }
+
+    fun getHeaderIndexes(): List<Int> = getUiModel()
+        .withIndex()
+        .filter { it.value is LibraryUpdateErrorUiModel.Header }
+        .map { it.index }
 }
 
 @Immutable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -544,6 +544,12 @@ class MainActivity : BaseActivity() {
                 navigator.popUntilRoot()
                 HomeScreen.Tab.More(toDownloads = true)
             }
+            // KMK -->
+            Constants.SHORTCUT_LIBRARY_UPDATE_ERRORS -> {
+                navigator.popUntilRoot()
+                HomeScreen.Tab.More(toDownloads = false, toLibraryUpdateErrors = true)
+            }
+            // KMK <--
             Intent.ACTION_SEARCH, Intent.ACTION_SEND, "com.google.android.gms.actions.SEARCH_ACTION" -> {
                 // If the intent match the "standard" Android search intent
                 // or the Google-specific search intent (triggered by saying or typing "search *query* on *Tachiyomi*" in Google Search/Google Assistant)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/MoreTab.kt
@@ -82,7 +82,6 @@ object MoreTab : Tab {
             onClickDownloadQueue = { navigator.push(DownloadQueueScreen) },
             onClickCategories = { navigator.push(CategoryScreen()) },
             onClickStats = { navigator.push(StatsScreen()) },
-            onClickLibraryUpdateErrors = { navigator.push(LibraryUpdateErrorScreen()) },
             onClickDataAndStorage = { navigator.push(SettingsScreen(SettingsScreen.Destination.DataAndStorage)) },
             onClickSettings = { navigator.push(SettingsScreen()) },
             onClickAbout = { navigator.push(SettingsScreen(SettingsScreen.Destination.About)) },
@@ -91,6 +90,9 @@ object MoreTab : Tab {
             onClickUpdates = { navigator.push(UpdatesTab) },
             onClickHistory = { navigator.push(HistoryTab) },
             // SY <--
+            // KMK -->
+            onClickLibraryUpdateErrors = { navigator.push(LibraryUpdateErrorScreen()) },
+            // KMK <--
         )
     }
 }

--- a/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
@@ -16,4 +16,8 @@ object Constants {
     const val SHORTCUT_SOURCES = "eu.kanade.tachiyomi.SHOW_CATALOGUES"
     const val SHORTCUT_EXTENSIONS = "eu.kanade.tachiyomi.EXTENSIONS"
     const val SHORTCUT_DOWNLOADS = "eu.kanade.tachiyomi.SHOW_DOWNLOADS"
+
+    // KMK -->
+    const val SHORTCUT_LIBRARY_UPDATE_ERRORS = "eu.kanade.tachiyomi.SHOW_LIBRARY_UPDATE_ERRORS"
+    // KMK <--
 }

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
@@ -45,6 +45,12 @@ class LibraryUpdateErrorRepositoryImpl(
         }
     }
 
+    override suspend fun cleanUnrelevantMangaErrors() {
+        return handler.await {
+            libraryUpdateErrorQueries.cleanUnrelevantMangaErrors()
+        }
+    }
+
     override suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorQueries.upsert(

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
@@ -37,6 +37,14 @@ class LibraryUpdateErrorRepositoryImpl(
         }
     }
 
+    override suspend fun deleteMangaError(mangaId: Long) {
+        return handler.await {
+            libraryUpdateErrorQueries.deleteMangaError(
+                mangaId = mangaId,
+            )
+        }
+    }
+
     override suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorQueries.upsert(

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
@@ -37,6 +37,15 @@ class LibraryUpdateErrorRepositoryImpl(
         }
     }
 
+    override suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
+        return handler.await(inTransaction = true) {
+            libraryUpdateErrorQueries.upsert(
+                mangaId = libraryUpdateError.mangaId,
+                messageId = libraryUpdateError.messageId,
+            )
+        }
+    }
+
     override suspend fun insert(libraryUpdateError: LibraryUpdateError) {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorQueries.insert(

--- a/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
@@ -29,8 +29,14 @@ class LibraryUpdateErrorMessageRepositoryImpl(
         return handler.await { libraryUpdateErrorMessageQueries.deleteAllErrorMessages() }
     }
 
-    override suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long? {
-        return handler.awaitOneOrNullExecutable(inTransaction = true) {
+    override suspend fun get(message: String): Long? {
+        return handler.awaitOneOrNullExecutable {
+            libraryUpdateErrorMessageQueries.getErrorMessages(message) { id, _ -> id }
+        }
+    }
+
+    override suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long {
+        return handler.awaitOneExecutable(inTransaction = true) {
             libraryUpdateErrorMessageQueries.insert(libraryUpdateErrorMessage.message)
             libraryUpdateErrorMessageQueries.selectLastInsertedRowId()
         }

--- a/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
@@ -42,7 +42,9 @@ class LibraryUpdateErrorMessageRepositoryImpl(
         }
     }
 
-    override suspend fun insertAll(libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>): List<Pair<Long, String>> {
+    override suspend fun insertAll(
+        libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>,
+    ): List<Pair<Long, String>> {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorMessages.map {
                 libraryUpdateErrorMessageQueries.insert(it.message)

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
@@ -1,6 +1,6 @@
 CREATE TABLE libraryUpdateError (
     _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    manga_id INTEGER NOT NULL,
+    manga_id INTEGER NOT NULL UNIQUE,
     message_id INTEGER NOT NULL
 );
 
@@ -10,6 +10,15 @@ FROM libraryUpdateError;
 
 insert:
 INSERT INTO libraryUpdateError(manga_id, message_id) VALUES (:mangaId, :messageId);
+
+upsert:
+INSERT INTO libraryUpdateError(manga_id, message_id)
+VALUES (:mangaId, :messageId)
+ON CONFLICT(manga_id)
+DO UPDATE
+SET
+    message_id = :messageId
+WHERE manga_id = :mangaId;
 
 deleteAllErrors:
 DELETE FROM libraryUpdateError;

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
@@ -30,3 +30,12 @@ WHERE _id = :_id;
 deleteMangaError:
 DELETE FROM libraryUpdateError
 WHERE manga_id = :mangaId;
+
+cleanUnrelevantMangaErrors:
+DELETE FROM libraryUpdateError
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM mangas
+    WHERE libraryUpdateError.manga_id = mangas._id
+    AND mangas.favorite == 1
+);

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
@@ -26,3 +26,7 @@ DELETE FROM libraryUpdateError;
 deleteError:
 DELETE FROM libraryUpdateError
 WHERE _id = :_id;
+
+deleteMangaError:
+DELETE FROM libraryUpdateError
+WHERE manga_id = :mangaId;

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
@@ -7,6 +7,10 @@ getAllErrorMessages:
 SELECT *
 FROM libraryUpdateErrorMessage;
 
+getErrorMessages:
+SELECT *
+FROM libraryUpdateErrorMessage WHERE message == :message;
+
 insert:
 INSERT INTO libraryUpdateErrorMessage(message) VALUES (:message);
 

--- a/data/src/main/sqldelight/tachiyomi/migrations/35.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/35.sqm
@@ -2,7 +2,7 @@ DROP VIEW IF EXISTS libraryUpdateErrorView;
 
 CREATE TABLE IF NOT EXISTS libraryUpdateError (
     _id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-    manga_id INTEGER NOT NULL,
+    manga_id INTEGER NOT NULL UNIQUE,
     message_id INTEGER NOT NULL
 );
 

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
@@ -39,6 +39,16 @@ class DeleteLibraryUpdateErrors(
         }
     }
 
+    suspend fun cleanUnrelevantMangaErrors() = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.cleanUnrelevantMangaErrors()
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+    }
+
     sealed class Result {
         object Success : Result()
         data class InternalError(val error: Throwable) : Result()

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
@@ -50,7 +50,7 @@ class DeleteLibraryUpdateErrors(
     }
 
     sealed class Result {
-        object Success : Result()
+        data object Success : Result()
         data class InternalError(val error: Throwable) : Result()
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
@@ -29,6 +29,16 @@ class DeleteLibraryUpdateErrors(
         }
     }
 
+    suspend fun deleteMangaError(mangaId: Long) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.deleteMangaError(mangaId)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+    }
+
     sealed class Result {
         object Success : Result()
         data class InternalError(val error: Throwable) : Result()

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
@@ -6,6 +6,10 @@ import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorReposito
 class InsertLibraryUpdateErrors(
     private val libraryUpdateErrorRepository: LibraryUpdateErrorRepository,
 ) {
+    suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
+        return libraryUpdateErrorRepository.upsert(libraryUpdateError)
+    }
+
     suspend fun insert(libraryUpdateError: LibraryUpdateError) {
         return libraryUpdateErrorRepository.insert(libraryUpdateError)
     }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/InsertLibraryUpdateErrors.kt
@@ -1,20 +1,42 @@
 package tachiyomi.domain.libraryUpdateError.interactor
 
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors.Result
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateError
 import tachiyomi.domain.libraryUpdateError.repository.LibraryUpdateErrorRepository
 
 class InsertLibraryUpdateErrors(
     private val libraryUpdateErrorRepository: LibraryUpdateErrorRepository,
 ) {
-    suspend fun upsert(libraryUpdateError: LibraryUpdateError) {
-        return libraryUpdateErrorRepository.upsert(libraryUpdateError)
+    suspend fun upsert(libraryUpdateError: LibraryUpdateError) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.upsert(libraryUpdateError)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
     }
 
-    suspend fun insert(libraryUpdateError: LibraryUpdateError) {
-        return libraryUpdateErrorRepository.insert(libraryUpdateError)
+    suspend fun insert(libraryUpdateError: LibraryUpdateError) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.insert(libraryUpdateError)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
     }
 
-    suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>) {
-        return libraryUpdateErrorRepository.insertAll(libraryUpdateErrors)
+    suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>) = withNonCancellableContext {
+        try {
+            libraryUpdateErrorRepository.insertAll(libraryUpdateErrors)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
@@ -15,6 +15,8 @@ interface LibraryUpdateErrorRepository {
 
     suspend fun deleteMangaError(mangaId: Long)
 
+    suspend fun cleanUnrelevantMangaErrors()
+
     suspend fun upsert(libraryUpdateError: LibraryUpdateError)
 
     suspend fun insert(libraryUpdateError: LibraryUpdateError)

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
@@ -13,6 +13,8 @@ interface LibraryUpdateErrorRepository {
 
     suspend fun delete(errorId: Long)
 
+    suspend fun deleteMangaError(mangaId: Long)
+
     suspend fun upsert(libraryUpdateError: LibraryUpdateError)
 
     suspend fun insert(libraryUpdateError: LibraryUpdateError)

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
@@ -13,6 +13,8 @@ interface LibraryUpdateErrorRepository {
 
     suspend fun delete(errorId: Long)
 
+    suspend fun upsert(libraryUpdateError: LibraryUpdateError)
+
     suspend fun insert(libraryUpdateError: LibraryUpdateError)
 
     suspend fun insertAll(libraryUpdateErrors: List<LibraryUpdateError>)

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/DeleteLibraryUpdateErrorMessages.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/DeleteLibraryUpdateErrorMessages.kt
@@ -21,7 +21,7 @@ class DeleteLibraryUpdateErrorMessages(
     }
 
     sealed class Result {
-        object Success : Result()
+        data object Success : Result()
         data class InternalError(val error: Throwable) : Result()
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/InsertLibraryUpdateErrorMessages.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/interactor/InsertLibraryUpdateErrorMessages.kt
@@ -6,8 +6,11 @@ import tachiyomi.domain.libraryUpdateErrorMessage.repository.LibraryUpdateErrorM
 class InsertLibraryUpdateErrorMessages(
     private val libraryUpdateErrorMessageRepository: LibraryUpdateErrorMessageRepository,
 ) {
+    suspend fun get(message: String): Long? {
+        return libraryUpdateErrorMessageRepository.get(message)
+    }
 
-    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long? {
+    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long {
         return libraryUpdateErrorMessageRepository.insert(libraryUpdateErrorMessage)
     }
 

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/repository/LibraryUpdateErrorMessageRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateErrorMessage/repository/LibraryUpdateErrorMessageRepository.kt
@@ -11,7 +11,9 @@ interface LibraryUpdateErrorMessageRepository {
 
     suspend fun deleteAll()
 
-    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long?
+    suspend fun get(message: String): Long?
+
+    suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long
 
     suspend fun insertAll(libraryUpdateErrorMessages: List<LibraryUpdateErrorMessage>): List<Pair<Long, String>>
 }

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -118,6 +118,8 @@
     <string name="info_empty_library_update_errors">You have no library update errors.</string>
     <string name="action_scroll_to_top">Scroll to top</string>
     <string name="action_scroll_to_bottom">Scroll to bottom</string>
+    <string name="action_scroll_to_previous">Scroll to previous</string>
+    <string name="action_scroll_to_next">Scroll to next</string>
 
     <!-- Feed Tab -->
     <string name="too_many_in_feed">Too many sources in your feed, cannot add more than limited (20)</string>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -116,6 +116,8 @@
     <string name="option_label_library_update_errors">Library update errors</string>
     <string name="label_library_update_errors">Library update errors (%d)</string>
     <string name="info_empty_library_update_errors">You have no library update errors.</string>
+    <string name="action_scroll_to_top">Scroll to top</string>
+    <string name="action_scroll_to_bottom">Scroll to bottom</string>
 
     <!-- Feed Tab -->
     <string name="too_many_in_feed">Too many sources in your feed, cannot add more than limited (20)</string>

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/ListGroupHeader.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/ListGroupHeader.kt
@@ -1,7 +1,9 @@
 package tachiyomi.presentation.core.components
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,15 +15,23 @@ fun ListGroupHeader(
     text: String,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = text,
+    // KMK -->
+    Surface(
         modifier = modifier
-            .padding(
-                horizontal = MaterialTheme.padding.medium,
-                vertical = MaterialTheme.padding.small,
-            ),
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        fontWeight = FontWeight.SemiBold,
-        style = MaterialTheme.typography.bodyMedium,
-    )
+            .fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerLow,
+    ) {
+        // KMK <--
+        Text(
+            text = text,
+            modifier = Modifier
+                .padding(
+                    horizontal = MaterialTheme.padding.medium,
+                    vertical = MaterialTheme.padding.small,
+                ),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
 }


### PR DESCRIPTION
- A dedicated screen in Settings for error list when updating library
- Allow to jump to Error screen if click on notification
- Allow to migrate error entry
- Create error on each entry updated instead of waiting for the whole updating list to finished
- Overwrite entry's error if new error happens after updating
- Clear entry's error if it successfully updated
- Clear un-relevant errors (entry which was removed from Library) on next update
- List of errors can jump to top/bottom or next/previous errors group
- Won't create error file anymore

Close #323
Close #444