### PR TITLE
EH/ExH: better language detection in case actual language tag is not the first one

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
@@ -127,11 +127,13 @@ fun BrowseSourceEHentaiListItem(
     val context = LocalContext.current
     val languageText by produceState("", metadata) {
         value = withIOContext {
-            val locale = SourceTagsUtil.getLocaleSourceUtil(
-                metadata.tags
-                    .firstOrNull { it.namespace == EHentaiSearchMetadata.EH_LANGUAGE_NAMESPACE }
-                    ?.name,
-            )
+            // KMK -->
+            val locale = metadata.tags
+                .filter { it.namespace == EHentaiSearchMetadata.EH_LANGUAGE_NAMESPACE }
+                .firstNotNullOfOrNull {
+                    SourceTagsUtil.getLocaleSourceUtil(it.name)
+                }
+            // KMK <--
             val pageCount = metadata.length
             if (locale != null && pageCount != null) {
                 context.pluralStringResource(

--- a/i18n-sy/src/commonMain/moko-resources/as/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/as/plurals.xml
@@ -21,8 +21,8 @@
         <item quantity="other">%1$d পৃষ্ঠাসমূহ</item>
     </plurals>
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d পৃষ্ঠা</item>
-        <item quantity="other">%2$s, %1$d পৃষ্ঠাসমূহ</item>
+        <item quantity="one">%2$s %1$d পৃষ্ঠা</item>
+        <item quantity="other">%2$s %1$d পৃষ্ঠাসমূহ</item>
     </plurals>
     <plurals name="humanize_year">
         <item quantity="one">%1$d বৰ্ষ পূৰ্বে</item>

--- a/i18n-sy/src/commonMain/moko-resources/base/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/plurals.xml
@@ -38,8 +38,8 @@
 
     <!-- Enhanced E/ExHentai Browse View -->
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d page</item>
-        <item quantity="other">%2$s, %1$d pages</item>
+        <item quantity="one">%2$s %1$d page</item>
+        <item quantity="other">%2$s %1$d pages</item>
     </plurals>
 
     <!-- Humanize time -->

--- a/i18n-sy/src/commonMain/moko-resources/de/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/de/plurals.xml
@@ -33,8 +33,8 @@
         <item quantity="other">%1$d Seiten</item>
     </plurals>
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d Seite</item>
-        <item quantity="other">%2$s, %1$d Seiten</item>
+        <item quantity="one">%2$s %1$d Seite</item>
+        <item quantity="other">%2$s %1$d Seiten</item>
     </plurals>
     <plurals name="humanize_year">
         <item quantity="one">vor %1$d Jahr</item>

--- a/i18n-sy/src/commonMain/moko-resources/eo/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/eo/plurals.xml
@@ -33,8 +33,8 @@
         <item quantity="other">antaŭ %1$d tagoj</item>
     </plurals>
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d paĝo</item>
-        <item quantity="other">%2$s, %1$d paĝoj</item>
+        <item quantity="one">%2$s %1$d paĝo</item>
+        <item quantity="other">%2$s %1$d paĝoj</item>
     </plurals>
     <plurals name="num_pages">
         <item quantity="one">%1$d paĝo</item>

--- a/i18n-sy/src/commonMain/moko-resources/es/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/es/plurals.xml
@@ -36,9 +36,9 @@
         <item quantity="other">%1$d páginas</item>
     </plurals>
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d página</item>
-        <item quantity="many">%2$s, %1$d páginas</item>
-        <item quantity="other">%2$s, %1$d páginas</item>
+        <item quantity="one">%2$s %1$d página</item>
+        <item quantity="many">%2$s %1$d páginas</item>
+        <item quantity="other">%2$s %1$d páginas</item>
     </plurals>
     <plurals name="humanize_year">
         <item quantity="one">hace %1$d año</item>

--- a/i18n-sy/src/commonMain/moko-resources/fil/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/fil/plurals.xml
@@ -41,8 +41,8 @@
         <item quantity="other">%1$d na mga pahina</item>
     </plurals>
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d na pahina</item>
-        <item quantity="other">%2$s, %1$d na mga pahina</item>
+        <item quantity="one">%2$s %1$d na pahina</item>
+        <item quantity="other">%2$s %1$d na mga pahina</item>
     </plurals>
     <plurals name="humanize_year">
         <item quantity="one">%1$d taon ang nakalipas</item>

--- a/i18n-sy/src/commonMain/moko-resources/fr/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/fr/plurals.xml
@@ -38,9 +38,9 @@
     </plurals>
     <!-- Enhanced E/ExHentai Browse View -->
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d page</item>
-        <item quantity="many">%2$s, %1$d pages</item>
-        <item quantity="other">%2$s, %1$d pages</item>
+        <item quantity="one">%2$s %1$d page</item>
+        <item quantity="many">%2$s %1$d pages</item>
+        <item quantity="other">%2$s %1$d pages</item>
     </plurals>
     <!-- Humanize time -->
     <plurals name="humanize_year">

--- a/i18n-sy/src/commonMain/moko-resources/hr/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/hr/plurals.xml
@@ -6,9 +6,9 @@
         <item quantity="other">%1$d stranica</item>
     </plurals>
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d stranica</item>
-        <item quantity="few">%2$s, %1$d stranice</item>
-        <item quantity="other">%2$s, %1$d stranica</item>
+        <item quantity="one">%2$s %1$d stranica</item>
+        <item quantity="few">%2$s %1$d stranice</item>
+        <item quantity="other">%2$s %1$d stranica</item>
     </plurals>
     <plurals name="cleanup_done">
         <item quantity="one">Čišćenje je gotovo. Uklonjena je %d mapa</item>

--- a/i18n-sy/src/commonMain/moko-resources/in/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/in/plurals.xml
@@ -37,8 +37,8 @@
     </plurals>
     <!-- Enhanced E/ExHentai Browse View -->
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d page</item>
-        <item quantity="other">%2$s, %1$d pages</item>
+        <item quantity="one">%2$s %1$d page</item>
+        <item quantity="other">%2$s %1$d pages</item>
     </plurals>
     <!-- Humanize time -->
     <plurals name="humanize_year">

--- a/i18n-sy/src/commonMain/moko-resources/ja/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/ja/plurals.xml
@@ -33,8 +33,8 @@
     </plurals>
     <!-- Enhanced E/ExHentai Browse View -->
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d ページ</item>
-        <item quantity="other">%2$s, %1$d ページ</item>
+        <item quantity="one">%2$s %1$d ページ</item>
+        <item quantity="other">%2$s %1$d ページ</item>
     </plurals>
     <!-- Humanize time -->
     <plurals name="humanize_year">

--- a/i18n-sy/src/commonMain/moko-resources/pt-rBR/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/pt-rBR/plurals.xml
@@ -35,8 +35,8 @@
 
     <!-- Enhanced E/ExHentai Browse View -->
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d página</item>
-        <item quantity="other">%2$s, %1$d páginas</item>
+        <item quantity="one">%2$s %1$d página</item>
+        <item quantity="other">%2$s %1$d páginas</item>
     </plurals>
 
     <!-- Humanize time -->

--- a/i18n-sy/src/commonMain/moko-resources/ru/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/ru/plurals.xml
@@ -51,10 +51,10 @@
     </plurals>
     <!-- Enhanced E/ExHentai Browse View -->
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d страница</item>
-        <item quantity="few">%2$s, %1$d страницы</item>
-        <item quantity="many">%2$s, %1$d страниц</item>
-        <item quantity="other">%2$s, %1$d страниц</item>
+        <item quantity="one">%2$s %1$d страница</item>
+        <item quantity="few">%2$s %1$d страницы</item>
+        <item quantity="many">%2$s %1$d страниц</item>
+        <item quantity="other">%2$s %1$d страниц</item>
     </plurals>
     <!-- Humanize time -->
     <plurals name="humanize_year">

--- a/i18n-sy/src/commonMain/moko-resources/ta/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/ta/plurals.xml
@@ -33,8 +33,8 @@
         <item quantity="other">%1$d பக்கங்கள்</item>
     </plurals>
     <plurals name="browse_language_and_pages">
-        <item quantity="one">%2$s, %1$d பக்கம்</item>
-        <item quantity="other">%2$s, %1$d பக்கங்கள்</item>
+        <item quantity="one">%2$s %1$d பக்கம்</item>
+        <item quantity="other">%2$s %1$d பக்கங்கள்</item>
     </plurals>
     <plurals name="humanize_year">
         <item quantity="one">%1$d ஆண்டுக்கு முன்பு</item>

--- a/i18n-sy/src/commonMain/moko-resources/zh-rCN/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/zh-rCN/plurals.xml
@@ -30,7 +30,7 @@
 
     <!-- Enhanced E/ExHentai Browse View -->
     <plurals name="browse_language_and_pages">
-        <item quantity="other">%2$s, %1$d 页</item>
+        <item quantity="other">%2$s %1$d 页</item>
     </plurals>
 
     <!-- Humanize time -->

--- a/i18n-sy/src/commonMain/moko-resources/zh-rTW/plurals.xml
+++ b/i18n-sy/src/commonMain/moko-resources/zh-rTW/plurals.xml
@@ -27,7 +27,7 @@
     </plurals>
     <!-- Enhanced E/ExHentai Browse View -->
     <plurals name="browse_language_and_pages">
-        <item quantity="other">%2$s, %1$d 頁</item>
+        <item quantity="other">%2$s %1$d 頁</item>
     </plurals>
     <!-- Humanize time -->
     <plurals name="humanize_year">


### PR DESCRIPTION
## Summary by Sourcery

Improve language detection in EHentai browse source by iterating through all tags to find the language tag, instead of only checking the first one. Also, update the string format in plurals.xml for 'browse_language_and_pages' to include a space between the language and the number of pages.

Enhancements:
- Improve language detection in EHentai browse source by iterating through all tags to find the language tag.
- Update the string format in plurals.xml for 'browse_language_and_pages' to include a space between the language and the number of pages.