### PR TITLE
Add user manga notes (mihonapp/mihon#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 ### Added
 - Add more Kaomoji for empty/error screens ([@ianfhunter](https://github.com/ianfhunter/)) ([#1909](https://github.com/mihonapp/mihon/pull/1909))
+- Add user manga notes ([@imkunet](https://github.com/imkunet), [@AntsyLich](https://github.com/AntsyLich)) ([#428](https://github.com/mihonapp/mihon/pull/428))
 
 ### Fixes
 - Fix Bangumi search results including novels ([@MajorTanya](https://github.com/MajorTanya)) ([#1885](https://github.com/mihonapp/mihon/pull/1885))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -281,6 +281,7 @@ dependencies {
     }
     implementation(libs.insetter)
     implementation(libs.bundles.richtext)
+    implementation(libs.richeditor.compose)
     implementation(libs.aboutLibraries.compose)
     implementation(libs.bundles.voyager)
     implementation(libs.compose.materialmotion)

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -80,6 +80,7 @@ import tachiyomi.domain.manga.interactor.GetMangaWithChapters
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.interactor.ResetViewerFlags
 import tachiyomi.domain.manga.interactor.SetMangaChapterFlags
+import tachiyomi.domain.manga.interactor.UpdateMangaNotes
 import tachiyomi.domain.manga.repository.MangaRepository
 import tachiyomi.domain.release.interactor.GetApplicationRelease
 import tachiyomi.domain.release.service.ReleaseService
@@ -133,6 +134,7 @@ class DomainModule : InjektModule {
         addFactory { SetMangaViewerFlags(get()) }
         addFactory { NetworkToLocalManga(get()) }
         addFactory { UpdateManga(get(), get()) }
+        addFactory { UpdateMangaNotes(get()) }
         addFactory { SetMangaCategories(get()) }
         addFactory { GetExcludedScanlators(get()) }
         addFactory { SetExcludedScanlators(get()) }

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaNotesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaNotesScreen.kt
@@ -1,0 +1,45 @@
+package eu.kanade.presentation.manga
+
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.components.AppBarTitle
+import eu.kanade.presentation.manga.components.MangaNotesTextArea
+import eu.kanade.tachiyomi.ui.manga.notes.MangaNotesScreen
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+fun MangaNotesScreen(
+    state: MangaNotesScreen.State,
+    navigateUp: () -> Unit,
+    onUpdate: (String) -> Unit,
+) {
+    Scaffold(
+        topBar = { topBarScrollBehavior ->
+            AppBar(
+                titleContent = {
+                    AppBarTitle(
+                        title = stringResource(MR.strings.action_edit_notes),
+                        subtitle = state.manga.title,
+                    )
+                },
+                navigateUp = navigateUp,
+                scrollBehavior = topBarScrollBehavior,
+            )
+        },
+    ) { contentPadding ->
+        MangaNotesTextArea(
+            state = state,
+            onUpdate = onUpdate,
+            modifier = Modifier
+                .padding(contentPadding)
+                .consumeWindowInsets(contentPadding)
+                .imePadding(),
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -170,6 +170,7 @@ fun MangaScreen(
     onEditCategoryClicked: (() -> Unit)?,
     onEditFetchIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
+    onEditNotesClicked: () -> Unit,
     // SY -->
     onMetadataViewerClicked: () -> Unit,
     onEditInfoClicked: () -> Unit,
@@ -243,6 +244,7 @@ fun MangaScreen(
             onEditCategoryClicked = onEditCategoryClicked,
             onEditIntervalClicked = onEditFetchIntervalClicked,
             onMigrateClicked = onMigrateClicked,
+            onEditNotesClicked = onEditNotesClicked,
             // SY -->
             onMetadataViewerClicked = onMetadataViewerClicked,
             onEditInfoClicked = onEditInfoClicked,
@@ -302,6 +304,7 @@ fun MangaScreen(
             onEditCategoryClicked = onEditCategoryClicked,
             onEditIntervalClicked = onEditFetchIntervalClicked,
             onMigrateClicked = onMigrateClicked,
+            onEditNotesClicked = onEditNotesClicked,
             // SY -->
             onMetadataViewerClicked = onMetadataViewerClicked,
             onEditInfoClicked = onEditInfoClicked,
@@ -371,6 +374,7 @@ private fun MangaScreenSmallImpl(
     onEditCategoryClicked: (() -> Unit)?,
     onEditIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
+    onEditNotesClicked: () -> Unit,
     // SY -->
     onMetadataViewerClicked: () -> Unit,
     onEditInfoClicked: () -> Unit,
@@ -477,6 +481,7 @@ private fun MangaScreenSmallImpl(
                 onClickEditCategory = onEditCategoryClicked,
                 onClickRefresh = onRefresh,
                 onClickMigrate = onMigrateClicked,
+                onClickEditNotes = onEditNotesClicked,
                 // SY -->
                 onClickEditInfo = onEditInfoClicked.takeIf { state.manga.favorite },
                 // KMK -->
@@ -673,8 +678,10 @@ private fun MangaScreenSmallImpl(
                             defaultExpandState = state.isFromSource && !state.manga.favorite,
                             description = state.manga.description,
                             tagsProvider = { state.manga.genre },
+                            notes = state.manga.notes,
                             onTagSearch = onTagSearch,
                             onCopyTagToClipboard = onCopyTagToClipboard,
+                            onEditNotes = onEditNotesClicked,
                             // SY -->
                             doSearch = onSearch,
                             searchMetadataChips = remember(state.meta, state.source.id, state.manga.genre) {
@@ -826,6 +833,7 @@ private fun MangaScreenLargeImpl(
     onEditCategoryClicked: (() -> Unit)?,
     onEditIntervalClicked: (() -> Unit)?,
     onMigrateClicked: (() -> Unit)?,
+    onEditNotesClicked: () -> Unit,
     // SY -->
     onMetadataViewerClicked: () -> Unit,
     onEditInfoClicked: () -> Unit,
@@ -923,6 +931,7 @@ private fun MangaScreenLargeImpl(
                 onClickEditCategory = onEditCategoryClicked,
                 onClickRefresh = onRefresh,
                 onClickMigrate = onMigrateClicked,
+                onClickEditNotes = onEditNotesClicked,
                 onCancelActionMode = { onAllChapterSelected(false) },
                 // SY -->
                 onClickEditInfo = onEditInfoClicked.takeIf { state.manga.favorite },
@@ -1100,8 +1109,10 @@ private fun MangaScreenLargeImpl(
                             defaultExpandState = true,
                             description = state.manga.description,
                             tagsProvider = { state.manga.genre },
+                            notes = state.manga.notes,
                             onTagSearch = onTagSearch,
                             onCopyTagToClipboard = onCopyTagToClipboard,
+                            onEditNotes = onEditNotesClicked,
                             // SY -->
                             doSearch = onSearch,
                             searchMetadataChips = remember(state.meta, state.source.id, state.manga.genre) {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -332,8 +332,10 @@ fun ExpandableMangaDescription(
     defaultExpandState: Boolean,
     description: String?,
     tagsProvider: () -> List<String>?,
+    notes: String,
     onTagSearch: (String) -> Unit,
     onCopyTagToClipboard: (tag: String) -> Unit,
+    onEditNotes: () -> Unit,
     // SY -->
     searchMetadataChips: SearchMetadataChips?,
     doSearch: (query: String, global: Boolean) -> Unit,
@@ -359,6 +361,8 @@ fun ExpandableMangaDescription(
             expandedDescription = desc,
             shrunkDescription = trimmedDescription,
             expanded = expanded,
+            notes = notes,
+            onEditNotesClicked = onEditNotes,
             modifier = Modifier
                 .padding(top = 8.dp)
                 .padding(horizontal = 16.dp)
@@ -825,7 +829,9 @@ private fun ColumnScope.MangaContentInfo(
 private fun MangaSummary(
     expandedDescription: String,
     shrunkDescription: String,
+    notes: String,
     expanded: Boolean,
+    onEditNotesClicked: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val animProgress by animateFloatAsState(
@@ -837,25 +843,41 @@ private fun MangaSummary(
         contents = listOf(
             {
                 Text(
-                    text = "\n\n", // Shows at least 3 lines
+                    // Shows at least 3 lines if no notes
+                    // when there are notes show 6
+                    text = if (notes.isBlank()) "\n\n" else "\n\n\n\n\n",
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
             {
-                Text(
-                    text = expandedDescription,
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            },
-            {
-                SelectionContainer {
-                    Text(
-                        text = if (expanded) expandedDescription else shrunkDescription,
-                        maxLines = Int.MAX_VALUE,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        modifier = Modifier.secondaryItemAlpha(),
+                Column {
+                    MangaNotesSection(
+                        content = notes,
+                        expanded = true,
+                        onEditNotes = onEditNotesClicked,
                     )
+                    Text(
+                        text = expandedDescription,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            },
+            {
+                Column {
+                    MangaNotesSection(
+                        content = notes,
+                        expanded = expanded,
+                        onEditNotes = onEditNotesClicked,
+                    )
+                    SelectionContainer {
+                        Text(
+                            text = if (expanded) expandedDescription else shrunkDescription,
+                            maxLines = Int.MAX_VALUE,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            modifier = Modifier.secondaryItemAlpha(),
+                        )
+                    }
                 }
             },
             {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesDisplay.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesDisplay.kt
@@ -1,0 +1,60 @@
+package eu.kanade.presentation.manga.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.ui.material3.RichText
+
+private val FADE_TIME = tween<Float>(500)
+
+@Composable
+fun MangaNotesDisplay(
+    content: String,
+    modifier: Modifier,
+) {
+    val alpha = remember { Animatable(1f) }
+    var contentUpdatedOnce by remember { mutableStateOf(false) }
+
+    val richTextState = rememberRichTextState()
+    val primaryColor = MaterialTheme.colorScheme.primary
+    LaunchedEffect(content) {
+        richTextState.setMarkdown(content)
+
+        if (!contentUpdatedOnce) {
+            contentUpdatedOnce = true
+            return@LaunchedEffect
+        }
+
+        alpha.snapTo(targetValue = 0f)
+        alpha.animateTo(targetValue = 1f, animationSpec = FADE_TIME)
+    }
+    LaunchedEffect(Unit) {
+        richTextState.config.unorderedListIndent = 4
+        richTextState.config.orderedListIndent = 20
+    }
+    LaunchedEffect(primaryColor) {
+        richTextState.config.linkColor = primaryColor
+    }
+
+    SelectionContainer {
+        RichText(
+            modifier = modifier
+                // Only animate size if the notes changes
+                .then(if (contentUpdatedOnce) Modifier.animateContentSize() else Modifier)
+                .alpha(alpha.value),
+            style = MaterialTheme.typography.bodyMedium,
+            state = richTextState,
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesSection.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesSection.kt
@@ -1,0 +1,90 @@
+package eu.kanade.presentation.manga.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EditNote
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.Button
+import tachiyomi.presentation.core.components.material.ButtonDefaults
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+fun MangaNotesSection(
+    content: String,
+    expanded: Boolean,
+    onEditNotes: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (content.isBlank()) return
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        MangaNotesDisplay(
+            content = content,
+            modifier = modifier.fillMaxWidth(),
+        )
+        if (expanded) {
+            Button(
+                onClick = onEditNotes,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color.Transparent,
+                    contentColor = MaterialTheme.colorScheme.primary,
+                ),
+                shape = RoundedCornerShape(8.dp),
+                modifier = Modifier
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.EditNote,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(16.dp),
+                    )
+                    Text(
+                        stringResource(MR.strings.action_edit_notes),
+                    )
+                }
+            }
+        }
+
+        HorizontalDivider(
+            modifier = Modifier
+                .padding(
+                    top = if (expanded) 0.dp else 12.dp,
+                    bottom = if (expanded) 16.dp else 12.dp,
+                ),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun MangaNotesSectionPreview() {
+    MangaNotesSection(
+        onEditNotes = {},
+        expanded = true,
+        content = "# Hello world\ntest1234 hi there!",
+    )
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesSection.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesSection.kt
@@ -39,7 +39,7 @@ fun MangaNotesSection(
     ) {
         MangaNotesDisplay(
             content = content,
-            modifier = modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
         )
         if (expanded) {
             Button(

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesTextArea.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesTextArea.kt
@@ -1,0 +1,224 @@
+package eu.kanade.presentation.manga.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.FormatListBulleted
+import androidx.compose.material.icons.outlined.FormatBold
+import androidx.compose.material.icons.outlined.FormatItalic
+import androidx.compose.material.icons.outlined.FormatListNumbered
+import androidx.compose.material.icons.outlined.FormatUnderlined
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
+import com.mohamedrejeb.richeditor.ui.material3.RichTextEditorDefaults.richTextEditorColors
+import eu.kanade.tachiyomi.ui.manga.notes.MangaNotesScreen
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+import kotlin.time.Duration.Companion.seconds
+
+private const val MAX_LENGTH = 250
+private const val MAX_LENGTH_WARN = MAX_LENGTH * 0.9
+
+@Composable
+fun MangaNotesTextArea(
+    state: MangaNotesScreen.State,
+    onUpdate: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    val richTextState = rememberRichTextState()
+    val primaryColor = MaterialTheme.colorScheme.primary
+
+    DisposableEffect(scope, richTextState) {
+        snapshotFlow { richTextState.annotatedString }
+            .debounce(0.25.seconds)
+            .distinctUntilChanged()
+            .map { richTextState.toMarkdown() }
+            .onEach { onUpdate(it) }
+            .launchIn(scope)
+
+        onDispose {
+            onUpdate(richTextState.toMarkdown())
+        }
+    }
+    LaunchedEffect(Unit) {
+        richTextState.setMarkdown(state.notes)
+        richTextState.config.unorderedListIndent = 4
+        richTextState.config.orderedListIndent = 20
+    }
+    LaunchedEffect(primaryColor) {
+        richTextState.config.linkColor = primaryColor
+    }
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(focusRequester) {
+        focusRequester.requestFocus()
+    }
+    val textLength = remember(richTextState.annotatedString) { richTextState.toText().length }
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = MaterialTheme.padding.small)
+            .fillMaxSize(),
+    ) {
+        RichTextEditor(
+            state = richTextState,
+            textStyle = MaterialTheme.typography.bodyLarge,
+            maxLength = MAX_LENGTH,
+            placeholder = {
+                Text(text = stringResource(MR.strings.notes_placeholder))
+            },
+            colors = richTextEditorColors(
+                containerColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+            ),
+            contentPadding = PaddingValues(
+                horizontal = MaterialTheme.padding.medium,
+            ),
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .padding(vertical = MaterialTheme.padding.small)
+                .fillMaxWidth(),
+        ) {
+            LazyRow(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                item {
+                    MangaNotesTextAreaButton(
+                        onClick = { richTextState.toggleSpanStyle(SpanStyle(fontWeight = FontWeight.Bold)) },
+                        isSelected = richTextState.currentSpanStyle.fontWeight == FontWeight.Bold,
+                        icon = Icons.Outlined.FormatBold,
+                    )
+                }
+                item {
+                    MangaNotesTextAreaButton(
+                        onClick = { richTextState.toggleSpanStyle(SpanStyle(fontStyle = FontStyle.Italic)) },
+                        isSelected = richTextState.currentSpanStyle.fontStyle == FontStyle.Italic,
+                        icon = Icons.Outlined.FormatItalic,
+                    )
+                }
+                item {
+                    MangaNotesTextAreaButton(
+                        onClick = {
+                            richTextState.toggleSpanStyle(SpanStyle(textDecoration = TextDecoration.Underline))
+                        },
+                        isSelected = richTextState.currentSpanStyle.textDecoration
+                            ?.contains(TextDecoration.Underline)
+                            ?: false,
+                        icon = Icons.Outlined.FormatUnderlined,
+                    )
+                }
+                item {
+                    VerticalDivider(
+                        modifier = Modifier
+                            .padding(horizontal = MaterialTheme.padding.extraSmall)
+                            .height(MaterialTheme.padding.large),
+                    )
+                }
+                item {
+                    MangaNotesTextAreaButton(
+                        onClick = { richTextState.toggleUnorderedList() },
+                        isSelected = richTextState.isUnorderedList,
+                        icon = Icons.AutoMirrored.Outlined.FormatListBulleted,
+                    )
+                }
+                item {
+                    MangaNotesTextAreaButton(
+                        onClick = { richTextState.toggleOrderedList() },
+                        isSelected = richTextState.isOrderedList,
+                        icon = Icons.Outlined.FormatListNumbered,
+                    )
+                }
+            }
+
+            Box(
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = (MAX_LENGTH - textLength).toString(),
+                    color = if (textLength > MAX_LENGTH_WARN) {
+                        MaterialTheme.colorScheme.error
+                    } else {
+                        Color.Unspecified
+                    },
+                    modifier = Modifier.padding(MaterialTheme.padding.extraSmall),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun MangaNotesTextAreaButton(
+    onClick: () -> Unit,
+    icon: ImageVector,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .clip(MaterialTheme.shapes.small)
+            .clickable(
+                onClick = onClick,
+                enabled = true,
+                role = Role.Button,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = icon.name,
+            tint = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .background(color = if (isSelected) MaterialTheme.colorScheme.onBackground else Color.Transparent)
+                .padding(MaterialTheme.padding.extraSmall),
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -47,6 +47,7 @@ fun MangaToolbar(
     onClickEditCategory: (() -> Unit)?,
     onClickRefresh: () -> Unit,
     onClickMigrate: (() -> Unit)?,
+    onClickEditNotes: () -> Unit,
     // SY -->
     onClickEditInfo: (() -> Unit)?,
     // KMK -->
@@ -182,6 +183,12 @@ fun MangaToolbar(
                             ),
                         )
                     }
+                    add(
+                        AppBar.OverflowAction(
+                            title = stringResource(MR.strings.action_notes),
+                            onClick = onClickEditNotes,
+                        ),
+                    )
                     // SY -->
                     if (onClickMerge != null) {
                         add(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
@@ -136,6 +136,7 @@ private fun Manga.toBackupManga(/* SY --> */customMangaInfo: CustomMangaInfo?/* 
         lastModifiedAt = this.lastModifiedAt,
         favoriteModifiedAt = this.favoriteModifiedAt,
         version = this.version,
+        notes = this.notes,
         // SY -->
     ).also { backupManga ->
         customMangaInfo?.let {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
@@ -38,8 +38,10 @@ data class BackupManga(
     @ProtoNumber(105) var updateStrategy: UpdateStrategy = UpdateStrategy.ALWAYS_UPDATE,
     @ProtoNumber(106) var lastModifiedAt: Long = 0,
     @ProtoNumber(107) var favoriteModifiedAt: Long? = null,
+    // Mihon values start here
     @ProtoNumber(108) var excludedScanlators: List<String> = emptyList(),
     @ProtoNumber(109) var version: Long = 0,
+    @ProtoNumber(110) var notes: String = "",
 
     // SY specific values
     @ProtoNumber(600) var mergedMangaReferences: List<BackupMergedMangaReference> = emptyList(),
@@ -77,6 +79,7 @@ data class BackupManga(
             lastModifiedAt = this@BackupManga.lastModifiedAt,
             favoriteModifiedAt = this@BackupManga.favoriteModifiedAt,
             version = this@BackupManga.version,
+            notes = this@BackupManga.notes,
         )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -167,6 +167,7 @@ class MangaRestorer(
                 updateStrategy = manga.updateStrategy.let(UpdateStrategyColumnAdapter::encode),
                 version = manga.version,
                 isSyncing = 1,
+                notes = manga.notes,
             )
         }
         return manga
@@ -567,7 +568,7 @@ class MangaRestorer(
         setCustomMangaInfo.set(mangaJson)
     }
 
-    fun BackupManga.getCustomMangaInfo(): CustomMangaInfo? {
+    private fun BackupManga.getCustomMangaInfo(): CustomMangaInfo? {
         if (customTitle != null ||
             customArtist != null ||
             customAuthor != null ||

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/MigrationFlags.kt
@@ -2,12 +2,12 @@ package eu.kanade.tachiyomi.ui.browse.migration
 
 object MigrationFlags {
 
-    const val CHAPTERS = 0b000001
-    const val CATEGORIES = 0b000010
-    const val TRACK = 0b000100
-    const val CUSTOM_COVER = 0b001000
-    const val EXTRA = 0b010000
-    const val DELETE_DOWNLOADED = 0b100000
+    const val CHAPTERS = 0b00001
+    const val CATEGORIES = 0b00010
+    const val TRACK = 0b00100
+    const val CUSTOM_COVER = 0b01000
+    const val DELETE_DOWNLOADED = 0b10000
+    const val EXTRA = 0b1000000
 
     fun hasChapters(value: Int): Boolean {
         return value and CHAPTERS != 0

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.ui.browse.migration.advanced.design
 
-import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.view.LayoutInflater
 import android.widget.CompoundButton
@@ -15,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.isVisible
 import eu.kanade.presentation.components.AdaptiveSheet
 import eu.kanade.presentation.theme.colorscheme.AndroidViewColorScheme
@@ -88,7 +88,7 @@ fun MigrationBottomSheetDialog(
                     backgroundTintList = colorScheme.editTextBackgroundTintList
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        textCursorDrawable = ColorDrawable(colorScheme.primary)
+                        textCursorDrawable = colorScheme.primary.toDrawable()
                         textSelectHandle?.let { drawable ->
                             drawable.setTint(colorScheme.primary)
                             setTextSelectHandle(drawable)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreenModel.kt
@@ -498,6 +498,10 @@ class MigrationListScreenModel(
                     .takeIf { migrateExtra },
                 // KMK <--
                 dateAdded = if (replace) oldManga.dateAdded else Instant.now().toEpochMilli(),
+                notes = oldManga.notes
+                    // KMK -->
+                    .takeIf { migrateExtra },
+                // KMK <--
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -79,6 +79,7 @@ import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.manga.merged.EditMergedSettingsDialog
+import eu.kanade.tachiyomi.ui.manga.notes.MangaNotesScreen
 import eu.kanade.tachiyomi.ui.manga.track.TrackInfoDialogHomeScreen
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.setting.SettingsScreen
@@ -370,6 +371,7 @@ class MangaScreen(
             },
             onMorePreviewsClicked = { openMorePagePreviews(navigator, successState.manga) },
             // SY <--
+            onEditNotesClicked = { navigator.push(MangaNotesScreen(manga = successState.manga)) },
             onMultiBookmarkClicked = screenModel::bookmarkChapters,
             onMultiMarkAsReadClicked = screenModel::markChaptersRead,
             onMarkPreviousAsReadClicked = screenModel::markPreviousChapterRead,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/notes/MangaNotesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/notes/MangaNotesScreen.kt
@@ -1,0 +1,61 @@
+package eu.kanade.tachiyomi.ui.manga.notes
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.manga.MangaNotesScreen
+import eu.kanade.presentation.util.Screen
+import kotlinx.coroutines.flow.update
+import tachiyomi.core.common.util.lang.launchNonCancellable
+import tachiyomi.domain.manga.interactor.UpdateMangaNotes
+import tachiyomi.domain.manga.model.Manga
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class MangaNotesScreen(
+    private val manga: Manga,
+) : Screen() {
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+
+        val screenModel = rememberScreenModel { Model(manga) }
+        val state by screenModel.state.collectAsState()
+
+        MangaNotesScreen(
+            state = state,
+            navigateUp = navigator::pop,
+            onUpdate = screenModel::updateNotes,
+        )
+    }
+
+    private class Model(
+        private val manga: Manga,
+        private val updateMangaNotes: UpdateMangaNotes = Injekt.get(),
+    ) : StateScreenModel<State>(State(manga, manga.notes)) {
+
+        fun updateNotes(content: String) {
+            if (content == state.value.notes) return
+
+            mutableState.update {
+                it.copy(notes = content)
+            }
+
+            screenModelScope.launchNonCancellable {
+                updateMangaNotes(manga.id, content)
+            }
+        }
+    }
+
+    @Immutable
+    data class State(
+        val manga: Manga,
+        val notes: String,
+    )
+}

--- a/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
@@ -35,6 +35,7 @@ object MangaMapper {
         version: Long,
         @Suppress("UNUSED_PARAMETER")
         isSyncing: Long,
+        notes: String,
     ): Manga = Manga(
         id = id,
         source = source,
@@ -61,6 +62,7 @@ object MangaMapper {
         lastModifiedAt = lastModifiedAt,
         favoriteModifiedAt = favoriteModifiedAt,
         version = version,
+        notes = notes,
     )
 
     fun mapLibraryManga(
@@ -92,6 +94,7 @@ object MangaMapper {
         favoriteModifiedAt: Long?,
         version: Long,
         isSyncing: Long,
+        notes: String,
         totalCount: Long,
         readCount: Double,
         latestUpload: Long,
@@ -128,6 +131,7 @@ object MangaMapper {
             favoriteModifiedAt,
             version,
             isSyncing,
+            notes,
         ),
         category = category,
         totalChapters = totalCount,

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -176,6 +176,7 @@ class MangaRepositoryImpl(
                     updateStrategy = value.updateStrategy?.let(UpdateStrategyColumnAdapter::encode),
                     version = value.version,
                     isSyncing = 0,
+                    notes = value.notes,
                 )
             }
         }

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -28,7 +28,8 @@ CREATE TABLE mangas(
     last_modified_at INTEGER NOT NULL DEFAULT 0,
     favorite_modified_at INTEGER,
     version INTEGER NOT NULL DEFAULT 0,
-    is_syncing INTEGER NOT NULL DEFAULT 0
+    is_syncing INTEGER NOT NULL DEFAULT 0,
+    notes TEXT NOT NULL DEFAULT ""
 );
 
 CREATE INDEX library_favorite_index ON mangas(favorite) WHERE favorite = 1;
@@ -187,7 +188,8 @@ UPDATE mangas SET
     update_strategy = coalesce(:updateStrategy, update_strategy),
     calculate_interval = coalesce(:calculateInterval, calculate_interval),
     version = coalesce(:version, version),
-    is_syncing = coalesce(:isSyncing, is_syncing)
+    is_syncing = coalesce(:isSyncing, is_syncing),
+    notes = coalesce(:notes, notes)
 WHERE _id = :mangaId;
 
 selectLastInsertedRowId:

--- a/data/src/main/sqldelight/tachiyomi/migrations/38.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/38.sqm
@@ -1,0 +1,3 @@
+-- Add notes column
+ALTER TABLE mangas
+ADD notes TEXT NOT NULL DEFAULT "";

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/UpdateMangaNotes.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/UpdateMangaNotes.kt
@@ -1,0 +1,18 @@
+package tachiyomi.domain.manga.interactor
+
+import tachiyomi.domain.manga.model.MangaUpdate
+import tachiyomi.domain.manga.repository.MangaRepository
+
+class UpdateMangaNotes(
+    private val mangaRepository: MangaRepository,
+) {
+
+    suspend operator fun invoke(mangaId: Long, notes: String): Boolean {
+        return mangaRepository.update(
+            MangaUpdate(
+                id = mangaId,
+                notes = notes,
+            ),
+        )
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
@@ -35,6 +35,7 @@ data class Manga(
     val lastModifiedAt: Long,
     val favoriteModifiedAt: Long?,
     val version: Long,
+    val notes: String,
 ) : Serializable {
 
     // SY -->
@@ -165,6 +166,7 @@ data class Manga(
             lastModifiedAt = 0L,
             favoriteModifiedAt = null,
             version = 0L,
+            notes = "",
         )
 
         // SY -->

--- a/domain/src/main/java/tachiyomi/domain/manga/model/MangaUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/MangaUpdate.kt
@@ -24,6 +24,7 @@ data class MangaUpdate(
     val updateStrategy: UpdateStrategy? = null,
     val initialized: Boolean? = null,
     val version: Long? = null,
+    val notes: String? = null,
     // SY -->
     val filteredScanlators: List<String>? = null,
     // SY <--
@@ -54,5 +55,6 @@ fun Manga.toMangaUpdate(): MangaUpdate {
         updateStrategy = updateStrategy,
         initialized = initialized,
         version = version,
+        notes = notes,
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,8 @@ natural-comparator = "com.github.gpanther:java-nat-sort:natural-comparator-1.1"
 richtext-commonmark = { module = "com.halilibo.compose-richtext:richtext-commonmark", version.ref = "richtext" }
 richtext-m3 = { module = "com.halilibo.compose-richtext:richtext-ui-material3", version.ref = "richtext" }
 
+richeditor-compose = "com.mohamedrejeb.richeditor:richeditor-compose:1.0.0-rc10"
+
 material = "com.google.android.material:material:1.12.0"
 flexible-adapter-core = "com.github.arkon.FlexibleAdapter:flexible-adapter:c8013533"
 photoview = "com.github.chrisbanes:PhotoView:2.3.0"

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -147,6 +147,8 @@
     <string name="action_move_to_top_all_for_series">Move series to top</string>
     <string name="action_move_to_bottom">Move to bottom</string>
     <string name="action_move_to_bottom_all_for_series">Move series to bottom</string>
+    <string name="action_notes">Notes</string>
+    <string name="action_edit_notes">Edit notes</string>
     <string name="action_install">Install</string>
     <string name="action_share">Share</string>
     <string name="action_save">Save</string>
@@ -985,4 +987,7 @@
     <string name="exception_http">HTTP %d, check website in WebView</string>
     <string name="exception_offline">No Internet connection</string>
     <string name="exception_unknown_host">Couldn\'t reach %s</string>
+
+    <!-- Notes screen -->
+    <string name="notes_placeholder">Enjoyed the part where…</string>
 </resources>


### PR DESCRIPTION
Co-authored-by: AntsyLich <59261191+AntsyLich@users.noreply.github.com>
(cherry picked from commit 8fbe630308b962043c7b59422878c94f80156e9f)

## Summary by Sourcery

Add user manga notes feature, allowing users to add and edit personal notes for individual manga

New Features:
- Implement a rich text editor for manga notes with support for basic formatting like bold, italic, underline, and lists
- Add ability to edit and save notes for individual manga

Enhancements:
- Create a new screen for editing manga notes
- Add notes section to manga details screen
- Implement character limit and formatting options for notes