### PR TITLE
Fix: Reorder feeds

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/FeedOrderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/FeedOrderScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
 import eu.kanade.presentation.browse.components.FeedOrderListItem
 import eu.kanade.tachiyomi.ui.browse.feed.FeedScreenState
-import kotlinx.collections.immutable.toImmutableList
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import tachiyomi.domain.source.model.FeedSavedSearch
@@ -39,7 +38,7 @@ fun FeedOrderScreen(
 
         else -> {
             val lazyListState = rememberLazyListState()
-            val feeds = state.items.toImmutableList()
+            val feeds = state.items
 
             val feedsState = remember { feeds.toMutableStateList() }
             val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->

--- a/app/src/main/java/eu/kanade/presentation/browse/FeedOrderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/FeedOrderScreen.kt
@@ -10,9 +10,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
 import eu.kanade.presentation.browse.components.FeedOrderListItem
 import eu.kanade.tachiyomi.ui.browse.feed.FeedScreenState
+import kotlinx.collections.immutable.toImmutableList
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import tachiyomi.domain.source.model.FeedSavedSearch
@@ -37,9 +39,9 @@ fun FeedOrderScreen(
 
         else -> {
             val lazyListState = rememberLazyListState()
-            val feeds = state.items
+            val feeds = state.items.toImmutableList()
 
-            val feedsState = remember { feeds.toMutableList() }
+            val feedsState = remember { feeds.toMutableStateList() }
             val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
                 val item = feedsState.removeAt(from.index)
                 feedsState.add(to.index, item)

--- a/app/src/main/java/eu/kanade/presentation/browse/SourceFeedOrderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourceFeedOrderScreen.kt
@@ -16,7 +16,6 @@ import eu.kanade.presentation.browse.components.FeedOrderListItem
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarTitle
 import eu.kanade.tachiyomi.ui.browse.source.feed.SourceFeedState
-import kotlinx.collections.immutable.toImmutableList
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import tachiyomi.domain.source.model.FeedSavedSearch
@@ -61,7 +60,6 @@ fun SourceFeedOrderScreen(
                 val lazyListState = rememberLazyListState()
                 val feeds = state.items
                     .filterIsInstance<SourceFeedUI.SourceSavedSearch>()
-                    .toImmutableList()
 
                 val feedsState = remember { feeds.toMutableStateList() }
                 val reorderableState = rememberReorderableLazyListState(lazyListState, paddingValues) { from, to ->

--- a/app/src/main/java/eu/kanade/presentation/browse/SourceFeedOrderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourceFeedOrderScreen.kt
@@ -10,11 +10,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
 import eu.kanade.presentation.browse.components.FeedOrderListItem
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarTitle
 import eu.kanade.tachiyomi.ui.browse.source.feed.SourceFeedState
+import kotlinx.collections.immutable.toImmutableList
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import tachiyomi.domain.source.model.FeedSavedSearch
@@ -59,8 +61,9 @@ fun SourceFeedOrderScreen(
                 val lazyListState = rememberLazyListState()
                 val feeds = state.items
                     .filterIsInstance<SourceFeedUI.SourceSavedSearch>()
+                    .toImmutableList()
 
-                val feedsState = remember { feeds.toMutableList() }
+                val feedsState = remember { feeds.toMutableStateList() }
                 val reorderableState = rememberReorderableLazyListState(lazyListState, paddingValues) { from, to ->
                     val item = feedsState.removeAt(from.index)
                     feedsState.add(to.index, item)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
@@ -93,7 +93,10 @@ open class FeedScreenModel(
                 }
                 mutableState.update { state ->
                     state.copy(
-                        items = items,
+                        items = items
+                            // KMK -->
+                            .toImmutableList(),
+                        // KMK <--
                     )
                 }
                 getFeed(items)
@@ -108,7 +111,10 @@ open class FeedScreenModel(
             val newItems = state.value.items?.map { it.copy(results = null) } ?: return@launchIO
             mutableState.update { state ->
                 state.copy(
-                    items = newItems,
+                    items = newItems
+                        // KMK -->
+                        .toImmutableList(),
+                    // KMK <--
                 )
             }
             getFeed(newItems)
@@ -306,7 +312,10 @@ open class FeedScreenModel(
 
                     mutableState.update { state ->
                         state.copy(
-                            items = state.items?.map { if (it.feed.id == result.feed.id) result else it },
+                            items = state.items?.map { if (it.feed.id == result.feed.id) result else it }
+                                // KMK -->
+                                ?.toImmutableList(),
+                            // KMK <--
                         )
                     }
                 }
@@ -379,7 +388,7 @@ open class FeedScreenModel(
 
 data class FeedScreenState(
     val dialog: FeedScreenModel.Dialog? = null,
-    val items: List<FeedItemUI>? = null,
+    val items: ImmutableList<FeedItemUI>? = null,
 ) {
     val isLoading
         get() = items == null


### PR DESCRIPTION
Feed reordering was not updating visually although the change still took effect.

## Summary by Sourcery

Fixes an issue where reordering feeds was not updating visually by ensuring the items list is converted to an immutable list in FeedScreenModel and using a MutableStateList in the FeedOrderScreen and SourceFeedOrderScreen.

Bug Fixes:
- Fixes an issue where feed reordering was not updating visually.
- Ensures the items list is converted to an immutable list in FeedScreenModel.
- Uses a MutableStateList in the FeedOrderScreen and SourceFeedOrderScreen.