### PR TITLE
feat: add badge to UpdateScreen header

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -259,7 +259,7 @@ private fun UpdatesBottomBar(
 }
 
 sealed interface UpdatesUiModel {
-    data class Header(val date: LocalDate) : UpdatesUiModel
+    data class Header(val date: LocalDate, val mangaCount: Int) : UpdatesUiModel
     open class Item(open val item: UpdatesItem, open val isExpandable: Boolean = false) : UpdatesUiModel
     // KMK -->
     /** The first [Item] in a group of chapters from same manga */

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import eu.kanade.presentation.components.relativeDateText
 import eu.kanade.presentation.manga.components.ChapterDownloadAction
 import eu.kanade.presentation.manga.components.ChapterDownloadIndicator
 import eu.kanade.presentation.manga.components.DotSeparatorText
@@ -51,9 +50,9 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.ui.updates.UpdatesItem
 import eu.kanade.tachiyomi.ui.updates.groupByDateAndManga
+import mihon.feature.upcoming.DateHeading
 import tachiyomi.domain.updates.model.UpdatesWithRelations
 import tachiyomi.i18n.MR
-import tachiyomi.presentation.core.components.ListGroupHeader
 import tachiyomi.presentation.core.components.material.DISABLED_ALPHA
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
@@ -109,13 +108,14 @@ internal fun LazyListScope.updatesUiItems(
     ) { item ->
         when (item) {
             is UpdatesUiModel.Header -> {
-                ListGroupHeader(
+                // KMK -->
+                DateHeading(
                     modifier = Modifier.animateItemFastScroll()
-                        // KMK -->
                         .padding(top = MaterialTheme.padding.extraSmall),
-                    // KMK <--
-                    text = relativeDateText(item.date),
+                    date = item.date,
+                    mangaCount = item.mangaCount,
                 )
+                // KMK <--
             }
             is UpdatesUiModel.Item -> {
                 val updatesItem = item.item
@@ -183,9 +183,11 @@ private fun UpdatesUiItem(
     expanded: Boolean,
     collapseToggle: (key: String) -> Unit,
     usePanoramaCover: Boolean,
-    coverRatio: MutableFloatState = remember { mutableFloatStateOf(1f) },
     // KMK <--
     modifier: Modifier = Modifier,
+    // KMK -->
+    coverRatio: MutableFloatState = remember { mutableFloatStateOf(1f) },
+    // KMK <--
 ) {
     val haptic = LocalHapticFeedback.current
     val textAlpha = if (update.read) DISABLED_ALPHA else 1f

--- a/app/src/main/java/mihon/feature/upcoming/UpcomingScreenContent.kt
+++ b/app/src/main/java/mihon/feature/upcoming/UpcomingScreenContent.kt
@@ -176,13 +176,16 @@ private fun UpcomingToolbar(
 }
 
 @Composable
-private fun DateHeading(
+internal fun DateHeading(
     date: LocalDate,
     mangaCount: Int,
+    // KMK -->
+    modifier: Modifier = Modifier,
+    // KMK <--
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Text(
             text = relativeDateText(date),


### PR DESCRIPTION
Close #476

## Summary by Sourcery

Enhance the Updates screen by adding a manga count badge to the date header

New Features:
- Add manga count display in the Updates screen date headers

Enhancements:
- Refactor updates grouping logic to include manga count in date headers
- Modify DateHeading component to support optional manga count display