### PR TITLE
Fix: Messed up trackers progress update always auto sync

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/TrackChapter.kt
@@ -23,6 +23,11 @@ class TrackChapter(
     private val delayedTrackingStore: DelayedTrackingStore,
 ) {
 
+    /**
+     * Fetches updated tracking data from all logged in trackers.
+     * Then update chapter progress to all trackers.
+     * This does not update local chapters' read status.
+     */
     suspend fun await(context: Context, mangaId: Long, chapterNumber: Double, setupJobOnFailure: Boolean = true) {
         withNonCancellableContext {
             val tracks = getTracks.await(mangaId)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -176,6 +176,7 @@ class MangaScreenModel(
     private val uiPreferences: UiPreferences = Injekt.get(),
     // KMK -->
     private val sourcePreferences: SourcePreferences = Injekt.get(),
+    private val refreshTracks: RefreshTracks = Injekt.get(),
     // KMK <--
     private val trackerManager: TrackerManager = Injekt.get(),
     private val trackChapter: TrackChapter = Injekt.get(),
@@ -562,8 +563,7 @@ class MangaScreenModel(
     private suspend fun syncTrackers() {
         if (!trackPreferences.autoSyncProgressFromTrackers().get()) return
 
-        val refreshTracks = Injekt.get<RefreshTracks>()
-        refreshTracks.await(mangaId)
+        refreshTracks.await(mangaId, enhancedTrackersOnly = false)
             .filter { it.first != null }
             .forEach { (track, e) ->
                 logcat(LogPriority.ERROR, e) {


### PR DESCRIPTION
## Summary by Sourcery

Fixes an issue where tracker progress updates were always automatically syncing, regardless of user preference. Now, syncing only occurs when the 'autoSyncProgressFromTrackers' preference is enabled. Also, the changes ensure that chapter progress is synced with all trackers when tracking a chapter, and only with enhanced trackers during a refresh.

Bug Fixes:
- Fixes an issue where tracker progress updates were always automatically syncing, regardless of user preference.
- Now, syncing only occurs when the 'autoSyncProgressFromTrackers' preference is enabled.
- Ensure that chapter progress is synced with all trackers when tracking a chapter, and only with enhanced trackers during a refresh.

Enhancements:
- Refactor the SyncChapterProgressWithTrack interactor to allow syncing with all trackers or only enhanced trackers.

Close #790 