### PR TITLE
fix(toolbar): do not bulk-selection on BrowseRecommends

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceSimpleToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceSimpleToolbar.kt
@@ -28,7 +28,7 @@ fun BrowseSourceSimpleToolbar(
     onDisplayModeChange: (LibraryDisplayMode) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
     // KMK -->
-    toggleSelectionMode: () -> Unit,
+    toggleSelectionMode: (() -> Unit)?,
     isRunning: Boolean,
     // KMK <--
 ) {
@@ -53,6 +53,8 @@ fun BrowseSourceSimpleToolbar(
                                     onClick = { selectingDisplayMode = true },
                                 ),
                             )
+                        }
+                        toggleSelectionMode?.let {
                             add(
                                 bulkSelectionButton(isRunning, toggleSelectionMode),
                             )

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -119,7 +119,9 @@ class BrowseRecommendsScreen(
                         onDisplayModeChange = { screenModel.displayMode = it },
                         scrollBehavior = scrollBehavior,
                         // KMK -->
-                        toggleSelectionMode = bulkFavoriteScreenModel::toggleSelectionMode,
+                        toggleSelectionMode = {
+                            bulkFavoriteScreenModel.toggleSelectionMode()
+                        }.takeIf { !isExternalSource },
                         isRunning = bulkFavoriteState.isRunning,
                         // KMK <--
                     )


### PR DESCRIPTION
## Summary by Sourcery

Prevent bulk selection functionality on BrowseRecommends screen for external sources

Bug Fixes:
- Disabled bulk selection for external sources in BrowseRecommends screen

Enhancements:
- Made toggle selection mode optional in BrowseSourceSimpleToolbar