### PR TITLE
feat(updates-screen): Animated Updates group expand visibility

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -29,7 +29,6 @@ import eu.kanade.presentation.manga.components.MangaBottomActionMenu
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.ui.updates.UpdatesItem
 import eu.kanade.tachiyomi.ui.updates.UpdatesScreenModel
-import eu.kanade.tachiyomi.ui.updates.groupByDateAndManga
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -130,15 +129,8 @@ fun UpdateScreen(
                         updatesLastUpdatedItem(lastUpdated)
 
                         updatesUiItems(
-                            uiModels = state.getUiModel()
-                                // KMK -->
-                                .filter {
-                                    when (it) {
-                                        is UpdatesUiModel.Header, is UpdatesUiModel.Leader -> true
-                                        is UpdatesUiModel.Item ->
-                                            state.expandedState.contains(it.item.update.groupByDateAndManga())
-                                    }
-                                },
+                            uiModels = state.getUiModel(),
+                            // KMK -->
                             expandedState = state.expandedState,
                             collapseToggle = collapseToggle,
                             usePanoramaCover = usePanoramaCover.value,

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
@@ -364,6 +364,11 @@ fun CollapseButton(
     collapseToggle: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val painter = rememberAnimatedVectorPainter(
+        AnimatedImageVector.animatedVectorResource(R.drawable.anim_caret_down),
+        !expanded,
+    )
+
     Box(
         modifier = modifier
             .size(IndicatorSize + MaterialTheme.padding.extraSmall),
@@ -374,10 +379,7 @@ fun CollapseButton(
             modifier = Modifier.size(IndicatorSize),
         ) {
             Icon(
-                painter = rememberAnimatedVectorPainter(
-                    AnimatedImageVector.animatedVectorResource(R.drawable.anim_caret_down),
-                    !expanded,
-                ),
+                painter = painter,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
             )


### PR DESCRIPTION
## Summary by Sourcery

Animate the visibility of grouped update items in the Updates screen, streamline the visibility logic by removing manual filtering, and improve the animated caret icon implementation.

New Features:
- Animate expand/collapse of update groups with vertical expand/shrink and fade transitions

Enhancements:
- Remove manual filtering of update items and rely on AnimatedVisibility for conditional display
- Extract leader and expanded state flags to simplify UpdatesUiItem parameters
- Inline AnimatedImageVector resource loading for caret icon animation