### PR TITLE
Improve  in case source is null

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreen.kt
@@ -6,12 +6,13 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.browse.BrowseTabWrapper
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import exh.recs.BrowseRecommendsScreen
 import exh.recs.RecommendsScreen
 import java.io.Serializable
 
 /**
  * Navigated to when invoking [MangaScreen.openSmartSearch] for entries to merge or
- * from [RecommendsScreen.openSmartSearch] for click a recommendation entry.
+ * from [RecommendsScreen], [BrowseRecommendsScreen] for click a recommendation entry.
  * This will show a [sourcesTab] to select a source to search for entries to merge or
  * search for recommending entry.
  */

--- a/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
@@ -10,22 +10,31 @@ import exh.metadata.metadata.RaisedSearchMetadata
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.domain.source.repository.SourcePagingSourceType
 
-class SourceSearchPagingSource(/* KMK --> */ override val /* KMK <-- */source: CatalogueSource, val query: String, val filters: FilterList) :
+class SourceSearchPagingSource(source: CatalogueSource, val query: String, val filters: FilterList) :
     SourcePagingSource(source) {
     override suspend fun requestNextPage(currentPage: Int): MangasPage {
-        return source.getSearchManga(currentPage, query, filters)
+        return source?.getSearchManga(currentPage, query, filters)
+            // KMK -->
+            ?: MangasPage(emptyList(), false)
+        // KMK <--
     }
 }
 
-class SourcePopularPagingSource(/* KMK --> */ override val /* KMK <-- */source: CatalogueSource) : SourcePagingSource(source) {
+class SourcePopularPagingSource(source: CatalogueSource) : SourcePagingSource(source) {
     override suspend fun requestNextPage(currentPage: Int): MangasPage {
-        return source.getPopularManga(currentPage)
+        return source?.getPopularManga(currentPage)
+            // KMK -->
+            ?: MangasPage(emptyList(), false)
+        // KMK <--
     }
 }
 
-class SourceLatestPagingSource(/* KMK --> */ override val /* KMK <-- */source: CatalogueSource) : SourcePagingSource(source) {
+class SourceLatestPagingSource(source: CatalogueSource) : SourcePagingSource(source) {
     override suspend fun requestNextPage(currentPage: Int): MangasPage {
-        return source.getLatestUpdates(currentPage)
+        return source?.getLatestUpdates(currentPage)
+            // KMK -->
+            ?: MangasPage(emptyList(), false)
+        // KMK <--
     }
 }
 


### PR DESCRIPTION
related to commit 343cd372

## Summary by Sourcery

Handle null source gracefully in paging sources by returning an empty manga page

Bug Fixes:
- Add null checks in paging sources to prevent potential null pointer exceptions when source is null

Enhancements:
- Simplify source parameter declaration in paging source classes
- Improve error handling for null sources in search, popular, and latest manga paging sources

Chores:
- Update source screen documentation to include additional recommendation screen reference