### PR TITLE
refactor checksum regex in GH release notes

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -853,6 +853,7 @@ private fun MangaSummary(
         modifier = modifier.clipToBounds(),
         contents = listOf(
             {
+                // shrunk: calculate minimum size when shrunk
                 Text(
                     // Shows at least 3 lines if no notes
                     // when there are notes show 6
@@ -861,6 +862,7 @@ private fun MangaSummary(
                 )
             },
             {
+                // expanded: calculate maximum size when expanded
                 Column {
                     MangaNotesSection(
                         content = notes,
@@ -875,6 +877,7 @@ private fun MangaSummary(
                 }
             },
             {
+                // actual: the actual displayed content
                 Column {
                     MangaNotesSection(
                         content = notes,
@@ -891,6 +894,7 @@ private fun MangaSummary(
                 }
             },
             {
+                // scrim
                 val colors = listOf(Color.Transparent, MaterialTheme.colorScheme.background)
                 Box(
                     modifier = Modifier.background(Brush.verticalGradient(colors = colors)),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
@@ -22,7 +22,7 @@ class NewUpdateScreen(
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
         val changelogInfoNoChecksum = remember {
-            changelogInfo.replace("""---(\R|.)*Checksums(\R|.)*""".toRegex(), "")
+            changelogInfo
         }
 
         NewUpdateScreen(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/WhatsNewScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/WhatsNewScreen.kt
@@ -21,7 +21,7 @@ class WhatsNewScreen(
         val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
         val changelogInfoNoChecksum = remember {
-            changelogInfo.replace("""---(\R|.)*Checksums(\R|.)*""".toRegex(), "")
+            changelogInfo
         }
 
         WhatsNewScreen(

--- a/data/src/main/java/tachiyomi/data/release/ReleaseServiceImpl.kt
+++ b/data/src/main/java/tachiyomi/data/release/ReleaseServiceImpl.kt
@@ -50,6 +50,7 @@ class ReleaseServiceImpl(
                         info = release.info.replace(gitHubUsernameMentionRegex) { mention ->
                             "[${mention.value}](https://github.com/${mention.value.substring(1)})"
                         }
+                            .replace(checksumRegex, "")
                             // KMK -->
                             .replace(getHubDownloadBadgeRegex, "")
                             .replace(gitHubCommitsCompareRegex) { matchResult ->
@@ -57,7 +58,6 @@ class ReleaseServiceImpl(
                                 val repo = matchResult.groups["repo"]!!.value
                                 val from = matchResult.groups["from"]!!.value
                                 val to = matchResult.groups["to"]!!.value
-
                                 "[$owner/$repo@$from...$to](https://github.com/$owner/$repo/compare/$from...$to)"
                             },
                         // KMK <--
@@ -103,6 +103,8 @@ class ReleaseServiceImpl(
          */
         private val gitHubUsernameMentionRegex = """\B@([a-z0-9](?:-(?=[a-z0-9])|[a-z0-9]){0,38}(?<=[a-z0-9]))"""
             .toRegex(RegexOption.IGNORE_CASE)
+
+        private val checksumRegex = """---(\R|.)*Checksums(\R|.)*""".toRegex()
 
         // KMK -->
         private val getHubDownloadBadgeRegex = """\[!\[GitHub downloads]\(.*\)]\(.*\)"""

--- a/domain/src/main/java/tachiyomi/domain/release/interactor/GetApplicationRelease.kt
+++ b/domain/src/main/java/tachiyomi/domain/release/interactor/GetApplicationRelease.kt
@@ -59,13 +59,11 @@ class GetApplicationRelease(
     suspend fun awaitReleaseNotes(arguments: Arguments): Result {
         val releases = service.releaseNotes(arguments)
             .filter { !it.preRelease }
-        val checksumRegex = """---(\R|.)*Checksums(\R|.)*""".toRegex()
 
         val release = releases.firstOrNull()
             ?.copy(
                 info = releases.joinToString("\r---\r") {
-                    "## ${it.version}\r\r" +
-                        it.info.replace(checksumRegex, "")
+                    "## ${it.version}\r\r${it.info}"
                 },
             )
         if (release == null) return Result.NoNewUpdate


### PR DESCRIPTION
## Summary by Sourcery

Remove checksum section removal from GitHub release notes processing

Bug Fixes:
- Fixed inconsistent handling of checksum sections in release notes across different components

Enhancements:
- Simplified release notes processing by removing checksum section stripping logic from multiple locations