### PR TITLE
Update report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_feature.yml
+++ b/.github/ISSUE_TEMPLATE/request_feature.yml
@@ -29,8 +29,6 @@ body:
       options:
         - label: I have searched the existing issues and this is a new ticket, **NOT** a duplicate or related to another open or closed issue.
           required: true
-        - label: If this is a request regarding an extension, I should be opening an issue in the extension's repository.
-          required: true
         - label: I have written a short but informative title.
           required: true
         - label: I have updated the app to version **[1.12.1](https://github.com/komikku-app/komikku/releases/latest)**.


### PR DESCRIPTION
1. Change Mihon to Komikku in the Acknowledgements section in report template
From
![image](https://github.com/user-attachments/assets/701991c8-4446-4861-a640-6e3a955bf5fa)
to
![image](https://github.com/user-attachments/assets/0f653a0d-5f24-41b2-b606-7479478f4a12)

## Summary by Sourcery

Chores:
- Update issue templates.