### PR TITLE
chore(network-local-manga): Reintroduce (in-memory) fast browsing

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasComfortableGrid.kt
@@ -80,7 +80,7 @@ fun RelatedMangasComfortableGrid(
                     )
                 }
                 items(
-                    key = { "related-comfort-${relatedManga.mangaList[it].id}" },
+                    key = { "related-comfort-${relatedManga.mangaList[it].url.hashCode()}" },
                     count = relatedManga.mangaList.size,
                 ) { index ->
                     val manga by getManga(relatedManga.mangaList[index])

--- a/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasCompactGrid.kt
@@ -79,7 +79,7 @@ fun RelatedMangasCompactGrid(
                     )
                 }
                 items(
-                    key = { "related-compact-${relatedManga.mangaList[it].id}" },
+                    key = { "related-compact-${relatedManga.mangaList[it].url.hashCode()}" },
                     count = relatedManga.mangaList.size,
                 ) { index ->
                     val manga by getManga(relatedManga.mangaList[index])

--- a/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasList.kt
@@ -82,7 +82,7 @@ fun RelatedMangasList(
                     )
                 }
                 items(
-                    key = { "related-list-${relatedManga.mangaList[it].id}" },
+                    key = { "related-list-${relatedManga.mangaList[it].url.hashCode()}" },
                     count = relatedManga.mangaList.size,
                 ) { index ->
                     val manga by getManga(relatedManga.mangaList[index])

--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
@@ -29,6 +29,7 @@ import eu.kanade.tachiyomi.ui.browse.feed.FeedScreenModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.components.material.TabText
 import tachiyomi.presentation.core.i18n.stringResource
@@ -68,14 +69,25 @@ fun TabbedScreen(
                         feedState.items?.let { result ->
                             result.mapNotNull { it.results }
                                 .flatten()
-                                .forEach { bulkFavoriteScreenModel.select(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                            .forEach { bulkFavoriteScreenModel.select(it) }
+                                    }
+                                }
                         }
                     },
                     onReverseSelection = {
                         feedState.items?.let { result ->
                             result.mapNotNull { it.results }
                                 .flatten()
-                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.reverseSelection(
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                        )
+                                    }
+                                }
                         }
                     },
                 )

--- a/app/src/main/java/eu/kanade/presentation/manga/components/RelatedMangasRow.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/RelatedMangasRow.kt
@@ -66,7 +66,7 @@ fun RelatedMangaCardRow(
         contentPadding = PaddingValues(MaterialTheme.padding.small),
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
     ) {
-        items(mangas, key = { "related-row-${it.id}" }) {
+        items(mangas, key = { "related-row-${it.url.hashCode()}" }) {
             val manga by getManga(it)
             MangaItem(
                 title = manga.title,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -54,7 +54,10 @@ class BulkFavoriteScreenModel(
     private val coverCache: CoverCache = Injekt.get(),
     private val setMangaDefaultChapterFlags: SetMangaDefaultChapterFlags = Injekt.get(),
     private val addTracks: AddTracks = Injekt.get(),
+
+    // KMK -->
     val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    // KMK <--
 ) : StateScreenModel<BulkFavoriteScreenModel.State>(initialState) {
 
     fun backHandler() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -34,6 +34,7 @@ import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.chapter.interactor.SetMangaDefaultChapterFlags
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
+import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.manga.model.toMangaUpdate
@@ -53,6 +54,7 @@ class BulkFavoriteScreenModel(
     private val coverCache: CoverCache = Injekt.get(),
     private val setMangaDefaultChapterFlags: SetMangaDefaultChapterFlags = Injekt.get(),
     private val addTracks: AddTracks = Injekt.get(),
+    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
 ) : StateScreenModel<BulkFavoriteScreenModel.State>(initialState) {
 
     fun backHandler() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
@@ -305,6 +305,7 @@ open class FeedScreenModel(
                                 .map { it.toDomainManga(itemUI.source!!.id) }
                                 .distinctBy { it.url }
                                 // KMK -->
+                                // .let { networkToLocalManga(it) }
                                 .filter { !hideInLibraryFeedItems.get() || !it.favorite },
                             // KMK <--
                         )
@@ -342,6 +343,7 @@ open class FeedScreenModel(
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
                 .collectLatest { manga ->
+                    /* KMK --> if (manga == null) return@collectLatest KMK <-- */
                     value = manga
                         // KMK -->
                         ?: initialManga

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
@@ -60,7 +60,7 @@ open class FeedScreenModel(
     val sourceManager: SourceManager = Injekt.get(),
     val sourcePreferences: SourcePreferences = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
-    private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     getFeedSavedSearchGlobal: GetFeedSavedSearchGlobal = Injekt.get(),
     private val getSavedSearchGlobalFeed: GetSavedSearchGlobalFeed = Injekt.get(),
     private val countFeedSavedSearchGlobal: CountFeedSavedSearchGlobal = Injekt.get(),
@@ -304,7 +304,6 @@ open class FeedScreenModel(
                             results = page
                                 .map { it.toDomainManga(itemUI.source!!.id) }
                                 .distinctBy { it.url }
-                                .let { networkToLocalManga(it) }
                                 // KMK -->
                                 .filter { !hideInLibraryFeedItems.get() || !it.favorite },
                             // KMK <--
@@ -343,8 +342,10 @@ open class FeedScreenModel(
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
                 .collectLatest { manga ->
-                    if (manga == null) return@collectLatest
                     value = manga
+                        // KMK -->
+                        ?: initialManga
+                    // KMK <--
                 }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -33,6 +34,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.persistentListOf
 import mihon.presentation.core.util.collectAsLazyPagingItems
 import tachiyomi.core.common.Constants
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.material.Scaffold
@@ -66,6 +68,7 @@ data class SourceSearchScreen(
 
         // KMK -->
         val context = LocalContext.current
+        val scope = rememberCoroutineScope()
 
         val bulkFavoriteScreenModel = rememberScreenModel { BulkFavoriteScreenModel() }
         val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
@@ -161,16 +164,26 @@ data class SourceSearchScreen(
                 },
                 onHelpClick = { uriHandler.openUri(Constants.URL_HELP) },
                 onLocalSourceHelpClick = { uriHandler.openUri(LocalSource.HELP_URL) },
-                onMangaClick = { manga ->
+                onMangaClick = {
                     // KMK -->
-                    if (bulkFavoriteState.selectionMode) {
-                        bulkFavoriteScreenModel.toggleSelection(manga)
-                    } else {
-                        // KMK <--
-                        openMigrateDialog(manga)
+                    scope.launchIO {
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        if (bulkFavoriteState.selectionMode) {
+                            bulkFavoriteScreenModel.toggleSelection(manga)
+                        } else {
+                            // KMK <--
+                            openMigrateDialog(manga)
+                        }
                     }
                 },
-                onMangaLongClick = { navigator.push(MangaScreen(it.id, true)) },
+                onMangaLongClick = {
+                    // KMK -->
+                    scope.launchIO {
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        // KMK <--
+                        navigator.push(MangaScreen(manga.id, true))
+                    }
+                },
                 // KMK -->
                 selection = bulkFavoriteState.selection,
                 // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
@@ -92,12 +92,23 @@ data class SourceSearchScreen(
                         onSelectAll = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .forEach { bulkFavoriteScreenModel.select(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                            .forEach { bulkFavoriteScreenModel.select(it) }
+                                    }
+                                }
                         },
                         onReverseSelection = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.reverseSelection(
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                        )
+                                    }
+                                }
                         },
                     )
                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -202,12 +202,23 @@ data class BrowseSourceScreen(
                             onSelectAll = {
                                 mangaList.itemSnapshotList.items
                                     .map { it.value.first }
-                                    .forEach { bulkFavoriteScreenModel.select(it) }
+                                    .let {
+                                        scope.launchIO {
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                                .forEach { bulkFavoriteScreenModel.select(it) }
+                                        }
+                                    }
                             },
                             onReverseSelection = {
                                 mangaList.itemSnapshotList.items
                                     .map { it.value.first }
-                                    .let { bulkFavoriteScreenModel.reverseSelection(it) }
+                                    .let {
+                                        scope.launchIO {
+                                            bulkFavoriteScreenModel.reverseSelection(
+                                                bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                            )
+                                        }
+                                    }
                             },
                         )
                     } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -356,32 +356,36 @@ data class BrowseSourceScreen(
                 onWebViewClick = onWebViewClick,
                 onHelpClick = { uriHandler.openUri(Constants.URL_HELP) },
                 onLocalSourceHelpClick = onHelpClick,
-                onMangaClick = { manga ->
+                onMangaClick = {
                     // KMK -->
-                    if (bulkFavoriteState.selectionMode) {
-                        bulkFavoriteScreenModel.toggleSelection(manga)
-                    } else {
-                        // KMK <--
-                        navigator.push(
-                            MangaScreen(
-                                mangaId = manga.id,
-                                // KMK -->
-                                // Finding the entry to be merged to, so we don't want to expand description
-                                // so that user can see the `Merge to another` button
-                                fromSource = smartSearchConfig == null,
-                                // KMK <--
-                                smartSearchConfig = smartSearchConfig,
-                            ),
-                        )
+                    scope.launchIO {
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        if (bulkFavoriteState.selectionMode) {
+                            bulkFavoriteScreenModel.toggleSelection(manga)
+                        } else {
+                            // KMK <--
+                            navigator.push(
+                                MangaScreen(
+                                    mangaId = manga.id,
+                                    // KMK -->
+                                    // Finding the entry to be merged to, so we don't want to expand description
+                                    // so that user can see the `Merge to another` button
+                                    fromSource = smartSearchConfig == null,
+                                    // KMK <--
+                                    smartSearchConfig = smartSearchConfig,
+                                ),
+                            )
+                        }
                     }
                 },
-                onMangaLongClick = { manga ->
+                onMangaLongClick = {
                     // KMK -->
-                    if (bulkFavoriteState.selectionMode) {
-                        navigator.push(MangaScreen(manga.id, true))
-                    } else {
-                        // KMK <--
-                        scope.launchIO {
+                    scope.launchIO {
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        if (bulkFavoriteState.selectionMode) {
+                            navigator.push(MangaScreen(manga.id, true))
+                        } else {
+                            // KMK <--
                             val duplicates = screenModel.getDuplicateLibraryManga(manga)
                             when {
                                 manga.favorite -> screenModel.setDialog(BrowseSourceScreenModel.Dialog.RemoveManga(manga))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -70,6 +70,7 @@ import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
 import tachiyomi.domain.manga.interactor.GetFlatMetadataById
 import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.manga.model.toMangaUpdate
@@ -108,6 +109,7 @@ open class BrowseSourceScreenModel(
     private val setMangaCategories: SetMangaCategories = Injekt.get(),
     private val setMangaDefaultChapterFlags: SetMangaDefaultChapterFlags = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
+    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val updateManga: UpdateManga = Injekt.get(),
     private val addTracks: AddTracks = Injekt.get(),
     private val getIncognitoState: GetIncognitoState = Injekt.get(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -39,6 +40,7 @@ import exh.md.follows.MangaDexFollowsScreen
 import exh.source.anyIs
 import exh.source.isEhBasedSource
 import exh.util.nullIfBlank
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.UnsortedPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.interactor.GetRemoteManga
@@ -65,6 +67,7 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
         val context = LocalContext.current
 
         // KMK -->
+        val scope = rememberCoroutineScope()
         screenModel.source.let {
             if (it is StubSource) {
                 MissingSourceScreen(
@@ -123,13 +126,16 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
                     // onClickDelete = screenModel::openDeleteFeed,
                     onLongClickFeed = screenModel::openActionsDialog,
                     // KMK <--
-                    onClickManga = { manga ->
+                    onClickManga = {
                         // KMK -->
-                        if (bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.toggleSelection(manga)
-                        } else {
-                            // KMK <--
-                            onMangaClick(navigator, manga)
+                        scope.launchIO {
+                            val manga = screenModel.networkToLocalManga.getLocal(it)
+                            if (bulkFavoriteState.selectionMode) {
+                                bulkFavoriteScreenModel.toggleSelection(manga)
+                            } else {
+                                // KMK <--
+                                onMangaClick(navigator, manga)
+                            }
                         }
                     },
                     onClickSearch = { onSearchClick(navigator, screenModel.source, it) },
@@ -164,11 +170,14 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
                                 .filterIsInstance<SourceFeedUI.SourceSavedSearch>()
                                 .isNotEmpty()
                         },
-                    onLongClickManga = { manga ->
-                        if (!bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                        } else {
-                            navigator.push(MangaScreen(manga.id, true))
+                    onLongClickManga = {
+                        scope.launchIO {
+                            val manga = screenModel.networkToLocalManga.getLocal(it)
+                            if (!bulkFavoriteState.selectionMode) {
+                                bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                            } else {
+                                navigator.push(MangaScreen(manga.id, true))
+                            }
                         }
                     },
                     bulkFavoriteScreenModel = bulkFavoriteScreenModel,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
@@ -250,6 +250,7 @@ open class SourceFeedScreenModel(
                     val titles = withIOContext {
                         page.map { it.toDomainManga(source.id) }
                             .distinctBy { it.url }
+                        /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
                     }
 
                     mutableState.update { state ->
@@ -283,6 +284,7 @@ open class SourceFeedScreenModel(
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
                 .collectLatest { manga ->
+                    /* KMK --> if (manga == null) return@collectLatest KMK <-- */
                     value = manga
                         // KMK -->
                         ?: initialManga

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
@@ -73,7 +73,7 @@ open class SourceFeedScreenModel(
     uiPreferences: UiPreferences = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
-    private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val getFeedSavedSearchBySourceId: GetFeedSavedSearchBySourceId = Injekt.get(),
     private val getSavedSearchBySourceIdFeed: GetSavedSearchBySourceIdFeed = Injekt.get(),
     private val countFeedSavedSearchBySourceId: CountFeedSavedSearchBySourceId = Injekt.get(),
@@ -250,7 +250,6 @@ open class SourceFeedScreenModel(
                     val titles = withIOContext {
                         page.map { it.toDomainManga(source.id) }
                             .distinctBy { it.url }
-                            .let { networkToLocalManga(it) }
                     }
 
                     mutableState.update { state ->
@@ -284,8 +283,10 @@ open class SourceFeedScreenModel(
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
                 .collectLatest { manga ->
-                    if (manga == null) return@collectLatest
                     value = manga
+                        // KMK -->
+                        ?: initialManga
+                    // KMK <--
                 }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
@@ -83,6 +83,7 @@ abstract class SearchScreenModel(
     fun getManga(initialManga: Manga): androidx.compose.runtime.State<Manga> {
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
+                /* KMK --> .filterNotNull() KMK <-- */
                 .collectLatest { manga ->
                     value = manga
                         // KMK -->
@@ -191,6 +192,7 @@ abstract class SearchScreenModel(
                         val titles = page.mangas
                             .map { it.toDomainManga(source.id) }
                             .distinctBy { it.url }
+                        /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
 
                         if (isActive) {
                             updateItem(source, SearchItemResult.Success(titles))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -39,7 +39,7 @@ abstract class SearchScreenModel(
     sourcePreferences: SourcePreferences = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val extensionManager: ExtensionManager = Injekt.get(),
-    private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val preferences: SourcePreferences = Injekt.get(),
 ) : StateScreenModel<SearchScreenModel.State>(initialState) {
@@ -83,9 +83,11 @@ abstract class SearchScreenModel(
     fun getManga(initialManga: Manga): androidx.compose.runtime.State<Manga> {
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
-                .filterNotNull()
                 .collectLatest { manga ->
                     value = manga
+                        // KMK -->
+                        ?: initialManga
+                    // KMK <--
                 }
         }
     }
@@ -189,7 +191,6 @@ abstract class SearchScreenModel(
                         val titles = page.mangas
                             .map { it.toDomainManga(source.id) }
                             .distinctBy { it.url }
-                            .let { networkToLocalManga(it) }
 
                         if (isActive) {
                             updateItem(source, SearchItemResult.Success(titles))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -389,8 +389,18 @@ class MangaScreen(
                 }
                 showRelatedMangasScreen()
             },
-            onRelatedMangaClick = { navigator.push(MangaScreen(it.id, true)) },
-            onRelatedMangaLongClick = { bulkFavoriteScreenModel.addRemoveManga(it, haptic) },
+            onRelatedMangaClick = {
+                scope.launchIO {
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    navigator.push(MangaScreen(manga.id, true))
+                }
+            },
+            onRelatedMangaLongClick = {
+                scope.launchIO {
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                }
+            },
             onSourceClick = {
                 if (successState.source !is StubSource) {
                     val screen = when {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -704,6 +704,7 @@ class MangaScreenModel(
     fun getManga(initialManga: Manga): RuntimeState<Manga> {
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
+                /* KMK --> .filterNotNull() KMK <-- */
                 .flowWithLifecycle(lifecycle)
                 .collectLatest { manga ->
                     value = manga
@@ -1156,6 +1157,7 @@ class MangaScreenModel(
                         mangaList
                             .map { it.toDomainManga(state.source.id) }
                             .distinctBy { it.url }
+                        /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
                     }
 
                     updateSuccessState { successState ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
@@ -58,14 +58,25 @@ fun RelatedMangasScreen(
                         successState.relatedMangasSorted?.let { result ->
                             result.map { it as RelatedManga.Success }
                                 .flatMap { it.mangaList }
-                                .forEach { bulkFavoriteScreenModel.select(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                            .forEach { bulkFavoriteScreenModel.select(it) }
+                                    }
+                                }
                         }
                     },
                     onReverseSelection = {
                         successState.relatedMangasSorted?.let { result ->
                             result.map { it as RelatedManga.Success }
                                 .flatMap { it.mangaList }
-                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.reverseSelection(
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                        )
+                                    }
+                                }
                         }
                     },
                 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
@@ -22,6 +22,7 @@ import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import kotlinx.coroutines.CoroutineScope
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.presentation.core.components.material.Scaffold
 import uy.kohesive.injekt.Injekt
@@ -88,18 +89,24 @@ fun RelatedMangasScreen(
             columns = getColumnsPreference(LocalConfiguration.current.orientation),
             displayMode = displayMode,
             contentPadding = paddingValues,
-            onMangaClick = { manga ->
-                if (bulkFavoriteState.selectionMode) {
-                    bulkFavoriteScreenModel.toggleSelection(manga)
-                } else {
-                    navigator.push(MangaScreen(manga.id, true))
+            onMangaClick = {
+                scope.launchIO {
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    if (bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.toggleSelection(manga)
+                    } else {
+                        navigator.push(MangaScreen(manga.id, true))
+                    }
                 }
             },
-            onMangaLongClick = { manga ->
-                if (!bulkFavoriteState.selectionMode) {
-                    bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                } else {
-                    navigator.push(MangaScreen(manga.id, true))
+            onMangaLongClick = {
+                scope.launchIO {
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    if (!bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                    } else {
+                        navigator.push(MangaScreen(manga.id, true))
+                    }
                 }
             },
             onKeywordClick = { query ->

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -117,22 +117,26 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                 onWebViewClick = null,
                 onHelpClick = null,
                 onLocalSourceHelpClick = null,
-                onMangaClick = { manga ->
+                onMangaClick = {
                     // KMK -->
-                    if (bulkFavoriteState.selectionMode) {
-                        bulkFavoriteScreenModel.toggleSelection(manga)
-                    } else {
-                        // KMK <--
-                        navigator.push(MangaScreen(manga.id, true))
+                    scope.launchIO {
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        if (bulkFavoriteState.selectionMode) {
+                            bulkFavoriteScreenModel.toggleSelection(manga)
+                        } else {
+                            // KMK <--
+                            navigator.push(MangaScreen(manga.id, true))
+                        }
                     }
                 },
-                onMangaLongClick = { manga ->
+                onMangaLongClick = {
                     // KMK -->
-                    if (bulkFavoriteState.selectionMode) {
-                        navigator.push(MangaScreen(manga.id, true))
-                    } else {
-                        // KMK <--
-                        scope.launchIO {
+                    scope.launchIO {
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        if (bulkFavoriteState.selectionMode) {
+                            navigator.push(MangaScreen(manga.id, true))
+                        } else {
+                            // KMK <--
                             val duplicates = screenModel.getDuplicateLibraryManga(manga)
                             when {
                                 manga.favorite -> screenModel.setDialog(BrowseSourceScreenModel.Dialog.RemoveManga(manga))

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -77,12 +77,23 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                         onSelectAll = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .forEach { bulkFavoriteScreenModel.select(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                            .forEach { bulkFavoriteScreenModel.select(it) }
+                                    }
+                                }
                         },
                         onReverseSelection = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.reverseSelection(
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                        )
+                                    }
+                                }
                         },
                     )
                 } else {

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -97,12 +97,23 @@ class BrowseRecommendsScreen(
                         onSelectAll = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .forEach { bulkFavoriteScreenModel.select(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                            .forEach { bulkFavoriteScreenModel.select(it) }
+                                    }
+                                }
                         },
                         onReverseSelection = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
+                                .let {
+                                    scope.launchIO {
+                                        bulkFavoriteScreenModel.reverseSelection(
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                        )
+                                    }
+                                }
                         },
                     )
                 } else {
@@ -144,25 +155,33 @@ class BrowseRecommendsScreen(
                 onLocalSourceHelpClick = null,
                 onMangaClick = {
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.toggleSelection(manga)
-                        } else {
-                            // KMK <--
-                            onClickItem(manga)
+                    if (isExternalSource) {
+                        onClickItem(it)
+                    } else {
+                        scope.launchIO {
+                            val manga = screenModel.networkToLocalManga.getLocal(it)
+                            if (bulkFavoriteState.selectionMode) {
+                                bulkFavoriteScreenModel.toggleSelection(manga)
+                            } else {
+                                // KMK <--
+                                onClickItem(manga)
+                            }
                         }
                     }
                 },
                 onMangaLongClick = {
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (!bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                        } else {
-                            // KMK <--
-                            onLongClickItem(manga)
+                    if (isExternalSource) {
+                        onLongClickItem(it)
+                    } else {
+                        scope.launchIO {
+                            val manga = screenModel.networkToLocalManga.getLocal(it)
+                            if (!bulkFavoriteState.selectionMode) {
+                                bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                            } else {
+                                // KMK <--
+                                onLongClickItem(manga)
+                            }
                         }
                     }
                 },

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -24,6 +25,7 @@ import eu.kanade.tachiyomi.ui.browse.source.SourcesScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import mihon.presentation.core.util.collectAsLazyPagingItems
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.screens.LoadingScreen
@@ -50,6 +52,7 @@ class BrowseRecommendsScreen(
         }
 
         // KMK -->
+        val scope = rememberCoroutineScope()
         val bulkFavoriteScreenModel = rememberScreenModel { BulkFavoriteScreenModel() }
         val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
 
@@ -139,23 +142,29 @@ class BrowseRecommendsScreen(
                 onWebViewClick = null,
                 onHelpClick = null,
                 onLocalSourceHelpClick = null,
-                onMangaClick = { manga ->
+                onMangaClick = {
                     // KMK -->
-                    if (bulkFavoriteState.selectionMode) {
-                        bulkFavoriteScreenModel.toggleSelection(manga)
-                    } else {
-                        // KMK <--
-                        onClickItem(manga)
+                    scope.launchIO {
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        if (bulkFavoriteState.selectionMode) {
+                            bulkFavoriteScreenModel.toggleSelection(manga)
+                        } else {
+                            // KMK <--
+                            onClickItem(manga)
+                        }
                     }
                 },
-                onMangaLongClick = { manga ->
+                onMangaLongClick = {
                     // KMK -->
-                    if (!bulkFavoriteState.selectionMode) {
-                        bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                    } else {
-                        onLongClickItem(manga)
+                    scope.launchIO {
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        if (!bulkFavoriteState.selectionMode) {
+                            bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                        } else {
+                            // KMK <--
+                            onLongClickItem(manga)
+                        }
                     }
-                    // KMK <--
                 },
                 // KMK -->
                 selection = bulkFavoriteState.selection,

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -179,10 +179,10 @@ class BrowseRecommendsScreen(
                             if (!bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                             } else {
-                                // KMK <--
                                 onLongClickItem(manga)
                             }
                         }
+                        // KMK <--
                     }
                 },
                 // KMK -->

--- a/app/src/main/java/exh/recs/RecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import cafe.adriel.voyager.core.model.rememberScreenModel
@@ -17,6 +18,7 @@ import eu.kanade.tachiyomi.ui.browse.source.SourcesScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import exh.recs.components.RecommendsScreen
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.presentation.core.screens.LoadingScreen
 
@@ -38,6 +40,7 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
         val state by screenModel.state.collectAsState()
 
         // KMK -->
+        val scope = rememberCoroutineScope()
         val bulkFavoriteScreenModel = rememberScreenModel { BulkFavoriteScreenModel() }
         val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
 
@@ -49,12 +52,21 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
         // KMK <--
 
         val onClickItem = { manga: Manga ->
-            navigator.push(
-                when (manga.source) {
-                    RECOMMENDS_SOURCE -> SourcesScreen(SourcesScreen.SmartSearchConfig(manga.ogTitle))
-                    else -> MangaScreen(manga.id, true)
-                },
-            )
+            when (manga.source) {
+                RECOMMENDS_SOURCE -> navigator.push(
+                    SourcesScreen(SourcesScreen.SmartSearchConfig(manga.ogTitle)),
+                )
+                else -> {
+                    // KMK -->
+                    scope.launchIO {
+                        val localManga = screenModel.networkToLocalManga.getLocal(manga)
+                        navigator.push(
+                            // KMK <--
+                            MangaScreen(localManga.id, true),
+                        )
+                    }
+                }
+            }
         }
 
         val onLongClickItem = { manga: Manga ->
@@ -62,11 +74,13 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
                 RECOMMENDS_SOURCE -> WebViewActivity.newIntent(context, manga.url, title = manga.title).let(context::startActivity)
                 else -> {
                     // KMK -->
-                    // Add to favorite
-                    bulkFavoriteScreenModel.addRemoveManga(
-                        manga,
-                        haptic,
-                    )
+                    scope.launchIO {
+                        val localManga = screenModel.networkToLocalManga.getLocal(manga)
+                        bulkFavoriteScreenModel.addRemoveManga(
+                            localManga,
+                            haptic,
+                        )
+                    }
                     // KMK <--
                 }
             }

--- a/app/src/main/java/exh/recs/RecommendsScreenModel.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreenModel.kt
@@ -83,6 +83,7 @@ open class RecommendsScreenModel(
                             // If the recommendation is associated with a source, resolve it
                             // Otherwise, skip this step. The user will be prompted to choose a source via SmartSearch
                             it.toDomainManga(recSourceId ?: RECOMMENDS_SOURCE)
+                            /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
                         }
                             // KMK <--
                             .distinctBy { it.url }

--- a/app/src/main/java/exh/recs/RecommendsScreenModel.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreenModel.kt
@@ -32,7 +32,7 @@ open class RecommendsScreenModel(
     val mangaId: Long,
     val sourceId: Long,
     private val getManga: GetManga = Injekt.get(),
-    protected val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
 ) : StateScreenModel<RecommendsScreenModel.State>(State()) {
 
     // KMK -->
@@ -78,14 +78,13 @@ open class RecommendsScreenModel(
                         }
 
                         val recSourceId = recSource.associatedSourceId
-                        val titles = if (recSourceId != null) {
+                        // KMK -->
+                        val titles = page.mangas.map {
                             // If the recommendation is associated with a source, resolve it
-                            page.mangas.map { it.toDomainManga(recSourceId) }
-                                .let { networkToLocalManga(it) }
-                        } else {
                             // Otherwise, skip this step. The user will be prompted to choose a source via SmartSearch
-                            page.mangas.map { it.toDomainManga(RECOMMENDS_SOURCE) }
+                            it.toDomainManga(recSourceId ?: RECOMMENDS_SOURCE)
                         }
+                            // KMK <--
                             .distinctBy { it.url }
 
                         if (isActive) {

--- a/data/src/main/java/tachiyomi/data/source/EHentaiPagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/EHentaiPagingSource.kt
@@ -20,6 +20,7 @@ abstract class EHentaiPagingSource(override val source: CatalogueSource) : BaseS
         val manga = mangasPage.mangas
             .map { it.toDomainManga(source.id) }
             .filter { seenManga.add(it.url) }
+            /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
             // SY -->
             .mapIndexed { index, manga -> manga to metadata.getOrNull(index) }
         // SY <--

--- a/data/src/main/java/tachiyomi/data/source/EHentaiPagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/EHentaiPagingSource.kt
@@ -20,7 +20,6 @@ abstract class EHentaiPagingSource(override val source: CatalogueSource) : BaseS
         val manga = mangasPage.mangas
             .map { it.toDomainManga(source.id) }
             .filter { seenManga.add(it.url) }
-            .let { networkToLocalManga(it) }
             // SY -->
             .mapIndexed { index, manga -> manga to metadata.getOrNull(index) }
         // SY <--

--- a/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
@@ -92,7 +92,6 @@ abstract class BaseSourcePagingSource(
         val manga = mangasPage.mangas
             .map { it.toDomainManga(source!!.id) }
             .filter { seenManga.add(it.url) }
-            .let { networkToLocalManga(it) }
             // SY -->
             .mapIndexed { index, manga -> manga to metadata.getOrNull(index) }
         // SY <--

--- a/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
@@ -92,6 +92,7 @@ abstract class BaseSourcePagingSource(
         val manga = mangasPage.mangas
             .map { it.toDomainManga(source!!.id) }
             .filter { seenManga.add(it.url) }
+            /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
             // SY -->
             .mapIndexed { index, manga -> manga to metadata.getOrNull(index) }
         // SY <--

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
@@ -14,4 +14,22 @@ class NetworkToLocalManga(
     suspend operator fun invoke(manga: List<Manga>): List<Manga> {
         return mangaRepository.insertNetworkManga(manga)
     }
+
+    // KMK -->
+    suspend fun getLocal(manga: Manga): Manga = if (manga.id <= 0) {
+        invoke(manga)
+    } else {
+        manga
+    }
+
+    suspend fun getLocal(mangas: List<Manga>): List<Manga> {
+        return mangas.map { manga ->
+            if (manga.id <= 0) {
+                invoke(manga)
+            } else {
+                manga
+            }
+        }
+    }
+    // KMK <--
 }


### PR DESCRIPTION
Restore in-memory fast browsing functionality while still allow using selectAll/reverseSelection with Bulk-selection

## Summary by Sourcery

Reintroduce in-memory fast browsing by asynchronously converting network-sourced manga to local entries before bulk-selection and navigation, while preserving selectAll/reverseSelection behavior across multiple browsing contexts.

New Features:
- Restore in-memory fast browsing support by mapping network manga to persisted local objects for UI interactions.

Enhancements:
- Wrap all onClick/onLongClick handlers and bulk selection actions (selectAll/reverseSelection) in coroutineScope.launchIO to fetch local manga via NetworkToLocalManga.getLocal.
- Add getLocal(NetworkToLocalManga) overloads for single and list inputs to convert network items on demand.
- Standardize conversion logic across BrowseSource, Recommends, GlobalSearch, MigrateSearch, SourceSearch, FeedTab, SourceFeed, MangaScreen and related screen models.
- Update related manga deduplication logic to use URL.hashCode and adjust Compose list keys accordingly.