### PR TITLE
feat(updates-selection): Enable whole-group selection & Fix range selection in Updates screen

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -60,7 +60,7 @@ fun UpdateScreen(
     onMultiBookmarkClicked: (List<UpdatesItem>, bookmark: Boolean) -> Unit,
     onMultiMarkAsReadClicked: (List<UpdatesItem>, read: Boolean) -> Unit,
     onMultiDeleteClicked: (List<UpdatesItem>) -> Unit,
-    onUpdateSelected: (UpdatesItem, Boolean, Boolean, Boolean, Boolean, Boolean) -> Unit,
+    onUpdateSelected: (UpdatesItem, /* KMK --> */ UpdatesScreenModel.UpdateSelectionOptions /* KMK <-- */) -> Unit,
     onOpenChapter: (UpdatesItem) -> Unit,
     // KMK -->
     collapseToggle: (key: String) -> Unit,

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -60,7 +60,7 @@ fun UpdateScreen(
     onMultiBookmarkClicked: (List<UpdatesItem>, bookmark: Boolean) -> Unit,
     onMultiMarkAsReadClicked: (List<UpdatesItem>, read: Boolean) -> Unit,
     onMultiDeleteClicked: (List<UpdatesItem>) -> Unit,
-    onUpdateSelected: (UpdatesItem, Boolean, Boolean, Boolean) -> Unit,
+    onUpdateSelected: (UpdatesItem, Boolean, Boolean, Boolean, Boolean, Boolean) -> Unit,
     onOpenChapter: (UpdatesItem) -> Unit,
     // KMK -->
     collapseToggle: (key: String) -> Unit,

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
@@ -91,7 +91,7 @@ internal fun LazyListScope.updatesUiItems(
     // SY -->
     preserveReadingPosition: Boolean,
     // SY <--
-    onUpdateSelected: (UpdatesItem, Boolean, Boolean, Boolean) -> Unit,
+    onUpdateSelected: (UpdatesItem, Boolean, Boolean, Boolean, Boolean, Boolean) -> Unit,
     onClickCover: (UpdatesItem) -> Unit,
     onClickUpdate: (UpdatesItem) -> Unit,
     onDownloadChapter: (List<UpdatesItem>, ChapterDownloadAction) -> Unit,
@@ -124,10 +124,10 @@ internal fun LazyListScope.updatesUiItems(
             }
             is UpdatesUiModel.Item -> {
                 val updatesItem = item.item
+                // KMK -->
                 val isLeader = item is UpdatesUiModel.Leader
                 val isExpanded = expandedState.contains(updatesItem.update.groupByDateAndManga())
 
-                // KMK -->
                 AnimatedVisibility(
                     visible = isLeader || isExpanded,
                     enter = fadeIn() + expandVertically(),
@@ -153,11 +153,29 @@ internal fun LazyListScope.updatesUiItems(
                                 )
                             },
                         onLongClick = {
-                            onUpdateSelected(updatesItem, !updatesItem.selected, true, true)
+                            onUpdateSelected(
+                                updatesItem,
+                                !updatesItem.selected,
+                                true,
+                                true,
+                                // KMK -->
+                                isLeader && item.isExpandable,
+                                isExpanded,
+                                // KMK <--
+                            )
                         },
                         onClick = {
                             when {
-                                selectionMode -> onUpdateSelected(updatesItem, !updatesItem.selected, true, false)
+                                selectionMode -> onUpdateSelected(
+                                    updatesItem,
+                                    !updatesItem.selected,
+                                    true,
+                                    false,
+                                    // KMK -->
+                                    isLeader && item.isExpandable,
+                                    isExpanded,
+                                    // KMK <--
+                                )
                                 else -> onClickUpdate(updatesItem)
                             }
                         },

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
@@ -54,6 +54,7 @@ import eu.kanade.presentation.util.relativeTimeSpanString
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.ui.updates.UpdatesItem
+import eu.kanade.tachiyomi.ui.updates.UpdatesScreenModel.UpdateSelectionOptions
 import eu.kanade.tachiyomi.ui.updates.groupByDateAndManga
 import mihon.feature.upcoming.DateHeading
 import tachiyomi.domain.updates.model.UpdatesWithRelations
@@ -91,7 +92,7 @@ internal fun LazyListScope.updatesUiItems(
     // SY -->
     preserveReadingPosition: Boolean,
     // SY <--
-    onUpdateSelected: (UpdatesItem, Boolean, Boolean, Boolean, Boolean, Boolean) -> Unit,
+    onUpdateSelected: (UpdatesItem, /* KMK --> */ UpdateSelectionOptions /* KMK <-- */) -> Unit,
     onClickCover: (UpdatesItem) -> Unit,
     onClickUpdate: (UpdatesItem) -> Unit,
     onDownloadChapter: (List<UpdatesItem>, ChapterDownloadAction) -> Unit,
@@ -155,12 +156,14 @@ internal fun LazyListScope.updatesUiItems(
                         onLongClick = {
                             onUpdateSelected(
                                 updatesItem,
-                                !updatesItem.selected,
-                                true,
-                                true,
                                 // KMK -->
-                                isLeader && item.isExpandable,
-                                isExpanded,
+                                UpdateSelectionOptions(
+                                    selected = !updatesItem.selected,
+                                    userSelected = true,
+                                    fromLongPress = true,
+                                    isGroup = isLeader && item.isExpandable,
+                                    isExpanded = isExpanded,
+                                ),
                                 // KMK <--
                             )
                         },
@@ -168,12 +171,14 @@ internal fun LazyListScope.updatesUiItems(
                             when {
                                 selectionMode -> onUpdateSelected(
                                     updatesItem,
-                                    !updatesItem.selected,
-                                    true,
-                                    false,
                                     // KMK -->
-                                    isLeader && item.isExpandable,
-                                    isExpanded,
+                                    UpdateSelectionOptions(
+                                        selected = !updatesItem.selected,
+                                        userSelected = true,
+                                        fromLongPress = false,
+                                        isGroup = isLeader && item.isExpandable,
+                                        isExpanded = isExpanded,
+                                    ),
                                     // KMK <--
                                 )
                                 else -> onClickUpdate(updatesItem)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -292,16 +292,26 @@ class UpdatesScreenModel(
         setDialog(Dialog.DeleteConfirmation(updatesItem))
     }
 
+    // KMK -->
+    /** Bundles all of the boolean flags for update‐selection into one type */
+    data class UpdateSelectionOptions(
+        val selected: Boolean,
+        val userSelected: Boolean = false,
+        val fromLongPress: Boolean = false,
+        val isGroup: Boolean = false,
+        val isExpanded: Boolean = false,
+    )
+    // KMK <--
+
     fun toggleSelection(
         item: UpdatesItem,
-        selected: Boolean,
-        userSelected: Boolean = false,
-        fromLongPress: Boolean = false,
         // KMK -->
-        isGroup: Boolean = false,
-        isExpanded: Boolean = false,
+        selectionOptions: UpdateSelectionOptions,
         // KMK <--
     ) {
+        // KMK -->
+        val (selected, userSelected, fromLongPress, isGroup, isExpanded) = selectionOptions
+        // KMK <--
         mutableState.update { state ->
             val newItems = state.items.toMutableList().apply {
                 val selectedIndex = indexOfFirst { it.update.chapterId == item.update.chapterId }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -297,6 +297,10 @@ class UpdatesScreenModel(
         selected: Boolean,
         userSelected: Boolean = false,
         fromLongPress: Boolean = false,
+        // KMK -->
+        isGroup: Boolean = false,
+        isExpanded: Boolean = false,
+        // KMK <--
     ) {
         mutableState.update { state ->
             val newItems = state.items.toMutableList().apply {
@@ -309,6 +313,20 @@ class UpdatesScreenModel(
                 val firstSelection = none { it.selected }
                 set(selectedIndex, selectedItem.copy(selected = selected))
                 selectedChapterIds.addOrRemove(item.update.chapterId, selected)
+
+                // KMK -->
+                if (isGroup && !isExpanded) {
+                    val selectedItemDate = selectedItem.update.dateFetch.toLocalDate()
+                    state.items.forEachIndexed { index, it ->
+                        if (it.update.mangaId == selectedItem.update.mangaId &&
+                            it.update.dateFetch.toLocalDate() == selectedItemDate
+                        ) {
+                            set(index, it.copy(selected = selected))
+                            selectedChapterIds.addOrRemove(it.update.chapterId, selected)
+                        }
+                    }
+                }
+                // KMK <--
 
                 if (selected && userSelected && fromLongPress) {
                     if (firstSelection) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -317,14 +317,19 @@ class UpdatesScreenModel(
                 // KMK -->
                 if (isGroup && !isExpanded) {
                     val selectedItemDate = selectedItem.update.dateFetch.toLocalDate()
-                    state.items.forEachIndexed { index, it ->
-                        if (it.update.mangaId == selectedItem.update.mangaId &&
-                            it.update.dateFetch.toLocalDate() == selectedItemDate
-                        ) {
-                            set(index, it.copy(selected = selected))
-                            selectedChapterIds.addOrRemove(it.update.chapterId, selected)
+                    val zone = java.time.ZoneId.systemDefault()
+                    val dayStartMillis = selectedItemDate.atStartOfDay(zone).toInstant().toEpochMilli()
+                    val dayEndMillis = selectedItemDate.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+
+                    state.items.mapIndexed { index, item -> index to item }
+                        .filter {
+                            it.second.update.mangaId == selectedItem.update.mangaId &&
+                                it.second.update.dateFetch in dayStartMillis..<dayEndMillis
                         }
-                    }
+                        .forEach { (index, item) ->
+                            set(index, item.copy(selected = selected))
+                            selectedChapterIds.addOrRemove(item.update.chapterId, selected)
+                        }
                 }
                 // KMK <--
 


### PR DESCRIPTION
Enhance the Updates screen by fixing the range selection issue and allowing users to select entire groups of updates at once.

## Summary by Sourcery

Enable bulk group selection on the Updates screen, correct range selection logic, and improve item ordering by grouping and sorting updates.

New Features:
- Allow toggling selection of entire update group via leader items

Bug Fixes:
- Fix range selection behavior on the Updates screen

Enhancements:
- Group updates by manga and sort unread-first then by fetch date
- Extend selection handler to include group-and-expansion state flags

## Summary by Sourcery

Enable bulk group selection, correct range selection logic, and improve update ordering and selection handling on the Updates screen

New Features:
- Allow toggling selection of entire update groups via leader items
- Add collapse toggle callback to control group expansion in the UI

Bug Fixes:
- Fix range selection behavior on the Updates screen

Enhancements:
- Group updates by manga and sort unread items first then by fetch date
- Introduce UpdateSelectionOptions data class to consolidate selection flags
- Refactor selection handlers in UI to use the new UpdateSelectionOptions structure