### PR TITLE
Update requery.sqlite-android dependency to 665608662e

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ libarchive = "me.zhanghai.android.libarchive:library:1.1.4"
 
 sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqlite" }
 sqlite-ktx = { module = "androidx.sqlite:sqlite-ktx", version.ref = "sqlite" }
-sqlite-android = "com.github.requery:sqlite-android:3.45.0"
+sqlite-android = "com.github.requery:sqlite-android:665608662e"
 
 preferencektx = "androidx.preference:preference-ktx:1.2.1"
 


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Upgrade sqlite-android library from version 3.45.0 to a specific commit hash (665608662e)