### PR TITLE
Allow to top align the cover in manga info view

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -71,7 +71,7 @@ class UiPreferences(
 
     fun usePanoramaCoverMangaInfo() = preferenceStore.getBoolean("use_panorama_cover_manga_info", false)
 
-    fun verticallyCenterCover() = preferenceStore.getBoolean("vertically_center_cover", true)
+    fun topAlignCover() = preferenceStore.getBoolean("top_align_cover", false)
     // KMK <--
 
     fun recommendsInOverflow() = preferenceStore.getBoolean("recommends_in_overflow", false)

--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -70,6 +70,8 @@ class UiPreferences(
     fun usePanoramaCoverAlways() = preferenceStore.getBoolean("use_panorama_cover_grid", true)
 
     fun usePanoramaCoverMangaInfo() = preferenceStore.getBoolean("use_panorama_cover_manga_info", false)
+
+    fun verticallyCenterCover() = preferenceStore.getBoolean("vertically_center_cover", true)
     // KMK <--
 
     fun recommendsInOverflow() = preferenceStore.getBoolean("recommends_in_overflow", false)

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -571,11 +571,7 @@ private fun MangaAndSourceTitlesSmall(
                 modifier = Modifier
                     .sizeIn(maxHeight = 100.dp)
                     // KMK -->
-                    .apply {
-                        if (verticallyCenterCover) {
-                            this.align(Alignment.CenterVertically)
-                        }
-                    },
+                    .align(if (verticallyCenterCover) Alignment.CenterVertically else Alignment.Top),
                 // KMK <--
                 data = ImageRequest.Builder(LocalContext.current)
                     .data(manga)
@@ -597,11 +593,7 @@ private fun MangaAndSourceTitlesSmall(
                 modifier = Modifier
                     .sizeIn(maxWidth = 100.dp)
                     // KMK -->
-                    .apply {
-                        if (verticallyCenterCover) {
-                            this.align(Alignment.CenterVertically)
-                        }
-                    },
+                    .align(if (verticallyCenterCover) Alignment.CenterVertically else Alignment.Top),
                 // KMK <--
                 data = ImageRequest.Builder(LocalContext.current)
                     .data(manga)

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -127,7 +127,7 @@ fun MangaInfoBox(
 ) {
     // KMK -->
     val usePanoramaCover by Injekt.get<UiPreferences>().usePanoramaCoverMangaInfo().collectAsState()
-    val verticallyCenterCover by Injekt.get<UiPreferences>().verticallyCenterCover().collectAsState()
+    val topAlignCover by Injekt.get<UiPreferences>().topAlignCover().collectAsState()
     // KMK <--
     Box(modifier = modifier) {
         // Backdrop
@@ -185,7 +185,7 @@ fun MangaInfoBox(
                     onCoverLoaded = onCoverLoaded,
                     coverRatio = coverRatio,
                     usePanoramaCover = usePanoramaCover,
-                    verticallyCenterCover = verticallyCenterCover,
+                    topAlignCover = topAlignCover,
                     // KMK <--
                 )
             } else {
@@ -555,7 +555,7 @@ private fun MangaAndSourceTitlesSmall(
     onCoverLoaded: (DomainMangaCover) -> Unit,
     coverRatio: MutableFloatState,
     usePanoramaCover: Boolean = false,
-    verticallyCenterCover: Boolean = false,
+    topAlignCover: Boolean = false,
     // KMK <--
 ) {
     Row(
@@ -563,7 +563,7 @@ private fun MangaAndSourceTitlesSmall(
             .fillMaxWidth()
             .padding(start = 16.dp, top = appBarPadding + 16.dp, end = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalAlignment = if (verticallyCenterCover) Alignment.CenterVertically else Alignment.Top,
+        verticalAlignment = if (topAlignCover) Alignment.Top else Alignment.CenterVertically,
     ) {
         // KMK -->
         if (usePanoramaCover && coverRatio.floatValue <= RatioSwitchToPanorama) {
@@ -571,7 +571,7 @@ private fun MangaAndSourceTitlesSmall(
                 modifier = Modifier
                     .sizeIn(maxHeight = 100.dp)
                     // KMK -->
-                    .align(if (verticallyCenterCover) Alignment.CenterVertically else Alignment.Top),
+                    .align(if (topAlignCover) Alignment.Top else Alignment.CenterVertically),
                 // KMK <--
                 data = ImageRequest.Builder(LocalContext.current)
                     .data(manga)
@@ -593,7 +593,7 @@ private fun MangaAndSourceTitlesSmall(
                 modifier = Modifier
                     .sizeIn(maxWidth = 100.dp)
                     // KMK -->
-                    .align(if (verticallyCenterCover) Alignment.CenterVertically else Alignment.Top),
+                    .align(if (topAlignCover) Alignment.Top else Alignment.CenterVertically),
                 // KMK <--
                 data = ImageRequest.Builder(LocalContext.current)
                     .data(manga)

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -127,6 +127,7 @@ fun MangaInfoBox(
 ) {
     // KMK -->
     val usePanoramaCover by Injekt.get<UiPreferences>().usePanoramaCoverMangaInfo().collectAsState()
+    val verticallyCenterCover by Injekt.get<UiPreferences>().verticallyCenterCover().collectAsState()
     // KMK <--
     Box(modifier = modifier) {
         // Backdrop
@@ -184,6 +185,7 @@ fun MangaInfoBox(
                     onCoverLoaded = onCoverLoaded,
                     coverRatio = coverRatio,
                     usePanoramaCover = usePanoramaCover,
+                    verticallyCenterCover = verticallyCenterCover,
                     // KMK <--
                 )
             } else {
@@ -553,6 +555,7 @@ private fun MangaAndSourceTitlesSmall(
     onCoverLoaded: (DomainMangaCover) -> Unit,
     coverRatio: MutableFloatState,
     usePanoramaCover: Boolean = false,
+    verticallyCenterCover: Boolean = false,
     // KMK <--
 ) {
     Row(
@@ -560,7 +563,7 @@ private fun MangaAndSourceTitlesSmall(
             .fillMaxWidth()
             .padding(start = 16.dp, top = appBarPadding + 16.dp, end = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = if (verticallyCenterCover) Alignment.CenterVertically else Alignment.Top,
     ) {
         // KMK -->
         if (usePanoramaCover && coverRatio.floatValue <= RatioSwitchToPanorama) {
@@ -568,7 +571,11 @@ private fun MangaAndSourceTitlesSmall(
                 modifier = Modifier
                     .sizeIn(maxHeight = 100.dp)
                     // KMK -->
-                    .align(Alignment.CenterVertically),
+                    .apply {
+                        if (verticallyCenterCover) {
+                            this.align(Alignment.CenterVertically)
+                        }
+                    },
                 // KMK <--
                 data = ImageRequest.Builder(LocalContext.current)
                     .data(manga)
@@ -590,7 +597,11 @@ private fun MangaAndSourceTitlesSmall(
                 modifier = Modifier
                     .sizeIn(maxWidth = 100.dp)
                     // KMK -->
-                    .align(Alignment.CenterVertically),
+                    .apply {
+                        if (verticallyCenterCover) {
+                            this.align(Alignment.CenterVertically)
+                        }
+                    },
                 // KMK <--
                 data = ImageRequest.Builder(LocalContext.current)
                     .data(manga)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -205,9 +205,9 @@ object SettingsAppearanceScreen : SearchableSettings {
                     subtitle = stringResource(KMR.strings.pref_panorama_cover_summary),
                 ),
                 Preference.PreferenceItem.SwitchPreference(
-                    preference = uiPreferences.verticallyCenterCover(),
-                    title = stringResource(KMR.strings.pref_vertically_center_cover),
-                    subtitle = stringResource(KMR.strings.pref_vertically_center_cover_summary),
+                    preference = uiPreferences.topAlignCover(),
+                    title = stringResource(KMR.strings.pref_top_align_cover),
+                    subtitle = stringResource(KMR.strings.pref_top_align_cover_summary),
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -204,6 +204,11 @@ object SettingsAppearanceScreen : SearchableSettings {
                     title = stringResource(KMR.strings.pref_panorama_cover),
                     subtitle = stringResource(KMR.strings.pref_panorama_cover_summary),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.verticallyCenterCover(),
+                    title = stringResource(KMR.strings.pref_vertically_center_cover),
+                    subtitle = stringResource(KMR.strings.pref_vertically_center_cover_summary),
+                ),
             ),
         )
     }

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -38,6 +38,8 @@
     <string name="pref_panorama_cover_summary">Show cover in landscape mode if it\'s a wide image</string>
     <string name="pref_panorama_cover_flow">Panorama Cover Flow</string>
     <string name="pref_panorama_cover_flow_summary">Show panorama cover in Global Search &amp; Suggestions</string>
+    <string name="pref_vertically_center_cover">Vertically center cover</string>
+    <string name="pref_vertically_center_cover_summary">Show the cover vertically centered alongside manga info</string>
     <string name="action_display_comfortable_grid_panorama">Panorama comfortable grid</string>
     <string name="pref_expand_related_mangas">Expand Suggestions</string>
     <string name="pref_expand_related_mangas_summary">If turned off, Suggestions won\'t automatically load &amp; show expanded</string>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -38,8 +38,8 @@
     <string name="pref_panorama_cover_summary">Show cover in landscape mode if it\'s a wide image</string>
     <string name="pref_panorama_cover_flow">Panorama Cover Flow</string>
     <string name="pref_panorama_cover_flow_summary">Show panorama cover in Global Search &amp; Suggestions</string>
-    <string name="pref_vertically_center_cover">Vertically center cover</string>
-    <string name="pref_vertically_center_cover_summary">Show the cover vertically centered alongside manga info</string>
+    <string name="pref_top_align_cover">Align Cover to Top</string>
+    <string name="pref_top_align_cover_summary">Show the cover aligned to the top alongside manga info</string>
     <string name="action_display_comfortable_grid_panorama">Panorama comfortable grid</string>
     <string name="pref_expand_related_mangas">Expand Suggestions</string>
     <string name="pref_expand_related_mangas_summary">If turned off, Suggestions won\'t automatically load &amp; show expanded</string>


### PR DESCRIPTION
Adds an option to align the cover to the top in the manga info view.

![settings](https://github.com/user-attachments/assets/1a65de2a-72ad-403b-807c-fc740c32acdb)

### Images
| Disabled (Vertical center, default) | Enable (Top) |
| ------- | ------- |
| ![](https://github.com/user-attachments/assets/dea09ecd-6e05-406b-b5f6-6de539d42dd7) | ![](https://github.com/user-attachments/assets/af0b79ea-a627-48d4-8203-8fb2dd45c3d9) |

## Summary by Sourcery

Add a user preference to control vertical alignment of manga cover images in the manga info view

New Features:
- Introduce a toggle to choose between vertically centering the cover image or aligning it to the top in the manga info view

Enhancements:
- Modify manga info view layout to support flexible cover image vertical alignment

Documentation:
- Add localized strings for the new vertical cover alignment preference