### PR TITLE
fix: download job stops all together even if 1 entry is failed to create directory

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -45,7 +45,8 @@ class DownloadProvider(
             throw Exception(
                 context.stringResource(
                     MR.strings.invalid_location,
-                    downloadsDir?.displayablePath ?: "",
+                    (downloadsDir?.displayablePath ?: "") +
+                        "/${getSourceDirName(source)}/${getMangaDirName(mangaTitle)}",
                 ),
             )
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -327,7 +327,15 @@ class Downloader(
      * @param download the chapter to be downloaded.
      */
     private suspend fun downloadChapter(download: Download) {
-        val mangaDir = provider.getMangaDir(/* SY --> */ download.manga.ogTitle /* SY <-- */, download.source)
+        val mangaDir: UniFile
+        try {
+            mangaDir = provider.getMangaDir(/* SY --> */ download.manga.ogTitle /* SY <-- */, download.source)
+        } catch (error: Exception) {
+            logcat(LogPriority.ERROR, error)
+            download.status = Download.State.ERROR
+            notifier.onError(error.message, download.chapter.name, download.manga.title, download.manga.id)
+            return
+        }
 
         val availSpace = DiskUtil.getAvailableStorageSpace(mangaDir)
         if (availSpace != -1L && availSpace < MIN_DISK_SPACE) {


### PR DESCRIPTION
Also, when some entry failed to create download folder, it shows a notification saying only "invalid location: /downloads" which is misleading.