### PR TITLE
Allow `migrate` mangas when using `Bulk-favorite`

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourceFeedScreen.kt
@@ -17,13 +17,13 @@ import eu.kanade.presentation.browse.components.GlobalSearchCardRow
 import eu.kanade.presentation.browse.components.GlobalSearchErrorResultItem
 import eu.kanade.presentation.browse.components.GlobalSearchLoadingResultItem
 import eu.kanade.presentation.browse.components.GlobalSearchResultItem
+import eu.kanade.presentation.browse.components.bulkSelectionButton
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.AppBarTitle
 import eu.kanade.presentation.components.BulkSelectionToolbar
 import eu.kanade.presentation.components.SearchToolbar
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
-import eu.kanade.tachiyomi.ui.browse.bulkSelectionButton
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.domain.manga.model.Manga

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceSimpleToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceSimpleToolbar.kt
@@ -14,7 +14,6 @@ import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.DropdownMenu
 import eu.kanade.presentation.components.RadioMenuItem
-import eu.kanade.tachiyomi.ui.browse.bulkSelectionButton
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.i18n.MR

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceToolbar.kt
@@ -20,7 +20,6 @@ import eu.kanade.presentation.components.RadioMenuItem
 import eu.kanade.presentation.components.SearchToolbar
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.Source
-import eu.kanade.tachiyomi.ui.browse.bulkSelectionButton
 import exh.source.anyIs
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.domain.library.model.LibraryDisplayMode

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
@@ -1,0 +1,201 @@
+package eu.kanade.presentation.browse.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Checklist
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import cafe.adriel.voyager.navigator.LocalNavigator
+import eu.kanade.presentation.category.components.ChangeCategoryDialog
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.presentation.manga.DuplicateMangaDialog
+import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
+import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel.Dialog
+import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialog
+import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialogScreenModel
+import eu.kanade.tachiyomi.ui.category.CategoryScreen
+import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.i18n.stringResource
+
+/**
+ * Compose to shows the bulk favorite dialogs.
+ *
+ * @param bulkFavoriteScreenModel the screen model.
+ * @param dialog the dialog to show.
+ */
+@Composable
+fun BulkFavoriteDialogs(
+    bulkFavoriteScreenModel: BulkFavoriteScreenModel,
+    dialog: Dialog?,
+) {
+    when (dialog) {
+        /* Bulk-favorite actions */
+        is Dialog.ChangeMangasCategory ->
+            ChangeMangasCategoryDialog(
+                bulkFavoriteScreenModel,
+                onConfirm = { include, exclude ->
+                    bulkFavoriteScreenModel.setMangasCategories(dialog.mangas, include, exclude)
+                },
+            )
+
+        is Dialog.BulkAllowDuplicate ->
+            BulkAllowDuplicateDialog(bulkFavoriteScreenModel)
+
+        /* Single-favorite actions for screens originally don't have it */
+        is Dialog.AddDuplicateManga ->
+            AddDuplicateMangaDialog(bulkFavoriteScreenModel)
+
+        is Dialog.RemoveManga ->
+            RemoveMangaDialog(bulkFavoriteScreenModel)
+
+        is Dialog.Migrate ->
+            ShowMigrateDialog(bulkFavoriteScreenModel)
+
+        else -> {}
+    }
+}
+
+@Composable
+private fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+    val navigator = LocalNavigator.current
+    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
+    val dialog = bulkFavoriteState.dialog as Dialog.Migrate
+
+    bulkFavoriteScreenModel.stopRunning()
+
+    MigrateDialog(
+        oldManga = dialog.oldManga,
+        newManga = dialog.newManga,
+        screenModel = MigrateDialogScreenModel(),
+        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
+        onClickTitle = { navigator?.push(MangaScreen(dialog.oldManga.id)) },
+        onPopScreen = {
+            bulkFavoriteScreenModel.toggleSelection(dialog.newManga, toSelectedState = false)
+            bulkFavoriteScreenModel.dismissDialog()
+            when {
+                // `selectionMode` is current state before calling above `toggleSelection`
+                !bulkFavoriteState.selectionMode -> {
+                    navigator?.push(MangaScreen(dialog.newManga.id))
+                }
+                // `selection.size` is at current value before calling above `toggleSelection`
+                bulkFavoriteState.selection.size > 1 -> {
+                    // Continue adding favorites
+                    bulkFavoriteScreenModel.addFavorite()
+                }
+            }
+        },
+    )
+}
+
+/**
+ * Shows dialog to add a single manga to library when there are duplicates.
+ *
+ * @param bulkFavoriteScreenModel the screen model.
+ */
+@Composable
+private fun AddDuplicateMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+    val navigator = LocalNavigator.current
+    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
+    val dialog = bulkFavoriteState.dialog as Dialog.AddDuplicateManga
+
+    bulkFavoriteScreenModel.stopRunning()
+
+    DuplicateMangaDialog(
+        duplicates = dialog.duplicates,
+        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
+        onConfirm = {
+            if (bulkFavoriteState.selectionMode) {
+                bulkFavoriteScreenModel.toggleSelectionMode()
+            }
+            bulkFavoriteScreenModel.addFavorite(dialog.manga)
+        },
+        onOpenManga = { navigator?.push(MangaScreen(it.id)) },
+        onMigrate = {
+            bulkFavoriteScreenModel.showMigrateDialog(
+                manga = dialog.manga,
+                duplicate = it,
+            )
+        },
+    )
+}
+
+@Composable
+private fun RemoveMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
+    val dialog = bulkFavoriteState.dialog as Dialog.RemoveManga
+
+    RemoveMangaDialog(
+        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
+        onConfirm = {
+            bulkFavoriteScreenModel.changeMangaFavorite(dialog.manga)
+        },
+        mangaToRemove = dialog.manga,
+    )
+}
+
+@Composable
+private fun ChangeMangasCategoryDialog(
+    bulkFavoriteScreenModel: BulkFavoriteScreenModel,
+    onConfirm: (List<Long>, List<Long>) -> Unit,
+) {
+    val navigator = LocalNavigator.current
+    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
+    val dialog = bulkFavoriteState.dialog as Dialog.ChangeMangasCategory
+
+    ChangeCategoryDialog(
+        initialSelection = dialog.initialSelection,
+        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
+        onEditCategories = { navigator?.push(CategoryScreen()) },
+        onConfirm = onConfirm,
+    )
+}
+
+/**
+ * Shows dialog to bulk allow/skip or migrate multiple manga to library when there are duplicates.
+ *
+ * @param bulkFavoriteScreenModel the screen model.
+ */
+@Composable
+private fun BulkAllowDuplicateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+    val navigator = LocalNavigator.current
+    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
+    val dialog = bulkFavoriteState.dialog as Dialog.BulkAllowDuplicate
+
+    DuplicateMangaDialog(
+        duplicates = dialog.duplicates,
+        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
+        onConfirm = {
+            bulkFavoriteScreenModel.addFavorite(startIdx = dialog.currentIdx + 1)
+        },
+        onOpenManga = { navigator?.push(MangaScreen(it.id)) },
+        onMigrate = {
+            bulkFavoriteScreenModel.showMigrateDialog(
+                manga = dialog.manga,
+                duplicate = it,
+            )
+        },
+        bulkFavoriteManga = dialog.manga,
+        onAllowAllDuplicate = bulkFavoriteScreenModel::addFavoriteDuplicate,
+        onSkipAllDuplicate = {
+            bulkFavoriteScreenModel.addFavoriteDuplicate(skipAllDuplicates = true)
+        },
+        onSkipDuplicate = {
+            bulkFavoriteScreenModel.removeDuplicateSelectedManga(index = dialog.currentIdx)
+            bulkFavoriteScreenModel.addFavorite(startIdx = dialog.currentIdx)
+        },
+        stopRunning = bulkFavoriteScreenModel::stopRunning,
+    )
+}
+
+@Composable
+fun bulkSelectionButton(
+    isRunning: Boolean,
+    toggleSelectionMode: () -> Unit,
+) = AppBar.Action(
+    title = stringResource(KMR.strings.action_bulk_select),
+    icon = Icons.Outlined.Checklist,
+    iconTint = MaterialTheme.colorScheme.primary.takeIf { isRunning },
+    onClick = toggleSelectionMode,
+)

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
@@ -115,16 +115,10 @@ private fun ShowMigrateDialog(
         onPopScreen = {
             toggleSelection(dialog.newManga, false)
             onDismiss()
-            when {
-                // `selectionMode` is current state before calling above `toggleSelection`
-                !state.selectionMode -> {
-                    navigator?.push(MangaScreen(dialog.newManga.id))
-                }
-                // `selection.size` is at current value before calling above `toggleSelection`
-                state.selection.size > 1 -> {
-                    // Continue adding favorites
-                    addFavorite()
-                }
+            // `selection.size` is at current value before calling above `toggleSelection`
+            if (state.selection.size > 1) {
+                // Continue adding favorites
+                addFavorite()
             }
         },
     )

--- a/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/GlobalSearchToolbar.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.SearchToolbar
-import eu.kanade.tachiyomi.ui.browse.bulkSelectionButton
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.i18n.MR

--- a/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
@@ -184,7 +184,7 @@ fun DuplicateMangaDialog(
                                 },
                                 Modifier.align(Alignment.CenterHorizontally),
                             ) {
-                                Text(text = stringResource(KMR.strings.action_allow_duplicate_manga))
+                                Text(text = stringResource(MR.strings.action_add_anyway))
                             }
 
                             TextButton(

--- a/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
@@ -147,12 +147,7 @@ fun DuplicateMangaDialog(
                     DuplicateMangaListItem(
                         manga = it,
                         getSource = { sourceManager.getOrStub(it.source) },
-                        onMigrate = {
-                            // KMK -->
-                            if (bulkFavoriteManga == null) onDismissRequest()
-                            // KMK <--
-                            onMigrate(it)
-                        },
+                        onMigrate = { onMigrate(it) },
                         onOpenManga = { onOpenManga(it) },
                     )
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -496,11 +496,10 @@ fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
         onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
         onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
         onPopScreen = {
+            bulkFavoriteScreenModel.toggleSelection(dialog.newManga, toSelectedState = false)
+            bulkFavoriteScreenModel.dismissDialog()
             if (!dialog.isBulkFavorite) {
                 bulkFavoriteScreenModel.toggleSelection(dialog.newManga, toSelectedState = false)
-                bulkFavoriteScreenModel.dismissDialog()
-                navigator.push(MangaScreen(dialog.newManga.id))
-            } else {
             }
         },
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -1,12 +1,6 @@
 package eu.kanade.tachiyomi.ui.browse
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Checklist
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.util.fastAny
@@ -15,20 +9,11 @@ import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachIndexed
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
-import cafe.adriel.voyager.navigator.LocalNavigator
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.track.interactor.AddTracks
-import eu.kanade.presentation.browse.components.RemoveMangaDialog
-import eu.kanade.presentation.category.components.ChangeCategoryDialog
-import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.BulkSelectionToolbar
 import eu.kanade.presentation.manga.DuplicateMangaDialog
 import eu.kanade.tachiyomi.data.cache.CoverCache
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel.Dialog
-import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialog
-import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialogScreenModel
-import eu.kanade.tachiyomi.ui.category.CategoryScreen
-import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.util.removeCovers
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.PersistentList
@@ -52,8 +37,6 @@ import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.toMangaUpdate
 import tachiyomi.domain.source.service.SourceManager
-import tachiyomi.i18n.kmk.KMR
-import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.time.Instant
@@ -437,184 +420,3 @@ class BulkFavoriteScreenModel(
         val isRunning: Boolean = false,
     )
 }
-
-/**
- * Compose to shows the bulk favorite dialogs.
- *
- * @param bulkFavoriteScreenModel the screen model.
- * @param dialog the dialog to show.
- */
-@Composable
-fun BulkFavoriteDialogs(
-    bulkFavoriteScreenModel: BulkFavoriteScreenModel,
-    dialog: Dialog?,
-) {
-    when (dialog) {
-        /* Bulk-favorite actions */
-        is Dialog.ChangeMangasCategory ->
-            ChangeMangasCategoryDialog(
-                bulkFavoriteScreenModel,
-                onConfirm = { include, exclude ->
-                    bulkFavoriteScreenModel.setMangasCategories(dialog.mangas, include, exclude)
-                },
-            )
-
-        is Dialog.BulkAllowDuplicate ->
-            BulkAllowDuplicateDialog(bulkFavoriteScreenModel)
-
-        /* Single-favorite actions for screens originally don't have it */
-        is Dialog.AddDuplicateManga ->
-            AddDuplicateMangaDialog(bulkFavoriteScreenModel)
-
-        is Dialog.RemoveManga ->
-            RemoveMangaDialog(bulkFavoriteScreenModel)
-
-        is Dialog.Migrate ->
-            ShowMigrateDialog(bulkFavoriteScreenModel)
-
-        else -> {}
-    }
-}
-
-@Composable
-private fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
-    val navigator = LocalNavigator.current
-    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
-    val dialog = bulkFavoriteState.dialog as Dialog.Migrate
-
-    bulkFavoriteScreenModel.stopRunning()
-
-    MigrateDialog(
-        oldManga = dialog.oldManga,
-        newManga = dialog.newManga,
-        screenModel = MigrateDialogScreenModel(),
-        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
-        onClickTitle = { navigator?.push(MangaScreen(dialog.oldManga.id)) },
-        onPopScreen = {
-            bulkFavoriteScreenModel.toggleSelection(dialog.newManga, toSelectedState = false)
-            bulkFavoriteScreenModel.dismissDialog()
-            when {
-                // `selectionMode` is current state before calling above `toggleSelection`
-                !bulkFavoriteState.selectionMode -> {
-                    navigator?.push(MangaScreen(dialog.newManga.id))
-                }
-                // `selection.size` is at current value before calling above `toggleSelection`
-                bulkFavoriteState.selection.size > 1 -> {
-                    // Continue adding favorites
-                    bulkFavoriteScreenModel.addFavorite()
-                }
-            }
-        },
-    )
-}
-
-/**
- * Shows dialog to add a single manga to library when there are duplicates.
- *
- * @param bulkFavoriteScreenModel the screen model.
- */
-@Composable
-private fun AddDuplicateMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
-    val navigator = LocalNavigator.current
-    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
-    val dialog = bulkFavoriteState.dialog as Dialog.AddDuplicateManga
-
-    bulkFavoriteScreenModel.stopRunning()
-
-    DuplicateMangaDialog(
-        duplicates = dialog.duplicates,
-        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
-        onConfirm = {
-            if (bulkFavoriteState.selectionMode) {
-                bulkFavoriteScreenModel.toggleSelectionMode()
-            }
-            bulkFavoriteScreenModel.addFavorite(dialog.manga)
-        },
-        onOpenManga = { navigator?.push(MangaScreen(it.id)) },
-        onMigrate = {
-            bulkFavoriteScreenModel.showMigrateDialog(
-                manga = dialog.manga,
-                duplicate = it,
-            )
-        },
-    )
-}
-
-@Composable
-private fun RemoveMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
-    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
-    val dialog = bulkFavoriteState.dialog as Dialog.RemoveManga
-
-    RemoveMangaDialog(
-        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
-        onConfirm = {
-            bulkFavoriteScreenModel.changeMangaFavorite(dialog.manga)
-        },
-        mangaToRemove = dialog.manga,
-    )
-}
-
-@Composable
-private fun ChangeMangasCategoryDialog(
-    bulkFavoriteScreenModel: BulkFavoriteScreenModel,
-    onConfirm: (List<Long>, List<Long>) -> Unit,
-) {
-    val navigator = LocalNavigator.current
-    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
-    val dialog = bulkFavoriteState.dialog as Dialog.ChangeMangasCategory
-
-    ChangeCategoryDialog(
-        initialSelection = dialog.initialSelection,
-        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
-        onEditCategories = { navigator?.push(CategoryScreen()) },
-        onConfirm = onConfirm,
-    )
-}
-
-/**
- * Shows dialog to bulk allow/skip or migrate multiple manga to library when there are duplicates.
- *
- * @param bulkFavoriteScreenModel the screen model.
- */
-@Composable
-private fun BulkAllowDuplicateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
-    val navigator = LocalNavigator.current
-    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
-    val dialog = bulkFavoriteState.dialog as Dialog.BulkAllowDuplicate
-
-    DuplicateMangaDialog(
-        duplicates = dialog.duplicates,
-        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
-        onConfirm = {
-            bulkFavoriteScreenModel.addFavorite(startIdx = dialog.currentIdx + 1)
-        },
-        onOpenManga = { navigator?.push(MangaScreen(it.id)) },
-        onMigrate = {
-            bulkFavoriteScreenModel.showMigrateDialog(
-                manga = dialog.manga,
-                duplicate = it,
-            )
-        },
-        bulkFavoriteManga = dialog.manga,
-        onAllowAllDuplicate = bulkFavoriteScreenModel::addFavoriteDuplicate,
-        onSkipAllDuplicate = {
-            bulkFavoriteScreenModel.addFavoriteDuplicate(skipAllDuplicates = true)
-        },
-        onSkipDuplicate = {
-            bulkFavoriteScreenModel.removeDuplicateSelectedManga(index = dialog.currentIdx)
-            bulkFavoriteScreenModel.addFavorite(startIdx = dialog.currentIdx)
-        },
-        stopRunning = bulkFavoriteScreenModel::stopRunning,
-    )
-}
-
-@Composable
-fun bulkSelectionButton(
-    isRunning: Boolean,
-    toggleSelectionMode: () -> Unit,
-) = AppBar.Action(
-    title = stringResource(KMR.strings.action_bulk_select),
-    icon = Icons.Outlined.Checklist,
-    iconTint = MaterialTheme.colorScheme.primary.takeIf { isRunning },
-    onClick = toggleSelectionMode,
-)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -196,7 +196,7 @@ class BulkFavoriteScreenModel(
                         }
                         .toImmutableList()
                     stopRunning()
-                    setDialog(Dialog.ChangeMangaCategory(mangaList, preselected))
+                    setDialog(Dialog.ChangeMangasCategory(mangaList, preselected))
                 }
             }
         }
@@ -367,7 +367,7 @@ class BulkFavoriteScreenModel(
                 else -> {
                     val preselectedIds = getCategories.await(manga.id).map { it.id }
                     setDialog(
-                        Dialog.ChangeMangaCategory(
+                        Dialog.ChangeMangasCategory(
                             listOf(manga),
                             categories.mapAsCheckboxState { it.id in preselectedIds }.toImmutableList(),
                         ),
@@ -419,12 +419,12 @@ class BulkFavoriteScreenModel(
         }
     }
 
-    interface Dialog {
+    sealed interface Dialog {
         data class Migrate(val newManga: Manga, val oldManga: Manga) : Dialog
         data class AddDuplicateManga(val manga: Manga, val duplicates: List<Manga>) : Dialog
         data class BulkAllowDuplicate(val manga: Manga, val duplicates: List<Manga>, val currentIdx: Int) : Dialog
         data class RemoveManga(val manga: Manga) : Dialog
-        data class ChangeMangaCategory(
+        data class ChangeMangasCategory(
             val mangas: List<Manga>,
             val initialSelection: ImmutableList<CheckboxState<Category>>,
         ) : Dialog
@@ -452,8 +452,8 @@ fun BulkFavoriteDialogs(
 ) {
     when (dialog) {
         /* Bulk-favorite actions */
-        is Dialog.ChangeMangaCategory ->
-            ChangeMangaCategoryDialog(
+        is Dialog.ChangeMangasCategory ->
+            ChangeMangasCategoryDialog(
                 bulkFavoriteScreenModel,
                 onConfirm = { include, exclude ->
                     bulkFavoriteScreenModel.setMangasCategories(dialog.mangas, include, exclude)
@@ -472,6 +472,8 @@ fun BulkFavoriteDialogs(
 
         is Dialog.Migrate ->
             ShowMigrateDialog(bulkFavoriteScreenModel)
+
+        else -> {}
     }
 }
 
@@ -554,13 +556,13 @@ private fun RemoveMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) 
 }
 
 @Composable
-private fun ChangeMangaCategoryDialog(
+private fun ChangeMangasCategoryDialog(
     bulkFavoriteScreenModel: BulkFavoriteScreenModel,
     onConfirm: (List<Long>, List<Long>) -> Unit,
 ) {
     val navigator = LocalNavigator.currentOrThrow
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
-    val dialog = bulkFavoriteState.dialog as Dialog.ChangeMangaCategory
+    val dialog = bulkFavoriteState.dialog as Dialog.ChangeMangasCategory
 
     ChangeCategoryDialog(
         initialSelection = dialog.initialSelection,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -293,7 +293,7 @@ class BulkFavoriteScreenModel(
      *
      * @return List of categories, not including the default category
      */
-    internal suspend fun getCategories(): List<Category> {
+    private suspend fun getCategories(): List<Category> {
         return getCategories.subscribe()
             .firstOrNull()
             ?.filterNot { it.isSystemCategory }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -136,6 +136,9 @@ class BulkFavoriteScreenModel(
     /**
      * Add mangas to library if there is default category or no category exists.
      * If not, it shows the categories list.
+     *
+     * @param skipAllDuplicates if true, skip all duplicates and add all selected mangas to library.
+     * if false, allow all duplicates and add all selected mangas to library
      */
     internal fun addFavoriteDuplicate(skipAllDuplicates: Boolean = false) {
         screenModelScope.launch {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -453,7 +453,7 @@ fun BulkFavoriteDialogs(
                 bulkFavoriteScreenModel,
                 onConfirm = { include, exclude ->
                     bulkFavoriteScreenModel.setMangasCategories(dialog.mangas, include, exclude)
-                }
+                },
             )
 
         is Dialog.BulkAllowDuplicate ->
@@ -472,7 +472,7 @@ fun BulkFavoriteDialogs(
                 onConfirm = { include, _ ->
                     bulkFavoriteScreenModel.changeMangaFavorite(dialog.manga)
                     bulkFavoriteScreenModel.moveMangaToCategories(dialog.manga, include)
-                }
+                },
             )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -97,10 +97,13 @@ class BulkFavoriteScreenModel(
     fun toggleSelection(manga: Manga, toSelectedState: Boolean? = null) {
         mutableState.update { state ->
             val newSelection = state.selection.mutate { list ->
-                if (toSelectedState != true && list.fastAny { it.id == manga.id }) {
-                    list.removeAll { it.id == manga.id }
-                } else if (toSelectedState != false && list.none { it.id == manga.id }) {
+                val isSelected = list.fastAny { it.id == manga.id }
+                val shouldSelect = toSelectedState ?: !isSelected
+                // Both condition to avoid adding duplicate entries
+                if (shouldSelect && !isSelected) {
                     list.add(manga)
+                } else if (!shouldSelect && isSelected) {
+                    list.removeAll { it.id == manga.id }
                 }
             }
             state.copy(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -449,7 +449,12 @@ fun BulkFavoriteDialogs(
     when (dialog) {
         /* Bulk-favorite actions */
         is Dialog.ChangeMangasCategory ->
-            ChangeMangasCategoryDialog(bulkFavoriteScreenModel)
+            ChangeMangaCategoryDialog(
+                bulkFavoriteScreenModel,
+                onConfirm = { include, exclude ->
+                    bulkFavoriteScreenModel.setMangasCategories(dialog.mangas, include, exclude)
+                }
+            )
 
         is Dialog.BulkAllowDuplicate ->
             BulkAllowDuplicateDialog(bulkFavoriteScreenModel)
@@ -462,7 +467,13 @@ fun BulkFavoriteDialogs(
             RemoveMangaDialog(bulkFavoriteScreenModel)
 
         is Dialog.ChangeMangaCategory ->
-            ChangeMangaCategoryDialog(bulkFavoriteScreenModel)
+            ChangeMangaCategoryDialog(
+                bulkFavoriteScreenModel,
+                onConfirm = { include, _ ->
+                    bulkFavoriteScreenModel.changeMangaFavorite(dialog.manga)
+                    bulkFavoriteScreenModel.moveMangaToCategories(dialog.manga, include)
+                }
+            )
     }
 }
 
@@ -515,7 +526,10 @@ fun RemoveMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
 }
 
 @Composable
-fun ChangeMangaCategoryDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+fun ChangeMangaCategoryDialog(
+    bulkFavoriteScreenModel: BulkFavoriteScreenModel,
+    onConfirm: (List<Long>, List<Long>) -> Unit,
+) {
     val navigator = LocalNavigator.currentOrThrow
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.ChangeMangaCategory
@@ -524,26 +538,7 @@ fun ChangeMangaCategoryDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) 
         initialSelection = dialog.initialSelection,
         onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
         onEditCategories = { navigator.push(CategoryScreen()) },
-        onConfirm = { include, _ ->
-            bulkFavoriteScreenModel.changeMangaFavorite(dialog.manga)
-            bulkFavoriteScreenModel.moveMangaToCategories(dialog.manga, include)
-        },
-    )
-}
-
-@Composable
-fun ChangeMangasCategoryDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
-    val navigator = LocalNavigator.currentOrThrow
-    val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
-    val dialog = bulkFavoriteState.dialog as Dialog.ChangeMangasCategory
-
-    ChangeCategoryDialog(
-        initialSelection = dialog.initialSelection,
-        onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
-        onEditCategories = { navigator.push(CategoryScreen()) },
-        onConfirm = { include, exclude ->
-            bulkFavoriteScreenModel.setMangasCategories(dialog.mangas, include, exclude)
-        },
+        onConfirm = onConfirm,
     )
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.util.fastForEachIndexed
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import cafe.adriel.voyager.navigator.LocalNavigator
-import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.track.interactor.AddTracks
 import eu.kanade.presentation.browse.components.RemoveMangaDialog
@@ -479,7 +478,7 @@ fun BulkFavoriteDialogs(
 
 @Composable
 private fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
-    val navigator = LocalNavigator.currentOrThrow
+    val navigator = LocalNavigator.current
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.Migrate
 
@@ -490,14 +489,14 @@ private fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) 
         newManga = dialog.newManga,
         screenModel = MigrateDialogScreenModel(),
         onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
-        onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
+        onClickTitle = { navigator?.push(MangaScreen(dialog.oldManga.id)) },
         onPopScreen = {
             bulkFavoriteScreenModel.toggleSelection(dialog.newManga, toSelectedState = false)
             bulkFavoriteScreenModel.dismissDialog()
             when {
                 // `selectionMode` is current state before calling above `toggleSelection`
                 !bulkFavoriteState.selectionMode -> {
-                    navigator.push(MangaScreen(dialog.newManga.id))
+                    navigator?.push(MangaScreen(dialog.newManga.id))
                 }
                 // `selection.size` is at current value before calling above `toggleSelection`
                 bulkFavoriteState.selection.size > 1 -> {
@@ -516,7 +515,7 @@ private fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) 
  */
 @Composable
 private fun AddDuplicateMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
-    val navigator = LocalNavigator.currentOrThrow
+    val navigator = LocalNavigator.current
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.AddDuplicateManga
 
@@ -531,7 +530,7 @@ private fun AddDuplicateMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenM
             }
             bulkFavoriteScreenModel.addFavorite(dialog.manga)
         },
-        onOpenManga = { navigator.push(MangaScreen(it.id)) },
+        onOpenManga = { navigator?.push(MangaScreen(it.id)) },
         onMigrate = {
             bulkFavoriteScreenModel.showMigrateDialog(
                 manga = dialog.manga,
@@ -560,14 +559,14 @@ private fun ChangeMangasCategoryDialog(
     bulkFavoriteScreenModel: BulkFavoriteScreenModel,
     onConfirm: (List<Long>, List<Long>) -> Unit,
 ) {
-    val navigator = LocalNavigator.currentOrThrow
+    val navigator = LocalNavigator.current
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.ChangeMangasCategory
 
     ChangeCategoryDialog(
         initialSelection = dialog.initialSelection,
         onDismissRequest = bulkFavoriteScreenModel::dismissDialog,
-        onEditCategories = { navigator.push(CategoryScreen()) },
+        onEditCategories = { navigator?.push(CategoryScreen()) },
         onConfirm = onConfirm,
     )
 }
@@ -579,7 +578,7 @@ private fun ChangeMangasCategoryDialog(
  */
 @Composable
 private fun BulkAllowDuplicateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
-    val navigator = LocalNavigator.currentOrThrow
+    val navigator = LocalNavigator.current
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.BulkAllowDuplicate
 
@@ -589,7 +588,7 @@ private fun BulkAllowDuplicateDialog(bulkFavoriteScreenModel: BulkFavoriteScreen
         onConfirm = {
             bulkFavoriteScreenModel.addFavorite(startIdx = dialog.currentIdx + 1)
         },
-        onOpenManga = { navigator.push(MangaScreen(it.id)) },
+        onOpenManga = { navigator?.push(MangaScreen(it.id)) },
         onMigrate = {
             bulkFavoriteScreenModel.showMigrateDialog(
                 manga = dialog.manga,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -499,7 +499,7 @@ private fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) 
             bulkFavoriteScreenModel.toggleSelection(dialog.newManga, toSelectedState = false)
             bulkFavoriteScreenModel.dismissDialog()
             if (!dialog.isBulkFavorite) {
-                bulkFavoriteScreenModel.toggleSelection(dialog.newManga, toSelectedState = false)
+                navigator.push(MangaScreen(dialog.newManga.id))
             }
         },
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -152,7 +152,7 @@ class BulkFavoriteScreenModel(
      * Add mangas to library if there is default category or no category exists.
      * If not, it shows the categories list.
      */
-    fun addFavoriteDuplicate(skipAllDuplicates: Boolean = false) {
+    internal fun addFavoriteDuplicate(skipAllDuplicates: Boolean = false) {
         screenModelScope.launch {
             val mangaList = if (skipAllDuplicates) getNotDuplicateLibraryMangas() else state.value.selection
             if (mangaList.isEmpty()) {
@@ -216,7 +216,7 @@ class BulkFavoriteScreenModel(
         return null
     }
 
-    fun removeDuplicateSelectedManga(index: Int) {
+    internal fun removeDuplicateSelectedManga(index: Int) {
         mutableState.update { state ->
             val newSelection = state.selection.mutate { list ->
                 list.removeAt(index)
@@ -232,7 +232,7 @@ class BulkFavoriteScreenModel(
      * @param addCategories the categories to add for all mangas.
      * @param removeCategories the categories to remove in all mangas.
      */
-    fun setMangasCategories(mangaList: List<Manga>, addCategories: List<Long>, removeCategories: List<Long>) {
+    internal fun setMangasCategories(mangaList: List<Manga>, addCategories: List<Long>, removeCategories: List<Long>) {
         screenModelScope.launchNonCancellable {
             startRunning()
             mangaList.fastForEach { manga ->
@@ -293,7 +293,7 @@ class BulkFavoriteScreenModel(
      *
      * @return List of categories, not including the default category
      */
-    suspend fun getCategories(): List<Category> {
+    internal suspend fun getCategories(): List<Category> {
         return getCategories.subscribe()
             .firstOrNull()
             ?.filterNot { it.isSystemCategory }
@@ -304,7 +304,7 @@ class BulkFavoriteScreenModel(
         moveMangaToCategories(manga, categories.filter { it.id != 0L }.map { it.id })
     }
 
-    fun moveMangaToCategories(manga: Manga, categoryIds: List<Long>) {
+    internal fun moveMangaToCategories(manga: Manga, categoryIds: List<Long>) {
         screenModelScope.launchIO {
             setMangaCategories.await(
                 mangaId = manga.id,
@@ -318,7 +318,7 @@ class BulkFavoriteScreenModel(
      *
      * @param manga the manga to update.
      */
-    fun changeMangaFavorite(manga: Manga) {
+    internal fun changeMangaFavorite(manga: Manga) {
         val source = sourceManager.getOrStub(manga.source)
 
         screenModelScope.launch {
@@ -341,7 +341,7 @@ class BulkFavoriteScreenModel(
         }
     }
 
-    fun addFavorite(manga: Manga) {
+    internal fun addFavorite(manga: Manga) {
         screenModelScope.launch {
             val categories = getCategories()
             val defaultCategoryId = libraryPreferences.defaultCategory().get()
@@ -388,13 +388,13 @@ class BulkFavoriteScreenModel(
         }
     }
 
-    fun setDialog(dialog: Dialog?) {
+    internal fun setDialog(dialog: Dialog?) {
         mutableState.update {
             it.copy(dialog = dialog)
         }
     }
 
-    fun dismissDialog() {
+    internal fun dismissDialog() {
         mutableState.update {
             it.copy(dialog = null)
         }
@@ -406,7 +406,7 @@ class BulkFavoriteScreenModel(
         }
     }
 
-    fun stopRunning() {
+    internal fun stopRunning() {
         mutableState.update {
             it.copy(isRunning = false)
         }
@@ -482,7 +482,7 @@ fun BulkFavoriteDialogs(
 }
 
 @Composable
-fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+private fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
     val navigator = LocalNavigator.currentOrThrow
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.Migrate
@@ -511,7 +511,7 @@ fun ShowMigrateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
  * @param bulkFavoriteScreenModel the screen model.
  */
 @Composable
-fun AddDuplicateMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+private fun AddDuplicateMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
     val navigator = LocalNavigator.currentOrThrow
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.AddDuplicateManga
@@ -541,7 +541,7 @@ fun AddDuplicateMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
 }
 
 @Composable
-fun RemoveMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+private fun RemoveMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.RemoveManga
 
@@ -555,7 +555,7 @@ fun RemoveMangaDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
 }
 
 @Composable
-fun ChangeMangaCategoryDialog(
+private fun ChangeMangaCategoryDialog(
     bulkFavoriteScreenModel: BulkFavoriteScreenModel,
     onConfirm: (List<Long>, List<Long>) -> Unit,
 ) {
@@ -577,7 +577,7 @@ fun ChangeMangaCategoryDialog(
  * @param bulkFavoriteScreenModel the screen model.
  */
 @Composable
-fun BulkAllowDuplicateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
+private fun BulkAllowDuplicateDialog(bulkFavoriteScreenModel: BulkFavoriteScreenModel) {
     val navigator = LocalNavigator.currentOrThrow
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val dialog = bulkFavoriteState.dialog as Dialog.BulkAllowDuplicate

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
@@ -22,13 +22,13 @@ import eu.kanade.presentation.browse.FeedAddDialog
 import eu.kanade.presentation.browse.FeedAddSearchDialog
 import eu.kanade.presentation.browse.FeedOrderScreen
 import eu.kanade.presentation.browse.FeedScreen
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.browse.components.FeedActionsDialog
 import eu.kanade.presentation.browse.components.SourceFeedDeleteDialog
+import eu.kanade.presentation.browse.components.bulkSelectionButton
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.TabContent
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
-import eu.kanade.tachiyomi.ui.browse.bulkSelectionButton
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -102,10 +102,7 @@ internal fun MigrateDialog(
                     horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
                 ) {
                     TextButton(
-                        onClick = {
-                            onDismissRequest()
-                            onClickTitle()
-                        },
+                        onClick = { onClickTitle() },
                     ) {
                         Text(text = stringResource(MR.strings.action_show_manga))
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
@@ -14,6 +14,9 @@ import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationListScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 
+/**
+ * Manual search [validSources] for manga to migrate to.
+ */
 class MigrateSearchScreen(private val mangaId: Long, private val validSources: List<Long>) : Screen() {
 
     @Composable
@@ -73,6 +76,7 @@ class MigrateSearchScreen(private val mangaId: Long, private val validSources: L
         )
 
         // KMK -->
+        // Bulk-favorite actions only
         BulkFavoriteDialogs(
             bulkFavoriteScreenModel = bulkFavoriteScreenModel,
             dialog = bulkFavoriteState.dialog,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
@@ -8,8 +8,8 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.browse.MigrateSearchScreen
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationListScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
@@ -16,14 +16,14 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.presentation.browse.BrowseSourceContent
 import eu.kanade.presentation.browse.components.BrowseSourceFloatingActionButton
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
+import eu.kanade.presentation.browse.components.bulkSelectionButton
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.BulkSelectionToolbar
 import eu.kanade.presentation.components.SearchToolbar
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.source.online.HttpSource
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
-import eu.kanade.tachiyomi.ui.browse.bulkSelectionButton
 import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationListScreen
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.SourceFilterDialog

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
@@ -41,7 +41,7 @@ import tachiyomi.presentation.core.screens.LoadingScreen
 import tachiyomi.source.local.LocalSource
 
 /**
- * Opened when click on a source in [MigrateSearchScreen]
+ * Opened when click on a source in [MigrateSearchScreen] while doing manual search for migration
  */
 data class SourceSearchScreen(
     private val oldManga: Manga,
@@ -212,6 +212,7 @@ data class SourceSearchScreen(
         }
 
         // KMK -->
+        // Bulk-favorite actions only
         BulkFavoriteDialogs(
             bulkFavoriteScreenModel = bulkFavoriteScreenModel,
             dialog = bulkFavoriteState.dialog,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -504,6 +504,7 @@ data class BrowseSourceScreen(
         }
 
         // KMK -->
+        // Bulk-favorite actions only
         BulkFavoriteDialogs(
             bulkFavoriteScreenModel = bulkFavoriteScreenModel,
             dialog = bulkFavoriteState.dialog,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -40,6 +40,7 @@ import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.presentation.browse.BrowseSourceContent
 import eu.kanade.presentation.browse.MissingSourceScreen
 import eu.kanade.presentation.browse.components.BrowseSourceToolbar
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.browse.components.RemoveMangaDialog
 import eu.kanade.presentation.browse.components.SavedSearchCreateDialog
 import eu.kanade.presentation.browse.components.SavedSearchDeleteDialog
@@ -52,7 +53,6 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.online.HttpSource
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.extension.details.SourcePreferencesScreen
 import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialog

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -463,9 +463,7 @@ data class BrowseSourceScreen(
                     screenModel = MigrateDialogScreenModel(),
                     onDismissRequest = onDismissRequest,
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
-                    onPopScreen = {
-                        onDismissRequest()
-                    },
+                    onPopScreen = { onDismissRequest() },
                 )
             }
             is BrowseSourceScreenModel.Dialog.RemoveManga -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
@@ -19,6 +19,7 @@ import eu.kanade.presentation.browse.MissingSourceScreen
 import eu.kanade.presentation.browse.SourceFeedOrderScreen
 import eu.kanade.presentation.browse.SourceFeedScreen
 import eu.kanade.presentation.browse.SourceFeedUI
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.browse.components.FeedActionsDialog
 import eu.kanade.presentation.browse.components.SourceFeedAddDialog
 import eu.kanade.presentation.browse.components.SourceFeedDeleteDialog
@@ -27,7 +28,6 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.online.HttpSource
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.extension.details.SourcePreferencesScreen
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
@@ -14,8 +14,8 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.presentation.browse.GlobalSearchScreen
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -141,7 +141,7 @@ data object HistoryTab : Tab {
                     screenModel = MigrateDialogScreenModel(),
                     onDismissRequest = onDismissRequest,
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
-                    onPopScreen = { navigator.replace(MangaScreen(dialog.newManga.id)) },
+                    onPopScreen = { onDismissRequest() },
                 )
             }
             null -> {}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -44,6 +44,7 @@ import dev.chrisbanes.haze.hazeEffect
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.domain.manga.model.hasCustomCover
 import eu.kanade.domain.manga.model.toSManga
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.components.NavigatorAdaptiveSheet
 import eu.kanade.presentation.manga.ChapterSettingsDialog
@@ -63,7 +64,6 @@ import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.isLocalOrStub
 import eu.kanade.tachiyomi.source.online.HttpSource
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.extension.ExtensionsScreen
 import eu.kanade.tachiyomi.ui.browse.extension.details.SourcePreferencesScreen

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -470,7 +470,7 @@ class MangaScreen(
                     screenModel = MigrateDialogScreenModel(),
                     onDismissRequest = onDismissRequest,
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
-                    onPopScreen = { navigator.replace(MangaScreen(dialog.newManga.id)) },
+                    onPopScreen = { onDismissRequest() },
                 )
             }
             MangaScreenModel.Dialog.SettingsSheet -> ChapterSettingsDialog(

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -175,9 +175,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                     screenModel = MigrateDialogScreenModel(),
                     onDismissRequest = onDismissRequest,
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
-                    onPopScreen = {
-                        onDismissRequest()
-                    },
+                    onPopScreen = { onDismissRequest() },
                 )
             }
             // KMK <--

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -17,12 +17,12 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.presentation.browse.BrowseSourceContent
 import eu.kanade.presentation.browse.components.BrowseSourceSimpleToolbar
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.browse.components.RemoveMangaDialog
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.components.BulkSelectionToolbar
 import eu.kanade.presentation.manga.DuplicateMangaDialog
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialog
 import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateDialogScreenModel

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -207,6 +207,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
         }
 
         // KMK -->
+        // Bulk-favorite actions only
         BulkFavoriteDialogs(
             bulkFavoriteScreenModel = bulkFavoriteScreenModel,
             dialog = bulkFavoriteState.dialog,

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -16,9 +16,9 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.presentation.browse.BrowseSourceContent
 import eu.kanade.presentation.browse.components.BrowseSourceSimpleToolbar
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.components.BulkSelectionToolbar
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.SourcesScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen

--- a/app/src/main/java/exh/recs/RecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreen.kt
@@ -10,8 +10,8 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifSourcesLoaded
+import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.ui.browse.BulkFavoriteDialogs
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.SourcesScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen


### PR DESCRIPTION
## Summary by Sourcery

Enhance bulk favorite functionality by adding support for migrating manga when encountering duplicates during bulk favorite operations

New Features:
- Add ability to migrate manga when encountering duplicates in bulk favorite operations

Enhancements:
- Refactor BulkFavoriteScreenModel to support more flexible selection and dialog handling
- Improve migration dialog interactions

Chores:
- Reorganize and clean up imports
- Move BulkFavoriteDialogs to a separate component file