### PR TITLE
Fix: Pinned sources were not restored from backup

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/PreferenceRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/PreferenceRestorer.kt
@@ -163,7 +163,7 @@ class PreferenceRestorer(
     ) {
         if (value.isEmpty()) return
 
-        val newValue = EXHMigrations.migratePinnedSources(value)
-        preferenceStore.getStringSet(key).set(newValue)
+        val valueToSet = EXHMigrations.migrateSourceIds(value)
+        preferenceStore.getStringSet(key).set(valueToSet)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/PreferenceRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/PreferenceRestorer.kt
@@ -110,14 +110,16 @@ class PreferenceRestorer(
                                 categoriesByName,
                             )
                             if (!restored) {
-                                // KMK -->
-                                when (key) {
-                                    SourcePreferences.PINNED_SOURCES_PREF_KEY ->
-                                        EXHMigrations.migratePinnedSources(value.value)
-                                    else ->
-                                        // KMK <--
-                                        preferenceStore.getStringSet(key).set(value.value)
-                                }
+                                preferenceStore.getStringSet(key).set(
+                                    // KMK -->
+                                    when (key) {
+                                        SourcePreferences.PINNED_SOURCES_PREF_KEY ->
+                                            EXHMigrations.migratePinnedSources(value.value)
+                                        else ->
+                                            // KMK <--
+                                            value.value
+                                    },
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/PreferenceRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/PreferenceRestorer.kt
@@ -110,16 +110,18 @@ class PreferenceRestorer(
                                 categoriesByName,
                             )
                             if (!restored) {
-                                preferenceStore.getStringSet(key).set(
-                                    // KMK -->
-                                    when (key) {
-                                        SourcePreferences.PINNED_SOURCES_PREF_KEY ->
-                                            EXHMigrations.migratePinnedSources(value.value)
-                                        else ->
-                                            // KMK <--
-                                            value.value
-                                    },
-                                )
+                                // KMK -->
+                                when (key) {
+                                    SourcePreferences.PINNED_SOURCES_PREF_KEY ->
+                                        restorePinnedSourcesPreference(
+                                            key,
+                                            value.value,
+                                            preferenceStore,
+                                        )
+                                    else ->
+                                        // KMK <--
+                                        preferenceStore.getStringSet(key).set(value.value)
+                                }
                             }
                         }
                     }
@@ -152,5 +154,16 @@ class PreferenceRestorer(
             preferenceStore.getStringSet(key) += ids
         }
         return true
+    }
+
+    private fun restorePinnedSourcesPreference(
+        key: String,
+        value: Set<String>,
+        preferenceStore: PreferenceStore,
+    ) {
+        if (value.isEmpty()) return
+
+        val newValue = EXHMigrations.migratePinnedSources(value)
+        preferenceStore.getStringSet(key).set(newValue)
     }
 }

--- a/app/src/main/java/exh/EXHMigrations.kt
+++ b/app/src/main/java/exh/EXHMigrations.kt
@@ -140,29 +140,29 @@ object EXHMigrations {
     /**
      * Migrate old source ID of delegated sources in old backup
      */
-    fun migratePinnedSources(pinnedSources: Set<String>): Set<String> {
-        var pinned = pinnedSources
-        if (NHENTAI_OLD_ID.toString() in pinned) {
-            pinned = pinned.minus(NHENTAI_OLD_ID.toString())
+    fun migrateSourceIds(oldSourceIds: Set<String>): Set<String> {
+        var newSourceIds = oldSourceIds
+        if (NHENTAI_OLD_ID.toString() in newSourceIds) {
+            newSourceIds = newSourceIds.minus(NHENTAI_OLD_ID.toString())
                 .plus(NHENTAI_SOURCE_ID.toString())
         }
-        if (TSUMINO_OLD_ID.toString() in pinned) {
-            pinned = pinned.minus(TSUMINO_OLD_ID.toString())
+        if (TSUMINO_OLD_ID.toString() in newSourceIds) {
+            newSourceIds = newSourceIds.minus(TSUMINO_OLD_ID.toString())
                 .plus(TSUMINO_SOURCE_ID.toString())
         }
-        if (HBROWSE_OLD_ID.toString() in pinned) {
-            pinned = pinned.minus(HBROWSE_OLD_ID.toString())
+        if (HBROWSE_OLD_ID.toString() in newSourceIds) {
+            newSourceIds = newSourceIds.minus(HBROWSE_OLD_ID.toString())
                 .plus(HBROWSE_SOURCE_ID.toString())
         }
-        if (EH_OLD_ID.toString() in pinned) {
-            pinned = pinned.minus(EH_OLD_ID.toString())
+        if (EH_OLD_ID.toString() in newSourceIds) {
+            newSourceIds = newSourceIds.minus(EH_OLD_ID.toString())
                 .plus(EH_SOURCE_ID.toString())
         }
-        if (EXH_OLD_ID.toString() in pinned) {
-            pinned = pinned.minus(EXH_OLD_ID.toString())
+        if (EXH_OLD_ID.toString() in newSourceIds) {
+            newSourceIds = newSourceIds.minus(EXH_OLD_ID.toString())
                 .plus(EXH_SOURCE_ID.toString())
         }
-        return pinned
+        return newSourceIds
     }
     // KMK -->
 


### PR DESCRIPTION
Forgot to set back preferences of pinned sources after migrating old-source/new-source

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where pinned sources were not restored correctly from backup due to old source IDs not being migrated to new source IDs.