### PR TITLE
Fix: Vertical chapter navigator overlap bottom bar

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -143,7 +143,7 @@ fun ReaderAppBars(
                 animationSpec = animationSpec,
             ),
             modifier = modifierWithInsetsPadding
-                .padding(bottom = 48.dp, top = 120.dp)
+                .padding(bottom = 64.dp, top = 112.dp)
                 .align(Alignment.TopStart),
         ) {
             ChapterNavigator(
@@ -171,7 +171,7 @@ fun ReaderAppBars(
                 animationSpec = animationSpec,
             ),
             modifier = modifierWithInsetsPadding
-                .padding(bottom = 48.dp, top = 120.dp)
+                .padding(bottom = 64.dp, top = 112.dp)
                 .align(Alignment.TopEnd),
         ) {
             ChapterNavigator(


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the vertical chapter navigator would overlap with the bottom bar.