### PR TITLE
Sync migration code logic with Mihon

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
@@ -7,7 +7,7 @@ object MigrationFlags {
     const val TRACK = 0b000100
     const val CUSTOM_COVER = 0b001000
     const val EXTRA = 0b010000
-    const val DELETE_CHAPTERS = 0b100000
+    const val DELETE_DOWNLOADED = 0b100000
 
     fun hasChapters(value: Int): Boolean {
         return value and CHAPTERS != 0
@@ -29,7 +29,7 @@ object MigrationFlags {
         return value and EXTRA != 0
     }
 
-    fun hasDeleteChapters(value: Int): Boolean {
-        return value and DELETE_CHAPTERS != 0
+    fun hasDeleteDownloaded(value: Int): Boolean {
+        return value and DELETE_DOWNLOADED != 0
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -130,7 +130,7 @@ class MigrationBottomSheetDialogState(
         binding.migTracking.isChecked = MigrationFlags.hasTracks(flags)
         binding.migCustomCover.isChecked = MigrationFlags.hasCustomCover(flags)
         binding.migExtra.isChecked = MigrationFlags.hasExtra(flags)
-        binding.migDeleteDownloaded.isChecked = MigrationFlags.hasDeleteChapters(flags)
+        binding.migDeleteDownloaded.isChecked = MigrationFlags.hasDeleteDownloaded(flags)
 
         binding.migChapters.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
         binding.migCategories.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
@@ -190,7 +190,7 @@ class MigrationBottomSheetDialogState(
         if (binding.migTracking.isChecked) flags = flags or MigrationFlags.TRACK
         if (binding.migCustomCover.isChecked) flags = flags or MigrationFlags.CUSTOM_COVER
         if (binding.migExtra.isChecked) flags = flags or MigrationFlags.EXTRA
-        if (binding.migDeleteDownloaded.isChecked) flags = flags or MigrationFlags.DELETE_CHAPTERS
+        if (binding.migDeleteDownloaded.isChecked) flags = flags or MigrationFlags.DELETE_DOWNLOADED
         preferences.migrateFlags().set(flags)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreen.kt
@@ -122,8 +122,8 @@ class MigrationListScreen(private val config: MigrationProcedureConfig) : Screen
                 val searchScreen = MigrateSearchScreen(migrationItem.manga.id, validSources.map { it.id })
                 navigator push searchScreen
             },
-            migrateNow = { screenModel.migrateManga(it, false) },
-            copyNow = { screenModel.migrateManga(it, true) },
+            migrateNow = { screenModel.migrateManga(it, true) },
+            copyNow = { screenModel.migrateManga(it, false) },
         )
 
         val onDismissRequest = { screenModel.dialog.value = null }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreenModel.kt
@@ -49,7 +49,6 @@ import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.history.interactor.GetHistoryByMangaId
-import tachiyomi.domain.history.interactor.RemoveHistory
 import tachiyomi.domain.history.interactor.UpsertHistory
 import tachiyomi.domain.history.model.HistoryUpdate
 import tachiyomi.domain.manga.interactor.GetManga


### PR DESCRIPTION
## Summary by Sourcery

This pull request synchronizes the migration code logic with Mihon, enhancing the manga migration process by incorporating chapter syncing, migrating read status, categories, tracking information, and custom covers. It also includes options to delete downloaded chapters from the old source and replace the old manga with the new one.