### PR TITLE
add divider & section header distinguish between settings for current series vs. app-wide 

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -2,6 +2,7 @@ package eu.kanade.presentation.reader.settings
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -50,6 +51,9 @@ internal fun ColumnScope.ReadingModePage(screenModel: ReaderSettingsScreenModel)
             )
         }
     }
+
+    HorizontalDivider()
+    HeadingItem(MR.strings.app_settings)
 
     val viewer by screenModel.viewerFlow.collectAsState()
     if (viewer is WebtoonViewer) {


### PR DESCRIPTION
The Reading mode dialog in Reader has mixed of settings for current series only & App-wide settings.
This PR add a divider and clarify the settings apply app-wide.
![image](https://github.com/user-attachments/assets/50e7b181-fd12-4146-9761-fdca2dc84953)
