### PR TITLE
feat(incognito): toggle incognito mode per manga

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -200,6 +200,6 @@ class DomainModule : InjektModule {
         addFactory { ReplaceExtensionRepo(get()) }
         addFactory { UpdateExtensionRepo(get(), get()) }
         addFactory { ToggleIncognito(get()) }
-        addFactory { GetIncognitoState(get(), get(), get()) }
+        addFactory { GetIncognitoState(get(), get(), get(), get()) }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/components/AppBar.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/AppBar.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -228,11 +229,21 @@ fun AppBarActions(
                 onClick = it.onClick,
                 enabled = it.enabled,
             ) {
-                Icon(
-                    imageVector = it.icon,
-                    tint = it.iconTint ?: LocalContentColor.current,
-                    contentDescription = it.title,
-                )
+                // KMK -->
+                if (it.iconPainter != null) {
+                    Icon(
+                        painter = it.iconPainter,
+                        tint = it.iconTint ?: LocalContentColor.current,
+                        contentDescription = it.title,
+                    )
+                } else {
+                    // KMK <--
+                    Icon(
+                        imageVector = it.icon!!,
+                        tint = it.iconTint ?: LocalContentColor.current,
+                        contentDescription = it.title,
+                    )
+                }
             }
         }
     }
@@ -461,7 +472,11 @@ sealed interface AppBar {
 
     data class Action(
         val title: String,
-        val icon: ImageVector,
+        val icon: ImageVector?,
+        // KMK -->
+        /** If iconPainter is passed, icon will be ignored */
+        val iconPainter: Painter? = null,
+        // KMK <--
         val iconTint: Color? = null,
         val onClick: () -> Unit,
         val enabled: Boolean = true,

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -141,6 +141,9 @@ import kotlin.math.roundToInt
 @Composable
 fun MangaScreen(
     state: MangaScreenModel.State.Success,
+    // KMK -->
+    mangaIncognitoState: Boolean?,
+    // KMK <--
     snackbarHostState: SnackbarHostState,
     nextUpdate: Instant?,
     isTabletUi: Boolean,
@@ -157,6 +160,9 @@ fun MangaScreen(
     // For tags menu
     onTagSearch: (String) -> Unit,
 
+    // KMK -->
+    onMangaIncognitoToggled: () -> Unit,
+    // KMK <--
     onFilterButtonClicked: () -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
@@ -222,6 +228,9 @@ fun MangaScreen(
     if (!isTabletUi) {
         MangaScreenSmallImpl(
             state = state,
+            // KMK -->
+            mangaIncognitoState = mangaIncognitoState,
+            // KMK <--
             snackbarHostState = snackbarHostState,
             nextUpdate = nextUpdate,
             chapterSwipeStartAction = chapterSwipeStartAction,
@@ -235,6 +244,9 @@ fun MangaScreen(
             onTrackingClicked = onTrackingClicked,
             onTagSearch = onTagSearch,
             onCopyTagToClipboard = onCopyTagToClipboard,
+            // KMK -->
+            onMangaIncognitoToggled = onMangaIncognitoToggled,
+            // KMK <--
             onFilterClicked = onFilterButtonClicked,
             onRefresh = onRefresh,
             onContinueReading = onContinueReading,
@@ -282,6 +294,9 @@ fun MangaScreen(
     } else {
         MangaScreenLargeImpl(
             state = state,
+            // KMK -->
+            mangaIncognitoState = mangaIncognitoState,
+            // KMK <--
             snackbarHostState = snackbarHostState,
             chapterSwipeStartAction = chapterSwipeStartAction,
             chapterSwipeEndAction = chapterSwipeEndAction,
@@ -295,6 +310,9 @@ fun MangaScreen(
             onTrackingClicked = onTrackingClicked,
             onTagSearch = onTagSearch,
             onCopyTagToClipboard = onCopyTagToClipboard,
+            // KMK -->
+            onMangaIncognitoToggled = onMangaIncognitoToggled,
+            // KMK <--
             onFilterButtonClicked = onFilterButtonClicked,
             onRefresh = onRefresh,
             onContinueReading = onContinueReading,
@@ -345,6 +363,9 @@ fun MangaScreen(
 @Composable
 private fun MangaScreenSmallImpl(
     state: MangaScreenModel.State.Success,
+    // KMK -->
+    mangaIncognitoState: Boolean?,
+    // KMK <--
     snackbarHostState: SnackbarHostState,
     nextUpdate: Instant?,
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
@@ -361,6 +382,9 @@ private fun MangaScreenSmallImpl(
     onTagSearch: (String) -> Unit,
     onCopyTagToClipboard: (tag: String) -> Unit,
 
+    // KMK -->
+    onMangaIncognitoToggled: () -> Unit,
+    // KMK <--
     onFilterClicked: () -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
@@ -474,8 +498,14 @@ private fun MangaScreenSmallImpl(
             )
             MangaToolbar(
                 title = state.manga.title,
+                // KMK -->
+                incognitoMode = mangaIncognitoState,
+                // KMK <--
                 hasFilters = state.filterActive,
                 navigateUp = navigateUp,
+                // KMK -->
+                onToggleMangaIncognito = onMangaIncognitoToggled,
+                // KMK <--
                 onClickFilter = onFilterClicked,
                 onClickShare = onShareClicked,
                 onClickDownload = onDownloadActionClicked,
@@ -810,6 +840,9 @@ private fun MangaScreenSmallImpl(
 @Composable
 private fun MangaScreenLargeImpl(
     state: MangaScreenModel.State.Success,
+    // KMK -->
+    mangaIncognitoState: Boolean?,
+    // KMK <--
     snackbarHostState: SnackbarHostState,
     nextUpdate: Instant?,
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
@@ -826,6 +859,9 @@ private fun MangaScreenLargeImpl(
     onTagSearch: (String) -> Unit,
     onCopyTagToClipboard: (tag: String) -> Unit,
 
+    // KMK -->
+    onMangaIncognitoToggled: () -> Unit,
+    // KMK <--
     onFilterButtonClicked: () -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
@@ -930,8 +966,14 @@ private fun MangaScreenLargeImpl(
             MangaToolbar(
                 modifier = Modifier.onSizeChanged { topBarHeight = it.height },
                 title = state.manga.title,
+                // KMK -->
+                incognitoMode = mangaIncognitoState,
+                // KMK <--
                 hasFilters = state.filterActive,
                 navigateUp = navigateUp,
+                // KMK -->
+                onToggleMangaIncognito = onMangaIncognitoToggled,
+                // KMK <--
                 onClickFilter = onFilterButtonClicked,
                 onClickShare = onShareClicked,
                 onClickDownload = onDownloadActionClicked,

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -1,5 +1,8 @@
 package eu.kanade.presentation.manga.components
 
+import androidx.compose.animation.graphics.res.animatedVectorResource
+import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
+import androidx.compose.animation.graphics.vector.AnimatedImageVector
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.FilterList
@@ -23,6 +26,7 @@ import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.AppBarTitle
 import eu.kanade.presentation.components.DownloadDropdownMenu
 import eu.kanade.presentation.manga.DownloadAction
+import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.browse.source.feed.SourceFeedScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
@@ -39,8 +43,14 @@ import uy.kohesive.injekt.api.get
 @Composable
 fun MangaToolbar(
     title: String,
+    // KMK -->
+    incognitoMode: Boolean?,
+    // KMK <--
     hasFilters: Boolean,
     navigateUp: () -> Unit,
+    // KMK -->
+    onToggleMangaIncognito: (() -> Unit)?,
+    // KMK <--
     onClickFilter: () -> Unit,
     onClickShare: (() -> Unit)?,
     onClickDownload: ((DownloadAction) -> Unit)?,
@@ -145,6 +155,22 @@ fun MangaToolbar(
                             ),
                         )
                     }
+                    // KMK -->
+                    if (onToggleMangaIncognito != null) {
+                        add(
+                            AppBar.Action(
+                                title = stringResource(MR.strings.pref_incognito_mode),
+                                icon = null,
+                                iconPainter = rememberAnimatedVectorPainter(
+                                    AnimatedImageVector.animatedVectorResource(R.drawable.anim_incognito),
+                                    incognitoMode == true,
+                                ),
+                                iconTint = if (incognitoMode == true) MaterialTheme.colorScheme.primary else null,
+                                onClick = onToggleMangaIncognito,
+                            ),
+                        )
+                    }
+                    // KMK <--
                     add(
                         AppBar.Action(
                             title = stringResource(MR.strings.action_filter),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
@@ -147,6 +147,9 @@ private fun Manga.toBackupManga(/* SY --> */customMangaInfo: CustomMangaInfo?/* 
             backupManga.customDescription = it.description
             backupManga.customGenre = it.genre
             backupManga.customStatus = it.status?.toInt() ?: 0
+            // KMK -->
+            backupManga.incognitoMode = it.incognitoMode ?: false
+            // KMK <--
         }
     }
 // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
@@ -48,6 +48,10 @@ data class BackupManga(
     @ProtoNumber(601) var flatMetadata: BackupFlatMetadata? = null,
     @ProtoNumber(602) var customStatus: Int = 0,
     @ProtoNumber(603) var customThumbnailUrl: String? = null,
+    // KMK -->
+    // Bump by 50 for values that are not in the original SY fork
+    @ProtoNumber(650) var incognitoMode: Boolean? = false,
+    // KMK <--
 
     // J2K specific values
     @ProtoNumber(800) var customTitle: String? = null,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -576,7 +576,10 @@ class MangaRestorer(
             customThumbnailUrl != null ||
             customDescription != null ||
             customGenre != null ||
-            customStatus != 0
+            customStatus != 0 ||
+            // KMK -->
+            incognitoMode != null
+            // KMK <--
         ) {
             return CustomMangaInfo(
                 id = 0L,
@@ -587,6 +590,9 @@ class MangaRestorer(
                 description = customDescription,
                 genre = customGenre,
                 status = customStatus.takeUnless { it == 0 }?.toLong(),
+                // KMK -->
+                incognitoMode = incognitoMode,
+                // KMK <--
             )
         }
         return null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -808,6 +808,9 @@ class LibraryScreenModel(
                 description = manga.description.takeUnless { it == manga.ogDescription },
                 genre = manga.genre.takeUnless { it == manga.ogGenre },
                 status = manga.status.takeUnless { it == manga.ogStatus }?.toLong(),
+                // KMK -->
+                incognitoMode = manga.incognitoMode,
+                // KMK <--
             )
 
             setCustomMangaInfo.set(mangaInfo)
@@ -838,6 +841,9 @@ class LibraryScreenModel(
                 description = null,
                 genre = null,
                 status = null,
+                // KMK -->
+                incognitoMode = null,
+                // KMK <--
             )
 
             setCustomMangaInfo.set(mangaInfo)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -269,6 +269,9 @@ class MangaScreen(
 
         MangaScreen(
             state = successState,
+            // KMK -->
+            mangaIncognitoState = screenModel.mangaIncognitoMode.value,
+            // KMK <--
             snackbarHostState = screenModel.snackbarHostState,
             nextUpdate = successState.manga.expectedNextUpdate,
             isTabletUi = isTabletUi(),
@@ -313,6 +316,9 @@ class MangaScreen(
                 }
             },
             onTagSearch = { scope.launch { performGenreSearch(navigator, it, screenModel.source!!) } },
+            // KMK -->
+            onMangaIncognitoToggled = screenModel::toggleMangaIncognitoMode,
+            // KMK <--
             onFilterButtonClicked = screenModel::showSettingsDialog,
             onRefresh = screenModel::fetchAllFromSource,
             onContinueReading = { continueReading(context, screenModel.getNextUnreadChapter()) },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -99,6 +99,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -512,6 +513,14 @@ class MangaScreenModel(
             // Initial loading finished
             updateSuccessState { it.copy(isRefreshingData = false) }
         }
+
+        // KMK-->
+        getIncognitoState.subscribe(sourceId = null, mangaId = mangaId)
+            .onEach {
+                mangaIncognitoMode.value = it
+            }
+            .launchIn(screenModelScope)
+        // KMK <--
     }
 
     // KMK -->
@@ -1791,8 +1800,7 @@ class MangaScreenModel(
 
     // KMK -->
     fun toggleMangaIncognitoMode() {
-        mangaIncognitoMode.value = !mangaIncognitoMode.value
-        setCustomMangaInfo.setIncognitoMode(mangaId, mangaIncognitoMode.value)
+        setCustomMangaInfo.setIncognitoMode(mangaId, !mangaIncognitoMode.value)
     }
     // KMK <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -270,7 +270,7 @@ class ReaderViewModel @JvmOverloads constructor(
             .map(::ReaderChapter)
     }
 
-    private val incognitoMode: Boolean by lazy { getIncognitoState.await(manga?.source) }
+    private val incognitoMode: Boolean by lazy { getIncognitoState.await(manga?.source, /* KMK --> */ manga?.id /* KMK <-- */) }
     private val downloadAheadAmount = downloadPreferences.autoDownloadWhileReading().get()
 
     init {

--- a/data/src/main/java/tachiyomi/data/manga/CustomMangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/CustomMangaRepositoryImpl.kt
@@ -2,8 +2,6 @@ package tachiyomi.data.manga
 
 import android.content.Context
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import tachiyomi.domain.manga.model.CustomMangaInfo
 import tachiyomi.domain.manga.repository.CustomMangaRepository
@@ -45,7 +43,10 @@ class CustomMangaRepositoryImpl(context: Context) : CustomMangaRepository {
             mangaInfo.thumbnailUrl == null &&
             mangaInfo.description == null &&
             mangaInfo.genre == null &&
-            mangaInfo.status == null
+            mangaInfo.status == null &&
+            // KMK -->
+            mangaInfo.incognitoMode != true
+            // KMK <--
         ) {
             customMangaMap.remove(mangaInfo.id)
         } else {
@@ -77,6 +78,9 @@ class CustomMangaRepositoryImpl(context: Context) : CustomMangaRepository {
         val description: String? = null,
         val genre: List<String>? = null,
         val status: Long? = null,
+        // KMK -->
+        val incognitoMode: Boolean? = null,
+        // KMK <--
     ) {
 
         fun toManga() = CustomMangaInfo(
@@ -88,6 +92,9 @@ class CustomMangaRepositoryImpl(context: Context) : CustomMangaRepository {
             description = this@MangaJson.description,
             genre = this@MangaJson.genre,
             status = this@MangaJson.status?.takeUnless { it == 0L },
+            // KMK -->
+            incognitoMode = this@MangaJson.incognitoMode,
+            // KMK <--
         )
     }
 
@@ -101,6 +108,9 @@ class CustomMangaRepositoryImpl(context: Context) : CustomMangaRepository {
             description,
             genre,
             status,
+            // KMK -->
+            incognitoMode,
+            // KMK <--
         )
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetCustomMangaInfo.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetCustomMangaInfo.kt
@@ -7,4 +7,8 @@ class GetCustomMangaInfo(
 ) {
 
     fun get(mangaId: Long) = customMangaRepository.get(mangaId)
+
+    // KMK -->
+    fun getIncognitoMode(mangaId: Long) = customMangaRepository.get(mangaId)?.incognitoMode ?: false
+    // KMK <--
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/SetCustomMangaInfo.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/SetCustomMangaInfo.kt
@@ -8,4 +8,11 @@ class SetCustomMangaInfo(
 ) {
 
     fun set(mangaInfo: CustomMangaInfo) = customMangaRepository.set(mangaInfo)
+
+    // KMK -->
+    fun setIncognitoMode(mangaId: Long, incognitoMode: Boolean?) {
+        val mangaInfo = customMangaRepository.get(mangaId) ?: CustomMangaInfo(mangaId, null)
+        set(mangaInfo.copy(incognitoMode = incognitoMode))
+    }
+    // KMK <--
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/model/CustomMangaInfo.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/CustomMangaInfo.kt
@@ -9,4 +9,7 @@ data class CustomMangaInfo(
     val description: String? = null,
     val genre: List<String>? = null,
     val status: Long? = null,
+    // KMK -->
+    val incognitoMode: Boolean? = null,
+    // KMK <--
 )

--- a/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
@@ -104,6 +104,10 @@ data class Manga(
             else -> TriState.DISABLED
         }
 
+    // KMK -->
+    val incognitoMode = customMangaInfo?.incognitoMode ?: false
+    // KMK <--
+
     fun sortDescending(): Boolean {
         return chapterFlags and CHAPTER_SORT_DIR_MASK == CHAPTER_SORT_DESC
     }


### PR DESCRIPTION
## Summary by Sourcery

Add support for toggling incognito mode on a per-manga basis, including UI controls, state management, persistence, and backup/restore integration.

New Features:
- Introduce per-manga incognito mode toggle in the manga screen UI.
- Persist incognito mode state for individual manga.
- Include per-manga incognito mode in backup and restore operations.

Enhancements:
- Update incognito state logic to support both global and per-manga settings.
- Extend AppBar action to support custom painter icons for animated incognito toggle.