### PR TITLE
refactor(network-to-local): simplify networkToLocalManga

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -64,7 +64,7 @@ fun GlobalSearchScreen(
                             .flatMap { it.result }
                             .let {
                                 scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                    bulkFavoriteScreenModel.networkToLocalManga(it)
                                         .forEach { bulkFavoriteScreenModel.select(it) }
                                 }
                             }
@@ -76,7 +76,7 @@ fun GlobalSearchScreen(
                             .let {
                                 scope.launchIO {
                                     bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                        bulkFavoriteScreenModel.networkToLocalManga(it),
                                     )
                                 }
                             }

--- a/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
@@ -54,7 +54,7 @@ fun MigrateSearchScreen(
                             .flatMap { it.result }
                             .let {
                                 scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                    bulkFavoriteScreenModel.networkToLocalManga(it)
                                         .forEach { bulkFavoriteScreenModel.select(it) }
                                 }
                             }
@@ -66,7 +66,7 @@ fun MigrateSearchScreen(
                             .let {
                                 scope.launchIO {
                                     bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                        bulkFavoriteScreenModel.networkToLocalManga(it),
                                     )
                                 }
                             }

--- a/app/src/main/java/eu/kanade/presentation/browse/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourceFeedScreen.kt
@@ -132,7 +132,7 @@ fun SourceFeedScreen(
                             .flatten()
                             .let {
                                 scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                    bulkFavoriteScreenModel.networkToLocalManga(it)
                                         .forEach { bulkFavoriteScreenModel.select(it) }
                                 }
                             }
@@ -143,7 +143,7 @@ fun SourceFeedScreen(
                             .let {
                                 scope.launchIO {
                                     bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                        bulkFavoriteScreenModel.networkToLocalManga(it),
                                     )
                                 }
                             }

--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
@@ -71,7 +71,7 @@ fun TabbedScreen(
                                 .flatten()
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -84,7 +84,7 @@ fun TabbedScreen(
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga(it),
                                         )
                                     }
                                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
@@ -171,7 +171,7 @@ fun Screen.feedTab(
                         onClickManga = {
                             // KMK -->
                             scope.launchIO {
-                                val manga = screenModel.networkToLocalManga.getLocal(it)
+                                val manga = screenModel.networkToLocalManga(it)
                                 if (bulkFavoriteState.selectionMode) {
                                     bulkFavoriteScreenModel.toggleSelection(manga)
                                 } else {
@@ -183,7 +183,7 @@ fun Screen.feedTab(
                         // KMK -->
                         onLongClickManga = {
                             scope.launchIO {
-                                val manga = screenModel.networkToLocalManga.getLocal(it)
+                                val manga = screenModel.networkToLocalManga(it)
                                 if (!bulkFavoriteState.selectionMode) {
                                     bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
@@ -58,7 +58,7 @@ class MigrateSearchScreen(private val mangaId: Long, private val validSources: L
             onClickItem = {
                 // KMK -->
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    val manga = screenModel.networkToLocalManga(it)
                     if (bulkFavoriteState.selectionMode) {
                         bulkFavoriteScreenModel.toggleSelection(manga)
                     } else
@@ -77,7 +77,7 @@ class MigrateSearchScreen(private val mangaId: Long, private val validSources: L
             onLongClickItem = {
                 // KMK -->
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    val manga = screenModel.networkToLocalManga(it)
                     // KMK <--
                     navigator.push(MangaScreen(manga.id, true))
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
@@ -94,7 +94,7 @@ data class SourceSearchScreen(
                                 .map { it.value.first }
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -105,7 +105,7 @@ data class SourceSearchScreen(
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga(it),
                                         )
                                     }
                                 }
@@ -178,7 +178,7 @@ data class SourceSearchScreen(
                 onMangaClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        val manga = screenModel.networkToLocalManga(it)
                         if (bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.toggleSelection(manga)
                         } else {
@@ -190,7 +190,7 @@ data class SourceSearchScreen(
                 onMangaLongClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        val manga = screenModel.networkToLocalManga(it)
                         // KMK <--
                         navigator.push(MangaScreen(manga.id, true))
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -204,7 +204,7 @@ data class BrowseSourceScreen(
                                     .map { it.value.first }
                                     .let {
                                         scope.launchIO {
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                            bulkFavoriteScreenModel.networkToLocalManga(it)
                                                 .forEach { bulkFavoriteScreenModel.select(it) }
                                         }
                                     }
@@ -215,7 +215,7 @@ data class BrowseSourceScreen(
                                     .let {
                                         scope.launchIO {
                                             bulkFavoriteScreenModel.reverseSelection(
-                                                bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                                bulkFavoriteScreenModel.networkToLocalManga(it),
                                             )
                                         }
                                     }
@@ -370,7 +370,7 @@ data class BrowseSourceScreen(
                 onMangaClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        val manga = screenModel.networkToLocalManga(it)
                         if (bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.toggleSelection(manga)
                         } else {
@@ -392,7 +392,7 @@ data class BrowseSourceScreen(
                 onMangaLongClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        val manga = screenModel.networkToLocalManga(it)
                         if (bulkFavoriteState.selectionMode) {
                             navigator.push(MangaScreen(manga.id, true))
                         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
@@ -129,7 +129,7 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
                     onClickManga = {
                         // KMK -->
                         scope.launchIO {
-                            val manga = screenModel.networkToLocalManga.getLocal(it)
+                            val manga = screenModel.networkToLocalManga(it)
                             if (bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.toggleSelection(manga)
                             } else {
@@ -172,7 +172,7 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
                         },
                     onLongClickManga = {
                         scope.launchIO {
-                            val manga = screenModel.networkToLocalManga.getLocal(it)
+                            val manga = screenModel.networkToLocalManga(it)
                             if (!bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                             } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
@@ -71,7 +71,7 @@ class GlobalSearchScreen(
                         if (manga != null) {
                             // KMK -->
                             scope.launchIO {
-                                val localManga = screenModel.networkToLocalManga.getLocal(manga)
+                                val localManga = screenModel.networkToLocalManga(manga)
                                 // KMK <--
                                 navigator.replace(MangaScreen(localManga.id, true))
                             }
@@ -98,7 +98,7 @@ class GlobalSearchScreen(
                 onClickItem = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        val manga = screenModel.networkToLocalManga(it)
                         if (bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.toggleSelection(manga)
                         } else {
@@ -110,7 +110,7 @@ class GlobalSearchScreen(
                 onLongClickItem = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        val manga = screenModel.networkToLocalManga(it)
                         if (!bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -391,13 +391,13 @@ class MangaScreen(
             },
             onRelatedMangaClick = {
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    val manga = screenModel.networkToLocalManga(it)
                     navigator.push(MangaScreen(manga.id, true))
                 }
             },
             onRelatedMangaLongClick = {
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    val manga = screenModel.networkToLocalManga(it)
                     bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                 }
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
@@ -60,7 +60,7 @@ fun RelatedMangasScreen(
                                 .flatMap { it.mangaList }
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -73,7 +73,7 @@ fun RelatedMangasScreen(
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga(it),
                                         )
                                     }
                                 }
@@ -102,7 +102,7 @@ fun RelatedMangasScreen(
             contentPadding = paddingValues,
             onMangaClick = {
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    val manga = screenModel.networkToLocalManga(it)
                     if (bulkFavoriteState.selectionMode) {
                         bulkFavoriteScreenModel.toggleSelection(manga)
                     } else {
@@ -112,7 +112,7 @@ fun RelatedMangasScreen(
             },
             onMangaLongClick = {
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                    val manga = screenModel.networkToLocalManga(it)
                     if (!bulkFavoriteState.selectionMode) {
                         bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                     } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -743,13 +743,10 @@ class ReaderViewModel @JvmOverloads constructor(
         // SY -->
         if (manga?.isEhBasedManga() == true) {
             viewModelScope.launchNonCancellable {
-                val chapterUpdates = chapterList
-                    .filter { it.chapter.source_order > readerChapter.chapter.source_order }
+                val chapterUpdates = unfilteredChapterList
+                    .filter { it.sourceOrder > readerChapter.chapter.source_order }
                     .map { chapter ->
-                        ChapterUpdate(
-                            id = chapter.chapter.id!!,
-                            read = true,
-                        )
+                        ChapterUpdate(id = chapter.id, read = true)
                     }
                 updateChapter.awaitAll(chapterUpdates)
             }

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -79,7 +79,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                                 .map { it.value.first }
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -90,7 +90,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga(it),
                                         )
                                     }
                                 }
@@ -131,7 +131,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                 onMangaClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        val manga = screenModel.networkToLocalManga(it)
                         if (bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.toggleSelection(manga)
                         } else {
@@ -143,7 +143,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                 onMangaLongClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                        val manga = screenModel.networkToLocalManga(it)
                         if (bulkFavoriteState.selectionMode) {
                             navigator.push(MangaScreen(manga.id, true))
                         } else {

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -99,7 +99,7 @@ class BrowseRecommendsScreen(
                                 .map { it.value.first }
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -110,7 +110,7 @@ class BrowseRecommendsScreen(
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga(it),
                                         )
                                     }
                                 }
@@ -159,7 +159,7 @@ class BrowseRecommendsScreen(
                         onClickItem(it)
                     } else {
                         scope.launchIO {
-                            val manga = screenModel.networkToLocalManga.getLocal(it)
+                            val manga = screenModel.networkToLocalManga(it)
                             if (bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.toggleSelection(manga)
                             } else {
@@ -175,7 +175,7 @@ class BrowseRecommendsScreen(
                         onLongClickItem(it)
                     } else {
                         scope.launchIO {
-                            val manga = screenModel.networkToLocalManga.getLocal(it)
+                            val manga = screenModel.networkToLocalManga(it)
                             if (!bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                             } else {

--- a/app/src/main/java/exh/recs/RecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreen.kt
@@ -59,7 +59,7 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
                 else -> {
                     // KMK -->
                     scope.launchIO {
-                        val localManga = screenModel.networkToLocalManga.getLocal(manga)
+                        val localManga = screenModel.networkToLocalManga(manga)
                         navigator.push(
                             // KMK <--
                             MangaScreen(localManga.id, true),
@@ -75,7 +75,7 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
                 else -> {
                     // KMK -->
                     scope.launchIO {
-                        val localManga = screenModel.networkToLocalManga.getLocal(manga)
+                        val localManga = screenModel.networkToLocalManga(manga)
                         bulkFavoriteScreenModel.addRemoveManga(
                             localManga,
                             haptic,

--- a/app/src/main/java/exh/recs/RecommendsScreenModel.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreenModel.kt
@@ -83,8 +83,8 @@ open class RecommendsScreenModel(
                             // If the recommendation is associated with a source, resolve it
                             // Otherwise, skip this step. The user will be prompted to choose a source via SmartSearch
                             it.toDomainManga(recSourceId ?: RECOMMENDS_SOURCE)
-                            /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
                         }
+                            /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
                             // KMK <--
                             .distinctBy { it.url }
 

--- a/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
@@ -86,7 +86,6 @@ object MangaMapper {
         coverLastModified: Long,
         dateAdded: Long,
         // SY -->
-        @Suppress("UNUSED_PARAMETER")
         filteredScanlators: String?,
         // SY <--
         updateStrategy: UpdateStrategy,
@@ -124,7 +123,7 @@ object MangaMapper {
             coverLastModified,
             dateAdded,
             // SY -->
-            null,
+            filteredScanlators,
             // SY <--
             updateStrategy,
             calculateInterval,
@@ -193,7 +192,9 @@ object MangaMapper {
             chapterFlags,
             coverLastModified,
             dateAdded,
+            // SY -->
             filteredScanlators,
+            // SY <--
             updateStrategy,
             calculateInterval,
             lastModifiedAt,

--- a/data/src/main/java/tachiyomi/data/source/EHentaiPagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/EHentaiPagingSource.kt
@@ -8,7 +8,9 @@ import exh.metadata.metadata.RaisedSearchMetadata
 import mihon.domain.manga.model.toDomainManga
 import tachiyomi.domain.manga.model.Manga
 
-abstract class EHentaiPagingSource(override val source: CatalogueSource) : BaseSourcePagingSource(source) {
+abstract class EHentaiPagingSource(
+    override val source: CatalogueSource,
+) : BaseSourcePagingSource(source) {
 
     override suspend fun getPageLoadResult(
         params: LoadParams<Long>,

--- a/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
@@ -90,11 +90,12 @@ abstract class BaseSourcePagingSource(
         // SY <--
 
         val manga = mangasPage.mangas
-            .map { it.toDomainManga(source!!.id) }
-            .filter { seenManga.add(it.url) }
-            /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
             // SY -->
-            .mapIndexed { index, manga -> manga to metadata.getOrNull(index) }
+            .mapIndexed { index, sManga -> sManga.toDomainManga(source!!.id) to metadata.getOrNull(index) }
+            .filter { seenManga.add(it.first.url) }
+        // KMK -->
+        // .let { pairs -> pairs.zip(networkToLocalManga(pairs.map { it.first })).map { it.second to it.first.second } }
+        // KMK <--
         // SY <--
 
         return LoadResult.Page(

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
@@ -8,28 +8,10 @@ class NetworkToLocalManga(
 ) {
 
     suspend operator fun invoke(manga: Manga): Manga {
-        return invoke(listOf(manga)).single()
+        return if (manga.id <= 0) invoke(listOf(manga)).single() else manga
     }
 
     suspend operator fun invoke(manga: List<Manga>): List<Manga> {
         return mangaRepository.insertNetworkManga(manga)
     }
-
-    // KMK -->
-    suspend fun getLocal(manga: Manga): Manga = if (manga.id <= 0) {
-        invoke(manga)
-    } else {
-        manga
-    }
-
-    suspend fun getLocal(mangas: List<Manga>): List<Manga> {
-        return mangas.map { manga ->
-            if (manga.id <= 0) {
-                invoke(manga)
-            } else {
-                manga
-            }
-        }
-    }
-    // KMK <--
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor NetworkToLocalManga to consolidate getLocal behavior into its invoke operator and remove redundant methods, then update all call sites to use the operator invocation instead of getLocal.

Enhancements:
- Merge getLocal logic into the suspend operator invoke in NetworkToLocalManga and remove the separate getLocal methods
- Replace all networkToLocalManga.getLocal(...) calls with the operator invocation networkToLocalManga(...) across the UI screens