### PR TITLE
Only allow edit cover of favorited entries

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseIcons.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseIcons.kt
@@ -99,13 +99,13 @@ fun ExtensionIcon(
         is Extension.Installed -> {
             val icon by extension.getIcon(density)
             when (icon) {
-                Result.Loading -> Box(modifier = modifier)
+                is Result.Loading -> Box(modifier = modifier)
                 is Result.Success -> Image(
                     bitmap = (icon as Result.Success<ImageBitmap>).value,
                     contentDescription = null,
                     modifier = modifier,
                 )
-                Result.Error -> Image(
+                is Result.Error -> Image(
                     bitmap = ImageBitmap.imageResource(id = R.mipmap.ic_default_source),
                     contentDescription = null,
                     modifier = modifier,

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
@@ -126,7 +126,7 @@ fun MangaCoverDialog(
                                 ),
                             ),
                         )
-                        if (onEditClick != null) {
+                        if (onEditClick != null && manga.favorite) {
                             Box {
                                 var expanded by remember { mutableStateOf(false) }
                                 IconButton(


### PR DESCRIPTION
## Summary by Sourcery

Restrict manga cover editing to favorited entries and fix type checking in icon loading.

Bug Fixes:
- Fix type checking for icon loading results in ExtensionIcon function.

Enhancements:
- Restrict the ability to edit manga cover images to only favorited entries.