### PR TITLE
Allow overwriting saved search

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/savedsearch/SavedSearchCreateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/savedsearch/SavedSearchCreateDialog.kt
@@ -1,0 +1,15 @@
+-okButton.setOnClickListener { createSavedSearch(nameInput.text.toString()) }
+okButton.setOnClickListener {
+    val name = nameInput.text.toString().trim()
+    databaseHandler.getSavedSearchByName(name) { existing ->
+        if (existing != null) {
+            showConfirmationDialog(
+                message = "A saved search with this name already exists. Overwrite?",
+                onConfirm = { createSavedSearch(name, overwrite = true) },
+                onCancel = { /* Allow user to modify the name */ }
+            )
+        } else {
+            createSavedSearch(name, overwrite = false)
+        }
+    }
+}


### PR DESCRIPTION
Now when trying to create a new saved search and a saved search with the same name already exists it will ask the user if they want to override it

Done with gitauto ai, Screenshot and testing were not done as discussed with the main dev

## Summary by Sourcery

Enhancements:
- Improves the saved search creation process by prompting users to overwrite existing saved searches with the same name.