### PR TITLE
fix(migrate-dialog): Fix migrate-dialog reappear before migration actual complete

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
@@ -28,7 +30,7 @@ import tachiyomi.presentation.core.i18n.stringResource
  * @param dialog the dialog to show.
  */
 @Composable
-fun BulkFavoriteDialogs(
+fun Screen.BulkFavoriteDialogs(
     bulkFavoriteScreenModel: BulkFavoriteScreenModel,
     dialog: Dialog?,
 ) {
@@ -84,6 +86,7 @@ fun BulkFavoriteDialogs(
                 dialog = dialog,
                 navigator = navigator,
                 state = bulkFavoriteState,
+                migrateScreenModel = rememberScreenModel { MigrateDialogScreenModel() },
                 onDismiss = bulkFavoriteScreenModel::dismissDialog,
                 stopRunning = bulkFavoriteScreenModel::stopRunning,
                 toggleSelection = bulkFavoriteScreenModel::toggleSelection,
@@ -99,6 +102,7 @@ private fun ShowMigrateDialog(
     dialog: Dialog.Migrate,
     navigator: Navigator?,
     state: BulkFavoriteScreenModel.State,
+    migrateScreenModel: MigrateDialogScreenModel,
     onDismiss: () -> Unit,
     stopRunning: () -> Unit,
     toggleSelection: (Manga, toSelectedState: Boolean) -> Unit,
@@ -109,7 +113,7 @@ private fun ShowMigrateDialog(
     MigrateDialog(
         oldManga = dialog.oldManga,
         newManga = dialog.newManga,
-        screenModel = MigrateDialogScreenModel(),
+        screenModel = migrateScreenModel,
         onDismissRequest = onDismiss,
         onClickTitle = { navigator?.push(MangaScreen(dialog.oldManga.id)) },
         onPopScreen = {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalHapticFeedback
+import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.core.stack.StackEvent
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -42,7 +43,7 @@ import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.i18n.stringResource
 
 @Composable
-fun feedTab(
+fun Screen.feedTab(
     // KMK -->
     screenModel: FeedScreenModel,
     bulkFavoriteScreenModel: BulkFavoriteScreenModel,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -463,7 +463,7 @@ data class BrowseSourceScreen(
                 MigrateDialog(
                     oldManga = dialog.oldManga,
                     newManga = dialog.newManga,
-                    screenModel = MigrateDialogScreenModel(),
+                    screenModel = rememberScreenModel { MigrateDialogScreenModel() },
                     onDismissRequest = onDismissRequest,
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
                     onPopScreen = { onDismissRequest() },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -138,7 +138,7 @@ data object HistoryTab : Tab {
                 MigrateDialog(
                     oldManga = dialog.oldManga,
                     newManga = dialog.newManga,
-                    screenModel = MigrateDialogScreenModel(),
+                    screenModel = rememberScreenModel { MigrateDialogScreenModel() },
                     onDismissRequest = onDismissRequest,
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
                     onPopScreen = onDismissRequest,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -467,7 +467,7 @@ class MangaScreen(
                 MigrateDialog(
                     oldManga = dialog.oldManga,
                     newManga = dialog.newManga,
-                    screenModel = MigrateDialogScreenModel(),
+                    screenModel = rememberScreenModel { MigrateDialogScreenModel() },
                     onDismissRequest = onDismissRequest,
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
                     onPopScreen = onDismissRequest,

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -169,7 +169,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                 MigrateDialog(
                     oldManga = dialog.oldManga,
                     newManga = dialog.newManga,
-                    screenModel = MigrateDialogScreenModel(),
+                    screenModel = rememberScreenModel { MigrateDialogScreenModel() },
                     onDismissRequest = onDismissRequest,
                     onClickTitle = { navigator.push(MangaScreen(dialog.oldManga.id)) },
                     onPopScreen = { onDismissRequest() },


### PR DESCRIPTION
refactor MigrateDialog to use rememberScreenModel for state management

## Summary by Sourcery

Persist the state of MigrateDialog using rememberScreenModel to address dialog reappearance issues and improve state management consistency.

Bug Fixes:
- Prevent MigrateDialog from reappearing before migration is actually complete by persisting its state.

Enhancements:
- Refactor MigrateDialog to use rememberScreenModel for consistent state management across multiple screens.