### PR TITLE
chore(custom-color): refactor EditText and TextInputLayout color handling

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -1,8 +1,6 @@
 package eu.kanade.presentation.more.settings.screen
 
 import android.content.Context
-import android.content.res.ColorStateList
-import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import androidx.compose.foundation.layout.Arrangement
@@ -258,25 +256,11 @@ object SettingsTrackingScreen : SearchableSettings {
                             val usernameEditText = binding.usernameEditText
                             val passwordEditText = binding.passwordEditText
 
-                            // Apply color scheme and selection handles
-                            listOf(usernameEditText, passwordEditText).forEach { editText ->
-                                editText.setTextColor(colorScheme.textColor)
-                                editText.highlightColor = colorScheme.textHighlightColor
-
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                    editText.textSelectHandle?.let { drawable ->
-                                        drawable.setTint(colorScheme.primary)
-                                        editText.setTextSelectHandle(drawable)
-                                    }
-                                    editText.textSelectHandleLeft?.let { drawable ->
-                                        drawable.setTint(colorScheme.primary)
-                                        editText.setTextSelectHandleLeft(drawable)
-                                    }
-                                    editText.textSelectHandleRight?.let { drawable ->
-                                        drawable.setTint(colorScheme.primary)
-                                        editText.setTextSelectHandleRight(drawable)
-                                    }
-                                }
+                            listOf(
+                                usernameEditText,
+                                passwordEditText,
+                            ).forEach {
+                                colorScheme.setEditTextColor(it)
                             }
 
                             usernameInputLayout.hint = usernameHint
@@ -306,43 +290,11 @@ object SettingsTrackingScreen : SearchableSettings {
                             val usernameInputLayout = binding.usernameInputLayout
                             val passwordInputLayout = binding.passwordInputLayout
 
-                            val (strokeColorFocused, strokeColorDefault, hintColor, cursorColor) = if (inputError) {
-                                arrayOf(
-                                    colorScheme.error,
-                                    colorScheme.error,
-                                    colorScheme.error,
-                                    colorScheme.error,
-                                )
-                            } else {
-                                arrayOf(
-                                    colorScheme.primary,
-                                    colorScheme.onSurfaceVariant,
-                                    colorScheme.primary,
-                                    colorScheme.primary,
-                                )
-                            }
-
-                            val boxStrokeColorStateList = ColorStateList(
-                                arrayOf(
-                                    intArrayOf(android.R.attr.state_focused),
-                                    intArrayOf(), // Default state
-                                ),
-                                intArrayOf(
-                                    strokeColorFocused,
-                                    strokeColorDefault,
-                                ),
-                            )
-                            val hintTextColorStateList = ColorStateList.valueOf(hintColor)
-                            val endIconTintList = ColorStateList.valueOf(colorScheme.onSurfaceVariant)
-                            val cursorColorStateList = ColorStateList.valueOf(cursorColor)
-
-                            listOf(usernameInputLayout, passwordInputLayout).forEach {
-                                it.setBoxStrokeColorStateList(boxStrokeColorStateList)
-                                it.hintTextColor = hintTextColorStateList
-                                it.setEndIconTintList(endIconTintList)
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                    it.cursorColor = cursorColorStateList
-                                }
+                            listOf(
+                                usernameInputLayout,
+                                passwordInputLayout,
+                            ).forEach {
+                                colorScheme.setTextInputLayoutColor(it, inputError)
                             }
                         },
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
-import androidx.core.graphics.drawable.toDrawable
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -236,14 +235,13 @@ class AndroidViewColorScheme(
      * @param editText The EditText to set the color for.
      */
     fun setEditTextColor(
-        editText: EditText,
+        editText: TextInputEditText,
     ) {
         editText.setTextColor(onSurfaceVariant)
         editText.highlightColor = inversePrimary
         editText.backgroundTintList = editTextBackgroundTintList
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            editText.textCursorDrawable = primary.toDrawable()
             editText.textSelectHandle?.let { drawable ->
                 drawable.setTint(primary)
                 editText.setTextSelectHandle(drawable)

--- a/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
@@ -4,6 +4,7 @@ import android.app.UiModeManager
 import android.content.Context
 import android.content.res.ColorStateList
 import android.os.Build
+import android.widget.EditText
 import androidx.annotation.ColorInt
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.surfaceColorAtElevation
@@ -11,7 +12,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
+import androidx.core.graphics.drawable.toDrawable
 import com.google.android.material.progressindicator.LinearProgressIndicator
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import com.materialkolor.Contrast
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamicColorScheme
@@ -188,7 +192,7 @@ class AndroidViewColorScheme(
         ),
         intArrayOf(
             onPrimary,
-            onSurface,
+            onSurfaceVariant,
         ),
     )
 
@@ -199,7 +203,7 @@ class AndroidViewColorScheme(
         ),
         intArrayOf(
             primary,
-            onSurface,
+            onSurfaceVariant,
         ),
     )
 
@@ -210,7 +214,7 @@ class AndroidViewColorScheme(
         ),
         intArrayOf(
             primary,
-            onSurface,
+            onSurfaceVariant,
         ),
     )
 
@@ -226,6 +230,66 @@ class AndroidViewColorScheme(
             primary, // Default color
         ),
     )
+
+    /**
+     * Set the color of the [TextInputEditText] or [EditText].
+     * @param editText The EditText to set the color for.
+     */
+    fun setEditTextColor(
+        editText: EditText,
+    ) {
+        editText.setTextColor(onSurfaceVariant)
+        editText.highlightColor = inversePrimary
+        editText.backgroundTintList = editTextBackgroundTintList
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            editText.textCursorDrawable = primary.toDrawable()
+            editText.textSelectHandle?.let { drawable ->
+                drawable.setTint(primary)
+                editText.setTextSelectHandle(drawable)
+            }
+            editText.textSelectHandleLeft?.let { drawable ->
+                drawable.setTint(primary)
+                editText.setTextSelectHandleLeft(drawable)
+            }
+            editText.textSelectHandleRight?.let { drawable ->
+                drawable.setTint(primary)
+                editText.setTextSelectHandleRight(drawable)
+            }
+        }
+    }
+
+    fun setTextInputLayoutColor(
+        inputLayout: TextInputLayout,
+        isError: Boolean = false,
+    ) {
+        val (strokeColorFocused, strokeColorDefault, hintColor, cursorColor) = if (isError) {
+            arrayOf(error, error, error, error)
+        } else {
+            arrayOf(primary, onSurfaceVariant, primary, primary)
+        }
+
+        val boxStrokeColorStateList = ColorStateList(
+            arrayOf(
+                intArrayOf(android.R.attr.state_focused),
+                intArrayOf(), // Default state
+            ),
+            intArrayOf(
+                strokeColorFocused,
+                strokeColorDefault,
+            ),
+        )
+        val hintTextColorStateList = ColorStateList.valueOf(hintColor)
+        val endIconTintList = ColorStateList.valueOf(onSurfaceVariant)
+        val cursorColorStateList = ColorStateList.valueOf(cursorColor)
+
+        inputLayout.setBoxStrokeColorStateList(boxStrokeColorStateList)
+        inputLayout.hintTextColor = hintTextColorStateList
+        inputLayout.setEndIconTintList(endIconTintList)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            inputLayout.cursorColor = cursorColorStateList
+        }
+    }
 
     companion object {
         fun LinearProgressIndicator.setColors(colorScheme: AndroidViewColorScheme) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -81,6 +81,7 @@ fun MigrationBottomSheetDialog(
                 binding.HideNotFoundManga.thumbTintList = colorScheme.thumbTintList
                 binding.OnlyShowUpdates.thumbTintList = colorScheme.thumbTintList
 
+                colorScheme.setTextInputLayoutColor(binding.extraSearchParamInputLayout)
                 colorScheme.setEditTextColor(binding.extraSearchParamText)
                 // KMK <--
                 binding.root
@@ -119,9 +120,9 @@ class MigrationBottomSheetDialogState(
         binding.migDeleteDownloaded.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
 
         binding.useSmartSearch.bindToPreference(preferences.smartMigration())
-        binding.extraSearchParamText.isVisible = false
+        binding.extraSearchParamInputLayout.isVisible = false
         binding.extraSearchParam.setOnCheckedChangeListener { _, isChecked ->
-            binding.extraSearchParamText.isVisible = isChecked
+            binding.extraSearchParamInputLayout.isVisible = isChecked
         }
         binding.sourceGroup.bindToPreference(preferences.useSourceWithMost())
 
@@ -142,8 +143,8 @@ class MigrationBottomSheetDialogState(
             preferences.hideNotFoundMigration().set(binding.HideNotFoundManga.isChecked)
             preferences.showOnlyUpdatesMigration().set(binding.OnlyShowUpdates.isChecked)
             onStartMigration.value(
-                if (binding.useSmartSearch.isChecked && binding.extraSearchParamText.text.isNotBlank()) {
-                    binding.extraSearchParamText.toString()
+                if (binding.useSmartSearch.isChecked && !binding.extraSearchParamText.text.isNullOrBlank()) {
+                    binding.extraSearchParamText.text.toString()
                 } else {
                     null
                 },
@@ -154,7 +155,7 @@ class MigrationBottomSheetDialogState(
         if (!fullSettings) {
             binding.useSmartSearch.isVisible = false
             binding.extraSearchParam.isVisible = false
-            binding.extraSearchParamText.isVisible = false
+            binding.extraSearchParamInputLayout.isVisible = false
             binding.sourceGroup.isVisible = false
             binding.skipStep.isVisible = false
             binding.migrateBtn.text = binding.root.context.stringResource(MR.strings.action_save)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.ui.browse.migration.advanced.design
 
-import android.os.Build
 import android.view.LayoutInflater
 import android.widget.CompoundButton
 import android.widget.RadioButton
@@ -14,7 +13,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.isVisible
 import eu.kanade.presentation.components.AdaptiveSheet
 import eu.kanade.presentation.theme.colorscheme.AndroidViewColorScheme
@@ -83,26 +81,7 @@ fun MigrationBottomSheetDialog(
                 binding.HideNotFoundManga.thumbTintList = colorScheme.thumbTintList
                 binding.OnlyShowUpdates.thumbTintList = colorScheme.thumbTintList
 
-                with(binding.extraSearchParamText) {
-                    highlightColor = colorScheme.textHighlightColor
-                    backgroundTintList = colorScheme.editTextBackgroundTintList
-
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        textCursorDrawable = colorScheme.primary.toDrawable()
-                        textSelectHandle?.let { drawable ->
-                            drawable.setTint(colorScheme.primary)
-                            setTextSelectHandle(drawable)
-                        }
-                        textSelectHandleLeft?.let { drawable ->
-                            drawable.setTint(colorScheme.primary)
-                            setTextSelectHandleLeft(drawable)
-                        }
-                        textSelectHandleRight?.let { drawable ->
-                            drawable.setTint(colorScheme.primary)
-                            setTextSelectHandleRight(drawable)
-                        }
-                    }
-                }
+                colorScheme.setEditTextColor(binding.extraSearchParamText)
                 // KMK <--
                 binding.root
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.ui.manga
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
-import android.os.Build
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.AdapterView
@@ -359,23 +358,7 @@ private fun onViewCreated(
         binding.thumbnailUrl,
         binding.mangaDescription,
     ).forEach {
-        it.setTextColor(colorScheme.textColor)
-        it.highlightColor = colorScheme.textHighlightColor
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            it.textSelectHandle?.let { drawable ->
-                drawable.setTint(colorScheme.iconColor)
-                it.setTextSelectHandle(drawable)
-            }
-            it.textSelectHandleLeft?.let { drawable ->
-                drawable.setTint(colorScheme.iconColor)
-                it.setTextSelectHandleLeft(drawable)
-            }
-            it.textSelectHandleRight?.let { drawable ->
-                drawable.setTint(colorScheme.iconColor)
-                it.setTextSelectHandleRight(drawable)
-            }
-        }
+        colorScheme.setEditTextColor(it)
     }
     listOf(
         binding.titleOutline,
@@ -384,11 +367,7 @@ private fun onViewCreated(
         binding.thumbnailUrlOutline,
         binding.mangaDescriptionOutline,
     ).forEach {
-        it.boxStrokeColor = colorScheme.iconColor
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            it.cursorColor = ColorStateList.valueOf(colorScheme.iconColor)
-        }
+        colorScheme.setTextInputLayoutColor(it)
     }
 
     binding.autofillFromTracker.setTextColor(colorScheme.btnTextColor)

--- a/app/src/main/java/eu/kanade/tachiyomi/widget/materialdialogs/MaterialAlertDialogBuilderExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/widget/materialdialogs/MaterialAlertDialogBuilderExtensions.kt
@@ -1,14 +1,12 @@
 package eu.kanade.tachiyomi.widget.materialdialogs
 
 import android.content.Context
-import android.content.res.ColorStateList
 import android.graphics.Canvas
 import android.graphics.ColorFilter
 import android.graphics.Paint
 import android.graphics.PixelFormat
 import android.graphics.RectF
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.view.LayoutInflater
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
@@ -39,7 +37,7 @@ fun DialogStubTextinputBinding.setPositiveButton(text: String, onClick: (String)
     positiveButton.text = text
 
     positiveButton.setOnClickListener {
-        val textEdit = textField.editText
+        val textEdit = textInputLayout.editText
         onClick(textEdit?.text?.toString() ?: "")
     }
     return this
@@ -56,13 +54,13 @@ fun DialogStubTextinputBinding.setNegativeButton(text: String, onClick: () -> Un
 
 @Suppress("unused")
 fun DialogStubTextinputBinding.setHint(hint: String? = null): DialogStubTextinputBinding {
-    textField.hint = hint
+    textInputLayout.hint = hint
     return this
 }
 
 fun DialogStubTextinputBinding.setTextEdit(prefill: String? = null): DialogStubTextinputBinding {
     // KMK <--
-    textField.editText?.apply {
+    textInputLayout.editText?.apply {
         setText(prefill, TextView.BufferType.EDITABLE)
         post {
             requestFocusFromTouch()
@@ -73,38 +71,15 @@ fun DialogStubTextinputBinding.setTextEdit(prefill: String? = null): DialogStubT
     return this
 }
 
-fun DialogStubTextinputBinding.setColors(colors: AndroidViewColorScheme): DialogStubTextinputBinding {
-    textField.boxStrokeColor = colors.iconColor
+fun DialogStubTextinputBinding.setColors(colorScheme: AndroidViewColorScheme): DialogStubTextinputBinding {
+    colorScheme.setTextInputLayoutColor(textInputLayout)
+    colorScheme.setEditTextColor(textInputEdit)
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        textField.cursorColor = ColorStateList.valueOf(colors.iconColor)
-    }
+    alertTitle.setTextColor(colorScheme.textColor)
+    positiveButton.setTextColor(colorScheme.iconColor)
+    negativeButton.setTextColor(colorScheme.iconColor)
 
-    textField.editText?.apply {
-        setTextColor(colors.textColor)
-        highlightColor = colors.textHighlightColor
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            textSelectHandle?.let { drawable ->
-                drawable.setTint(colors.iconColor)
-                setTextSelectHandle(drawable)
-            }
-            textSelectHandleLeft?.let { drawable ->
-                drawable.setTint(colors.iconColor)
-                setTextSelectHandleLeft(drawable)
-            }
-            textSelectHandleRight?.let { drawable ->
-                drawable.setTint(colors.iconColor)
-                setTextSelectHandleRight(drawable)
-            }
-        }
-    }
-
-    alertTitle.setTextColor(colors.textColor)
-    positiveButton.setTextColor(colors.iconColor)
-    negativeButton.setTextColor(colors.iconColor)
-
-    root.background = RoundedCornerDrawable(color = colors.dialogBgColor)
+    root.background = RoundedCornerDrawable(color = colorScheme.dialogBgColor)
 
     return this
 }

--- a/app/src/main/res/layout/dialog_stub_textinput.xml
+++ b/app/src/main/res/layout/dialog_stub_textinput.xml
@@ -15,12 +15,13 @@
         android:layout_marginBottom="16dp" />
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/text_field"
+        android:id="@+id/text_input_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="16dp">
 
         <eu.kanade.tachiyomi.widget.TachiyomiTextInputEditText
+            android:id="@+id/text_input_edit"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/migration_bottom_sheet.xml
+++ b/app/src/main/res/layout/migration_bottom_sheet.xml
@@ -182,16 +182,21 @@
                 android:paddingVertical="16dp"
                 android:text="@string/include_extra_search_parameter" />
 
-            <EditText
-                android:id="@+id/extra_search_param_text"
+
+            <com.google.android.material.textfield.TextInputLayout
+                app:boxBackgroundMode="none"
+                android:id="@+id/extra_search_param_input_layout"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:ems="10"
-                android:hint="@string/search_parameter"
-                android:importantForAutofill="no"
-                android:inputType="textPersonName"
-                android:textSize="16sp" />
+                android:layout_height="wrap_content">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/extra_search_param_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/search_parameter"
+                    android:importantForAutofill="no"
+                    android:inputType="textPersonName"
+                    android:textSize="14sp"/>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.materialswitch.MaterialSwitch
                 android:id="@+id/skip_step"


### PR DESCRIPTION
## Summary by Sourcery

Refactor color handling for EditText and TextInputLayout components to centralize and simplify color management across different screens

Enhancements:
- Introduced centralized color setting methods in AndroidViewColorScheme
- Simplified color application for EditText and TextInputLayout across multiple screens
- Standardized text input color handling

Chores:
- Replaced manual color setting with method calls
- Updated multiple layout files to use new color setting methods