### PR TITLE
fix: reader's transition dark/light theme was wrong in auto mode

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -27,9 +27,6 @@ class PagerConfig(
     readerPreferences: ReaderPreferences = Injekt.get(),
 ) : ViewerConfig(readerPreferences, scope) {
 
-    var theme = readerPreferences.readerTheme().get()
-        private set
-
     var automaticBackground = false
         private set
 
@@ -81,10 +78,18 @@ class PagerConfig(
         readerPreferences.readerTheme()
             .register(
                 {
-                    theme = it
+                    // SY -->
+                    themeToColor(it)
+                    // SY <--
                     automaticBackground = it == 3
                 },
-                { imagePropertyChangedListener?.invoke() },
+                {
+                    imagePropertyChangedListener?.invoke()
+                    // SY -->
+                    themeToColor(it)
+                    reloadChapterListener?.invoke(doublePages)
+                    // SY <--
+                },
             )
 
         readerPreferences.imageScaleType()
@@ -139,16 +144,7 @@ class PagerConfig(
         // SY -->
         readerPreferences.pageTransitionsPager()
             .register({ usePageTransitions = it }, { imagePropertyChangedListener?.invoke() })
-        readerPreferences.readerTheme()
-            .register(
-                {
-                    themeToColor(it)
-                },
-                {
-                    themeToColor(it)
-                    reloadChapterListener?.invoke(doublePages)
-                },
-            )
+
         readerPreferences.pageLayout()
             .register(
                 {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -42,8 +42,6 @@ class WebtoonConfig(
 
     var doubleTapZoomChangedListener: ((Boolean) -> Unit)? = null
 
-    val theme = readerPreferences.readerTheme().get()
-
     // SY -->
     var usePageTransitions = false
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
@@ -15,6 +15,7 @@ import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import com.hippo.unifile.UniFile
 import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.domain.ui.model.ThemeMode
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.base.delegate.ThemingDelegate
@@ -107,9 +108,13 @@ fun Context.createFileInCacheDir(name: String): File {
 fun Context.createReaderThemeContext(): Context {
     val preferences = Injekt.get<UiPreferences>()
     val readerPreferences = Injekt.get<ReaderPreferences>()
+    val themeMode = preferences.themeMode().get()
     val isDarkBackground = when (readerPreferences.readerTheme().get()) {
         1, 2 -> true // Black, Gray
-        3 -> applicationContext.isNightMode() // Automatic bg uses activity background by default
+        3 -> when (themeMode) { // Automatic bg uses activity background by default
+            ThemeMode.SYSTEM -> applicationContext.isNightMode()
+            else -> themeMode == ThemeMode.DARK
+        }
         else -> false // White
     }
     val expected = if (isDarkBackground) Configuration.UI_MODE_NIGHT_YES else Configuration.UI_MODE_NIGHT_NO


### PR DESCRIPTION
#### Reproduce:
1. Set Reader's background color mode to *Auto*
2. System is in Light mode, App theme is in Dark mode; OR System is in Light mode, App theme is in Dark mode

#### This happens
![image](https://github.com/user-attachments/assets/1ef14e2d-af9b-40e0-9ffc-5cf5efcfade5)
![image](https://github.com/user-attachments/assets/4ae2f49a-135d-4799-8261-54f67c17c32f)