### PR TITLE
feat(incognito): Add incognito mode for EH based sources

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -200,6 +200,6 @@ class DomainModule : InjektModule {
         addFactory { ReplaceExtensionRepo(get()) }
         addFactory { UpdateExtensionRepo(get(), get()) }
         addFactory { ToggleIncognito(get()) }
-        addFactory { GetIncognitoState(get(), get(), get(), get()) }
+        addFactory { GetIncognitoState(get(), get(), get()) }
     }
 }

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -200,6 +200,6 @@ class DomainModule : InjektModule {
         addFactory { ReplaceExtensionRepo(get()) }
         addFactory { UpdateExtensionRepo(get(), get()) }
         addFactory { ToggleIncognito(get()) }
-        addFactory { GetIncognitoState(get(), get(), get()) }
+        addFactory { GetIncognitoState(get(), get(), get(), get()) }
     }
 }

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetIncognitoState.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetIncognitoState.kt
@@ -2,24 +2,23 @@ package eu.kanade.domain.source.interactor
 
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.source.service.SourcePreferences
-import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.source.isIncognitoModeEnabled
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flow
 import tachiyomi.domain.source.service.SourceManager
 
 class GetIncognitoState(
     private val basePreferences: BasePreferences,
     private val sourcePreferences: SourcePreferences,
-    private val extensionManager: ExtensionManager,
     private val sourceManager: SourceManager,
 ) {
     fun await(sourceId: Long?): Boolean {
         if (basePreferences.incognitoMode().get()) return true
         if (sourceId == null) return false
+        // KMK -->
         return sourceManager.get(sourceId)?.isIncognitoModeEnabled() == true
+        // KMK <--
     }
 
     fun subscribe(sourceId: Long?): Flow<Boolean> {
@@ -28,10 +27,10 @@ class GetIncognitoState(
         return combine(
             basePreferences.incognitoMode().changes(),
             sourcePreferences.incognitoExtensions().changes(),
-            extensionManager.getExtensionPackageAsFlow(sourceId),
-            flow { emit(sourceManager.get(sourceId)?.isIncognitoModeEnabled() == true) },
-        ) { incognito, incognitoExtensions, extensionPackage, isSourceIncognito ->
-            incognito || (extensionPackage in incognitoExtensions) || isSourceIncognito
+        ) { incognito, incognitoExtensions ->
+            // KMK -->
+            incognito || sourceManager.get(sourceId)?.isIncognitoModeEnabled(incognitoExtensions) == true
+            // KMK <--
         }
             .distinctUntilChanged()
     }

--- a/app/src/main/java/eu/kanade/domain/source/interactor/GetIncognitoState.kt
+++ b/app/src/main/java/eu/kanade/domain/source/interactor/GetIncognitoState.kt
@@ -3,21 +3,23 @@ package eu.kanade.domain.source.interactor
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
+import eu.kanade.tachiyomi.source.isIncognitoModeEnabled
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import tachiyomi.domain.source.service.SourceManager
 
 class GetIncognitoState(
     private val basePreferences: BasePreferences,
     private val sourcePreferences: SourcePreferences,
     private val extensionManager: ExtensionManager,
+    private val sourceManager: SourceManager,
 ) {
     fun await(sourceId: Long?): Boolean {
         if (basePreferences.incognitoMode().get()) return true
         if (sourceId == null) return false
-        val extensionPackage = extensionManager.getExtensionPackage(sourceId) ?: return false
-
-        return extensionPackage in sourcePreferences.incognitoExtensions().get()
+        return sourceManager.get(sourceId)?.isIncognitoModeEnabled() == true
     }
 
     fun subscribe(sourceId: Long?): Flow<Boolean> {
@@ -27,8 +29,9 @@ class GetIncognitoState(
             basePreferences.incognitoMode().changes(),
             sourcePreferences.incognitoExtensions().changes(),
             extensionManager.getExtensionPackageAsFlow(sourceId),
-        ) { incognito, incognitoExtensions, extensionPackage ->
-            incognito || (extensionPackage in incognitoExtensions)
+            flow { emit(sourceManager.get(sourceId)?.isIncognitoModeEnabled() == true) },
+        ) { incognito, incognitoExtensions, extensionPackage, isSourceIncognito ->
+            incognito || (extensionPackage in incognitoExtensions) || isSourceIncognito
         }
             .distinctUntilChanged()
     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsEhScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsEhScreen.kt
@@ -139,6 +139,14 @@ object SettingsEhScreen : SearchableSettings {
         ConfigureExhDialog(run = runConfigureDialog, onRunning = { runConfigureDialog = false })
 
         return listOf(
+            // KMK -->
+            Preference.PreferenceGroup(
+                stringResource(MR.strings.source_settings),
+                preferenceItems = persistentListOf(
+                    ehIncognitoMode(unsortedPreferences),
+                ),
+            ),
+            // KMK <--
             Preference.PreferenceGroup(
                 stringResource(SYMR.strings.ehentai_prefs_account_settings),
                 preferenceItems = persistentListOf(
@@ -179,6 +187,19 @@ object SettingsEhScreen : SearchableSettings {
             ),
         )
     }
+
+    // KMK -->
+    @Composable
+    fun ehIncognitoMode(
+        unsortedPreferences: UnsortedPreferences,
+    ): Preference.PreferenceItem.SwitchPreference {
+        return Preference.PreferenceItem.SwitchPreference(
+            preference = unsortedPreferences.ehIncognitoMode(),
+            title = stringResource(MR.strings.pref_incognito_mode),
+            subtitle = stringResource(MR.strings.pref_incognito_mode_summary),
+        )
+    }
+    // KMK <--
 
     @Composable
     fun getLoginPreference(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsEhScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsEhScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.core.content.ContextCompat.startActivity
+import eu.kanade.domain.source.interactor.ToggleIncognito
 import eu.kanade.presentation.library.components.SyncFavoritesWarningDialog
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
@@ -52,6 +52,7 @@ import exh.eh.EHentaiUpdateWorker
 import exh.eh.EHentaiUpdateWorkerConstants
 import exh.eh.EHentaiUpdaterStats
 import exh.metadata.metadata.EHentaiSearchMetadata
+import exh.source.EH_PACKAGE
 import exh.ui.login.EhLoginActivity
 import exh.util.nullIfBlank
 import kotlinx.collections.immutable.persistentListOf
@@ -197,6 +198,11 @@ object SettingsEhScreen : SearchableSettings {
             preference = unsortedPreferences.ehIncognitoMode(),
             title = stringResource(MR.strings.pref_incognito_mode),
             subtitle = stringResource(MR.strings.pref_incognito_mode_summary),
+            onValueChanged = { newVal ->
+                val toggleIncognito = Injekt.get<ToggleIncognito>()
+                toggleIncognito.await(EH_PACKAGE, newVal)
+                newVal
+            },
         )
     }
     // KMK <--
@@ -296,14 +302,12 @@ object SettingsEhScreen : SearchableSettings {
             subtitle = stringResource(SYMR.strings.watched_tags_summary),
             enabled = exhentaiEnabled,
             onClick = {
-                startActivity(
-                    context,
+                context.startActivity(
                     WebViewActivity.newIntent(
                         context,
                         url = "https://exhentai.org/mytags",
                         title = context.stringResource(SYMR.strings.watched_tags_exh),
                     ),
-                    null,
                 )
             },
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.source
 
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
+import exh.source.isEhBasedSource
+import tachiyomi.domain.UnsortedPreferences
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.presentation.core.icons.FlagEmoji
 import tachiyomi.source.local.isLocal
@@ -81,6 +83,7 @@ fun Source.isLocalOrStub(): Boolean = isLocal() || this is StubSource
 
 // KMK -->
 fun Source.isIncognitoModeEnabled(): Boolean {
+    if (isEhBasedSource()) return Injekt.get<UnsortedPreferences>().ehIncognitoMode().get()
     val extensionPackage = Injekt.get<ExtensionManager>().getExtensionPackage(id)
     return extensionPackage in Injekt.get<SourcePreferences>().incognitoExtensions().get()
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -2,8 +2,8 @@ package eu.kanade.tachiyomi.source
 
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
+import exh.source.EH_PACKAGE
 import exh.source.isEhBasedSource
-import tachiyomi.domain.UnsortedPreferences
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.presentation.core.icons.FlagEmoji
 import tachiyomi.source.local.isLocal
@@ -82,9 +82,8 @@ private fun getMergedSourcesString(
 fun Source.isLocalOrStub(): Boolean = isLocal() || this is StubSource
 
 // KMK -->
-fun Source.isIncognitoModeEnabled(): Boolean {
-    if (isEhBasedSource()) return Injekt.get<UnsortedPreferences>().ehIncognitoMode().get()
-    val extensionPackage = Injekt.get<ExtensionManager>().getExtensionPackage(id)
-    return extensionPackage in Injekt.get<SourcePreferences>().incognitoExtensions().get()
+fun Source.isIncognitoModeEnabled(incognitoExtensions: Set<String>? = null): Boolean {
+    val extensionPackage = if (isEhBasedSource()) EH_PACKAGE else Injekt.get<ExtensionManager>().getExtensionPackage(id)
+    return extensionPackage in (incognitoExtensions ?: Injekt.get<SourcePreferences>().incognitoExtensions().get())
 }
 // KMK <--

--- a/domain/src/main/java/tachiyomi/domain/UnsortedPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/UnsortedPreferences.kt
@@ -36,6 +36,10 @@ class UnsortedPreferences(
 
     fun isHentaiEnabled() = preferenceStore.getBoolean("eh_is_hentai_enabled", false)
 
+    // KMK -->
+    fun ehIncognitoMode() = preferenceStore.getBoolean("eh_incognito_mode", false)
+    // KMK <--
+
     fun enableExhentai() = preferenceStore.getBoolean(Preference.privateKey("enable_exhentai"), false)
 
     fun imageQuality() = preferenceStore.getString("ehentai_quality", "auto")

--- a/source-api/src/commonMain/kotlin/exh/source/SourceIds.kt
+++ b/source-api/src/commonMain/kotlin/exh/source/SourceIds.kt
@@ -6,6 +6,7 @@ const val LEWD_SOURCE_SERIES = 6900L
 // KMK -->
 const val EH_SOURCE_ID = 1713178126840476467 // LEWD_SOURCE_SERIES + 1
 const val EXH_SOURCE_ID = 6225928719850211219 // LEWD_SOURCE_SERIES + 2
+const val EH_PACKAGE = "eu.kanade.tachiyomi.extension.all.ehentai"
 // KMK <--
 
 const val NHENTAI_SOURCE_ID = 7309872737163460316L


### PR DESCRIPTION
Introduce incognito mode functionality specifically for EH based sources and simplify the logic for retrieving incognito state. This enhancement allows users to toggle incognito mode within the settings.

## Summary by Sourcery

Introduce incognito mode support for EH-based sources, allowing users to enable or disable it via settings, and streamline the logic for retrieving incognito state.

New Features:
- Add incognito mode toggle for EH-based sources in settings.

Enhancements:
- Simplify and centralize logic for determining incognito state for sources.

Close #849 