### PR TITLE
Add smaller tap zone preference for navigation regions

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -16,6 +16,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
@@ -65,6 +66,12 @@ object SettingsReaderScreen : SearchableSettings {
                 title = stringResource(MR.strings.pref_show_navigation_mode),
                 subtitle = stringResource(MR.strings.pref_show_navigation_mode_summary),
             ),
+            // KMK -->
+            Preference.PreferenceItem.SwitchPreference(
+                preference = readerPref.smallerTapZone(),
+                title = stringResource(KMR.strings.pref_viewer_nav_smaller_tap_zone),
+            ),
+            // KMK <--
             // SY -->
             Preference.PreferenceItem.SwitchPreference(
                 preference = readerPref.forceHorizontalSeekbar(),

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.CheckboxItem
 import tachiyomi.presentation.core.components.HeadingItem
@@ -111,6 +112,13 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
     }
     // SY <--
 
+    // KMK -->
+    CheckboxItem(
+        label = stringResource(KMR.strings.pref_viewer_nav_smaller_tap_zone),
+        pref = screenModel.preferences.smallerTapZone(),
+    )
+    // KMK <--
+
     CheckboxItem(
         label = stringResource(MR.strings.pref_crop_borders),
         pref = screenModel.preferences.cropBorders(),
@@ -202,6 +210,13 @@ private fun ColumnScope.WebtoonViewerSettings(screenModel: ReaderSettingsScreenM
         },
         pillColor = MaterialTheme.colorScheme.surfaceContainerHighest,
     )
+
+    // KMK -->
+    CheckboxItem(
+        label = stringResource(KMR.strings.pref_viewer_nav_smaller_tap_zone),
+        pref = screenModel.preferences.smallerTapZone(),
+    )
+    // KMK <--
 
     CheckboxItem(
         label = stringResource(MR.strings.pref_crop_borders),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -143,6 +143,10 @@ class ReaderPreferences(
 
     fun showNavigationOverlayOnStart() = preferenceStore.getBoolean("reader_navigation_overlay_on_start", false)
 
+    // KMK -->
+    fun smallerTapZone() = preferenceStore.getBoolean("reader_navigation_smaller_tap_zone", false)
+    // KMK <--
+
     // endregion
 
     // SY -->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerNavigation.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ViewerNavigation.kt
@@ -7,6 +7,7 @@ import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.lang.invert
 import tachiyomi.i18n.MR
+import uy.kohesive.injekt.injectLazy
 
 abstract class ViewerNavigation {
 
@@ -51,4 +52,11 @@ abstract class ViewerNavigation {
             else -> NavigationRegion.MENU
         }
     }
+
+    // KMK -->
+    private val readerPreferences: ReaderPreferences by injectLazy()
+    protected val regionSize1
+        get() = if (readerPreferences.smallerTapZone().get()) 0.25f else 0.33f
+    protected val regionSize2 = 1f - regionSize1
+    // KMK <--
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/EdgeNavigation.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/EdgeNavigation.kt
@@ -17,15 +17,15 @@ class EdgeNavigation : ViewerNavigation() {
 
     override var regionList: List<Region> = listOf(
         Region(
-            rectF = RectF(0f, 0f, 0.33f, 1f),
+            rectF = RectF(0f, 0f, regionSize1, 1f),
             type = NavigationRegion.NEXT,
         ),
         Region(
-            rectF = RectF(0.33f, 0.66f, 0.66f, 1f),
+            rectF = RectF(regionSize1, regionSize2, regionSize2, 1f),
             type = NavigationRegion.PREV,
         ),
         Region(
-            rectF = RectF(0.66f, 0f, 1f, 1f),
+            rectF = RectF(regionSize2, 0f, 1f, 1f),
             type = NavigationRegion.NEXT,
         ),
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/KindlishNavigation.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/KindlishNavigation.kt
@@ -17,11 +17,11 @@ class KindlishNavigation : ViewerNavigation() {
 
     override var regionList: List<Region> = listOf(
         Region(
-            rectF = RectF(0.33f, 0.33f, 1f, 1f),
+            rectF = RectF(regionSize1, regionSize1, 1f, 1f),
             type = NavigationRegion.NEXT,
         ),
         Region(
-            rectF = RectF(0f, 0.33f, 0.33f, 1f),
+            rectF = RectF(0f, regionSize1, regionSize1, 1f),
             type = NavigationRegion.PREV,
         ),
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/LNavigation.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/LNavigation.kt
@@ -17,19 +17,19 @@ open class LNavigation : ViewerNavigation() {
 
     override var regionList: List<Region> = listOf(
         Region(
-            rectF = RectF(0f, 0.33f, 0.33f, 0.66f),
+            rectF = RectF(0f, regionSize1, regionSize1, regionSize2),
             type = NavigationRegion.PREV,
         ),
         Region(
-            rectF = RectF(0f, 0f, 1f, 0.33f),
+            rectF = RectF(0f, 0f, 1f, regionSize1),
             type = NavigationRegion.PREV,
         ),
         Region(
-            rectF = RectF(0.66f, 0.33f, 1f, 0.66f),
+            rectF = RectF(regionSize2, regionSize1, 1f, regionSize2),
             type = NavigationRegion.NEXT,
         ),
         Region(
-            rectF = RectF(0f, 0.66f, 1f, 1f),
+            rectF = RectF(0f, regionSize2, 1f, 1f),
             type = NavigationRegion.NEXT,
         ),
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/RightAndLeftNavigation.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/navigation/RightAndLeftNavigation.kt
@@ -17,11 +17,11 @@ class RightAndLeftNavigation : ViewerNavigation() {
 
     override var regionList: List<Region> = listOf(
         Region(
-            rectF = RectF(0f, 0f, 0.33f, 1f),
+            rectF = RectF(0f, 0f, regionSize1, 1f),
             type = NavigationRegion.LEFT,
         ),
         Region(
-            rectF = RectF(0.66f, 0f, 1f, 1f),
+            rectF = RectF(regionSize2, 0f, 1f, 1f),
             type = NavigationRegion.RIGHT,
         ),
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -116,6 +116,12 @@ class PagerConfig(
             .drop(1)
             .onEach { navigationModeChangedListener?.invoke() }
             .launchIn(scope)
+        // KMK -->
+        readerPreferences.smallerTapZone().changes()
+            .drop(1)
+            .onEach { updateNavigation(navigationMode) }
+            .launchIn(scope)
+        // KMK <--
 
         readerPreferences.dualPageSplitPaged()
             .register(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -65,6 +65,12 @@ class WebtoonConfig(
             .drop(1)
             .onEach { navigationModeChangedListener?.invoke() }
             .launchIn(scope)
+        // KMK -->
+        readerPreferences.smallerTapZone().changes()
+            .drop(1)
+            .onEach { updateNavigation(navigationMode) }
+            .launchIn(scope)
+        // KMK <--
 
         readerPreferences.dualPageSplitWebtoon()
             .register({ dualPageSplit = it }, { imagePropertyChangedListener?.invoke() })

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -19,6 +19,7 @@
     <string name="action_copy_to_clipboard_first_page">Copy first page to clipboard</string>
     <string name="action_copy_to_clipboard_second_page">Copy second page to clipboard</string>
     <string name="action_copy_to_clipboard_combined_page">Copy combined page to clipboard</string>
+    <string name="pref_viewer_nav_smaller_tap_zone">Smaller tap zones</string>
     <!-- Preferences -->
       <!-- Appearance section -->
     <string name="pref_custom_theme_style">Custom theme style</string>


### PR DESCRIPTION
## Summary by Sourcery

Add a preference to use smaller tap zones for navigation in the manga reader

New Features:
- Introduce a new reader preference to reduce the size of navigation tap zones from 33% to 25% of the screen

Enhancements:
- Modify navigation region calculations to support configurable tap zone sizes
- Update multiple navigation modes to use the new configurable region size