### PR TITLE
feat(update-errors): Allow manually `delete update errors`

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.DeleteOutline
 import androidx.compose.material.icons.outlined.FindReplace
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll
@@ -63,6 +64,8 @@ fun LibraryUpdateErrorScreen(
     onMultiMigrateClicked: (() -> Unit),
     onSelectAll: (Boolean) -> Unit,
     onInvertSelection: () -> Unit,
+    onErrorsDelete: () -> Unit,
+    onErrorDelete: (Long) -> Unit,
     onErrorSelected: (LibraryUpdateErrorItem, Boolean, Boolean, Boolean) -> Unit,
     navigateUp: () -> Unit,
 ) {
@@ -112,6 +115,7 @@ fun LibraryUpdateErrorScreen(
                 onClickUnselectAll = { onSelectAll(false) },
                 onClickSelectAll = { onSelectAll(true) },
                 onClickInvertSelection = onInvertSelection,
+                onClickDeleteErrors = onErrorsDelete,
                 scrollBehavior = scrollBehavior,
             )
         },
@@ -173,6 +177,7 @@ fun LibraryUpdateErrorScreen(
                         onErrorSelected = onErrorSelected,
                         onClick = onClick,
                         onClickCover = onClickCover,
+                        onDelete = onErrorDelete,
                     )
                 }
             }
@@ -303,6 +308,7 @@ private fun LibraryUpdateErrorAppBar(
     onClickUnselectAll: () -> Unit,
     onClickSelectAll: () -> Unit,
     onClickInvertSelection: () -> Unit,
+    onClickDeleteErrors: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,
 ) {
     AppBar(
@@ -326,6 +332,11 @@ private fun LibraryUpdateErrorAppBar(
         actionModeActions = {
             AppBarActions(
                 persistentListOf(
+                    AppBar.Action(
+                        title = stringResource(MR.strings.action_delete),
+                        icon = Icons.Outlined.DeleteOutline,
+                        onClick = onClickDeleteErrors,
+                    ),
                     AppBar.Action(
                         title = stringResource(MR.strings.action_select_all),
                         icon = Icons.Outlined.SelectAll,

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -51,6 +51,7 @@ internal fun LazyListScope.libraryUpdateErrorUiItems(
                         modifier = Modifier.animateItemFastScroll(),
                         text = uiModel.errorMessage,
                         tonalElevation = 1.dp,
+                        count = uiModel.count,
                     )
                 }
             }
@@ -175,7 +176,7 @@ private fun LibraryUpdateErrorUiItem(
 
 sealed class LibraryUpdateErrorUiModel {
 
-    data class Header(val errorMessage: String) : LibraryUpdateErrorUiModel()
+    data class Header(val errorMessage: String, val count: Int) : LibraryUpdateErrorUiModel()
 
     data class Item(val item: LibraryUpdateErrorItem) : LibraryUpdateErrorUiModel()
 }

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -33,9 +33,11 @@ import eu.kanade.presentation.manga.components.MangaCover
 import eu.kanade.presentation.util.animateItemFastScroll
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
+import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.ListGroupHeader
 import tachiyomi.presentation.core.components.Scroller.STICKY_HEADER_KEY_PREFIX
 import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.secondaryItemAlpha
 import tachiyomi.presentation.core.util.selectedBackground
 
@@ -216,7 +218,7 @@ fun DismissBackground(dismissState: SwipeToDismissBoxState) {
     ) {
         Icon(
             imageVector = Icons.Outlined.Delete,
-            contentDescription = "Delete",
+            contentDescription = stringResource(MR.strings.action_delete),
             tint = MaterialTheme.colorScheme.onErrorContainer,
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -26,14 +26,11 @@ import eu.kanade.presentation.util.animateItemFastScroll
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
 import me.saket.swipe.SwipeableActionsBox
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
-import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.presentation.core.components.ListGroupHeader
 import tachiyomi.presentation.core.components.Scroller.STICKY_HEADER_KEY_PREFIX
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.util.secondaryItemAlpha
 import tachiyomi.presentation.core.util.selectedBackground
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 
 internal fun LazyListScope.libraryUpdateErrorUiItems(
     uiModels: List<LibraryUpdateErrorUiModel>,
@@ -66,6 +63,8 @@ internal fun LazyListScope.libraryUpdateErrorUiItems(
                     LibraryUpdateErrorUiItem(
                         modifier = Modifier.animateItemFastScroll(),
                         error = libraryUpdateErrorItem.error,
+                        mangaCover = libraryUpdateErrorItem.mangaCover,
+                        sourceName = libraryUpdateErrorItem.sourceName,
                         selected = libraryUpdateErrorItem.selected,
                         onClick = {
                             when {
@@ -100,6 +99,8 @@ internal fun LazyListScope.libraryUpdateErrorUiItems(
 private fun LibraryUpdateErrorUiItem(
     modifier: Modifier,
     error: LibraryUpdateErrorWithRelations,
+    mangaCover: tachiyomi.domain.manga.model.MangaCover,
+    sourceName: String,
     selected: Boolean,
     onClick: () -> Unit,
     onLongClick: () -> Unit,
@@ -141,7 +142,7 @@ private fun LibraryUpdateErrorUiItem(
                 modifier = Modifier
                     .padding(vertical = 6.dp)
                     .height(48.dp),
-                data = error.mangaCover,
+                data = mangaCover,
                 onClick = onClickCover,
             )
 
@@ -158,7 +159,7 @@ private fun LibraryUpdateErrorUiItem(
 
                 Row(modifier = Modifier.padding(vertical = 4.dp), verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        text = Injekt.get<SourceManager>().getOrStub(error.mangaSource).name,
+                        text = sourceName,
                         style = MaterialTheme.typography.bodySmall,
                         overflow = TextOverflow.Visible,
                         maxLines = 1,

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -8,21 +8,20 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.manga.components.MangaCover
+import eu.kanade.presentation.manga.components.swipeAction
+import eu.kanade.presentation.manga.components.swipeActionThreshold
 import eu.kanade.presentation.util.animateItemFastScroll
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
 import me.saket.swipe.SwipeableActionsBox
@@ -109,21 +108,24 @@ private fun LibraryUpdateErrorUiItem(
 ) {
     val haptic = LocalHapticFeedback.current
 
-    val swipeAction = swipeAction(
-        icon = Icons.Outlined.Delete,
-        background = MaterialTheme.colorScheme.primaryContainer,
-        onSwipe = onSwipe,
-    )
+    val swipeBackground = MaterialTheme.colorScheme.primaryContainer
+    val swipeAction = remember {
+        swipeAction(
+            icon = Icons.Outlined.Delete,
+            background = swipeBackground,
+            onSwipe = onSwipe,
+        )
+    }
 
     SwipeableActionsBox(
-        modifier = Modifier.clipToBounds(),
+        modifier = modifier.clipToBounds(),
         startActions = listOfNotNull(swipeAction),
         endActions = listOfNotNull(swipeAction),
         swipeThreshold = swipeActionThreshold,
         backgroundUntilSwipeThreshold = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) {
         Row(
-            modifier = modifier
+            modifier = Modifier
                 .selectedBackground(selected)
                 .combinedClickable(
                     onClick = onClick,
@@ -169,29 +171,6 @@ private fun LibraryUpdateErrorUiItem(
         }
     }
 }
-
-private fun swipeAction(
-    onSwipe: () -> Unit,
-    icon: ImageVector,
-    background: Color,
-    isUndo: Boolean = false,
-): me.saket.swipe.SwipeAction {
-    return me.saket.swipe.SwipeAction(
-        icon = {
-            Icon(
-                modifier = Modifier.padding(16.dp),
-                imageVector = icon,
-                tint = contentColorFor(background),
-                contentDescription = null,
-            )
-        },
-        background = background,
-        onSwipe = onSwipe,
-        isUndo = isUndo,
-    )
-}
-
-private val swipeActionThreshold = 56.dp
 
 sealed class LibraryUpdateErrorUiModel {
 

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/components/LibraryUpdateErrorUiItem.kt
@@ -124,7 +124,7 @@ private fun LibraryUpdateErrorUiItem(
             when (it) {
                 StartToEnd -> onSwipe()
                 EndToStart -> onSwipe()
-                Settled -> return@rememberSwipeToDismissBoxState false
+                else -> {}
             }
             return@rememberSwipeToDismissBoxState true
         },

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
@@ -96,14 +96,14 @@ fun MangaChapterListItem(
     }
 
     SwipeableActionsBox(
-        modifier = Modifier.clipToBounds(),
+        modifier = modifier.clipToBounds(),
         startActions = listOfNotNull(swipeStart),
         endActions = listOfNotNull(swipeEnd),
         swipeThreshold = swipeActionThreshold,
         backgroundUntilSwipeThreshold = MaterialTheme.colorScheme.surfaceContainerLowest,
     ) {
         Row(
-            modifier = modifier
+            modifier = Modifier
                 .selectedBackground(selected)
                 .combinedClickable(
                     onClick = onClick,
@@ -244,7 +244,7 @@ internal fun getSwipeAction(
     }
 }
 
-private fun swipeAction(
+internal fun swipeAction(
     onSwipe: () -> Unit,
     icon: ImageVector,
     background: Color,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -655,7 +655,7 @@ class LibraryUpdateJob(private val context: Context, private val workerParams: W
 
     // KMK -->
     private suspend fun clearErrorFromDB(mangaId: Long) {
-        deleteLibraryUpdateErrors.deleteMangaError(mangaId = mangaId)
+        deleteLibraryUpdateErrors.deleteMangaError(mangaIds = listOf(mangaId))
     }
 
     private suspend fun writeErrorToDB(error: Pair<Manga, String?>) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -41,6 +41,8 @@ class LibraryUpdateErrorScreen : Screen() {
             },
             onSelectAll = screenModel::toggleAllSelection,
             onInvertSelection = screenModel::invertSelection,
+            onErrorsDelete = screenModel::deleteSelected,
+            onErrorDelete = screenModel::delete,
             onErrorSelected = screenModel::toggleSelection,
             navigateUp = navigator::pop,
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -15,6 +15,8 @@ import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrorWithR
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
 import tachiyomi.domain.libraryUpdateErrorMessage.interactor.GetLibraryUpdateErrorMessages
 import tachiyomi.domain.libraryUpdateErrorMessage.model.LibraryUpdateErrorMessage
+import tachiyomi.domain.manga.model.MangaCover
+import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -22,6 +24,7 @@ class LibraryUpdateErrorScreenModel(
     private val getLibraryUpdateErrorWithRelations: GetLibraryUpdateErrorWithRelations = Injekt.get(),
     private val getLibraryUpdateErrorMessages: GetLibraryUpdateErrorMessages = Injekt.get(),
     private val deleteLibraryUpdateErrors: DeleteLibraryUpdateErrors = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
 ) : StateScreenModel<LibraryUpdateErrorScreenState>(LibraryUpdateErrorScreenState()) {
 
     // First and last selected index in list
@@ -48,6 +51,7 @@ class LibraryUpdateErrorScreenModel(
         return map { error ->
             LibraryUpdateErrorItem(
                 error = error,
+                sourceName = sourceManager.getOrStub(error.mangaSource).name,
                 selected = error.errorId in selectedErrorIds,
             )
         }
@@ -195,5 +199,14 @@ data class LibraryUpdateErrorScreenState(
 @Immutable
 data class LibraryUpdateErrorItem(
     val error: LibraryUpdateErrorWithRelations,
+    val sourceName: String,
     val selected: Boolean,
-)
+) {
+    val mangaCover = MangaCover(
+        mangaId = error.mangaId,
+        sourceId = error.mangaSource,
+        isMangaFavorite = error.favorite,
+        ogUrl = error.mangaThumbnail,
+        lastModified = error.coverLastModified,
+    )
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -184,7 +184,7 @@ data class LibraryUpdateErrorScreenState(
         val errorMap = items.groupBy { it.error.messageId }
         errorMap.forEach { (messageId, errors) ->
             val message = messages.find { it.id == messageId }
-            uiModels.add(LibraryUpdateErrorUiModel.Header(message!!.message))
+            uiModels.add(LibraryUpdateErrorUiModel.Header(message!!.message, errors.size))
             uiModels.addAll(errors.map { LibraryUpdateErrorUiModel.Item(it) })
         }
         return uiModels

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -5,9 +5,12 @@ import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.core.util.addOrRemove
 import eu.kanade.presentation.libraryUpdateError.components.LibraryUpdateErrorUiModel
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.update
 import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.core.common.util.lang.withUIContext
+import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors
 import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrorWithRelations
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
 import tachiyomi.domain.libraryUpdateErrorMessage.interactor.GetLibraryUpdateErrorMessages
@@ -18,6 +21,7 @@ import uy.kohesive.injekt.api.get
 class LibraryUpdateErrorScreenModel(
     private val getLibraryUpdateErrorWithRelations: GetLibraryUpdateErrorWithRelations = Injekt.get(),
     private val getLibraryUpdateErrorMessages: GetLibraryUpdateErrorMessages = Injekt.get(),
+    private val deleteLibraryUpdateErrors: DeleteLibraryUpdateErrors = Injekt.get(),
 ) : StateScreenModel<LibraryUpdateErrorScreenState>(LibraryUpdateErrorScreenState()) {
 
     // First and last selected index in list
@@ -138,6 +142,26 @@ class LibraryUpdateErrorScreenModel(
         }
         selectedPositions[0] = -1
         selectedPositions[1] = -1
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    fun deleteSelected() {
+        launchIO {
+            deleteLibraryUpdateErrors.delete(selectedErrorIds.toList())
+            withUIContext {
+                selectedErrorIds.clear()
+            }
+        }
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    fun delete(errorId: Long) {
+        launchIO {
+            deleteLibraryUpdateErrors.delete(listOf(errorId))
+            withUIContext {
+                selectedErrorIds.remove(errorId)
+            }
+        }
     }
 }
 

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorRepositoryImpl.kt
@@ -25,17 +25,15 @@ class LibraryUpdateErrorRepositoryImpl(
         return handler.await { libraryUpdateErrorQueries.deleteAllErrors() }
     }
 
-    override suspend fun delete(errorId: Long) {
+    override suspend fun delete(errorIds: List<Long>) {
         return handler.await {
-            libraryUpdateErrorQueries.deleteError(
-                _id = errorId,
-            )
+            libraryUpdateErrorQueries.deleteErrors(_ids = errorIds)
         }
     }
 
-    override suspend fun deleteMangaError(mangaId: Long) {
+    override suspend fun deleteMangaError(mangaIds: List<Long>) {
         return handler.await {
-            libraryUpdateErrorQueries.deleteMangaError(mangaId = mangaId)
+            libraryUpdateErrorQueries.deleteMangaErrors(mangaIds = mangaIds)
         }
     }
 

--- a/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorWithRelationsMapper.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateError/LibraryUpdateErrorWithRelationsMapper.kt
@@ -1,7 +1,6 @@
 package tachiyomi.data.libraryUpdateError
 
 import tachiyomi.domain.libraryUpdateError.model.LibraryUpdateErrorWithRelations
-import tachiyomi.domain.manga.model.MangaCover
 
 val libraryUpdateErrorWithRelationsMapper:
     (Long, String, Long, Boolean, String?, Long, Long, Long, Long) -> LibraryUpdateErrorWithRelations =
@@ -10,13 +9,9 @@ val libraryUpdateErrorWithRelationsMapper:
             mangaId = mangaId,
             mangaTitle = mangaTitle,
             mangaSource = mangaSource,
-            mangaCover = MangaCover(
-                mangaId = mangaId,
-                sourceId = mangaSource,
-                isMangaFavorite = favorite,
-                ogUrl = mangaThumbnail,
-                lastModified = coverLastModified,
-            ),
+            favorite = favorite,
+            mangaThumbnail = mangaThumbnail,
+            coverLastModified = coverLastModified,
             errorId = errorId,
             messageId = messageId,
             lastUpdate = lastUpdate,

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateError.sq
@@ -25,13 +25,13 @@ WHERE manga_id = :mangaId;
 deleteAllErrors:
 DELETE FROM libraryUpdateError;
 
-deleteError:
+deleteErrors:
 DELETE FROM libraryUpdateError
-WHERE _id = :_id;
+WHERE _id IN :_ids;
 
-deleteMangaError:
+deleteMangaErrors:
 DELETE FROM libraryUpdateError
-WHERE manga_id = :mangaId;
+WHERE manga_id IN :mangaIds;
 
 cleanUnrelevantMangaErrors:
 DELETE FROM libraryUpdateError

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/interactor/DeleteLibraryUpdateErrors.kt
@@ -9,7 +9,7 @@ class DeleteLibraryUpdateErrors(
     private val libraryUpdateErrorRepository: LibraryUpdateErrorRepository,
 ) {
 
-    suspend fun await() = withNonCancellableContext {
+    suspend fun deleteAll() = withNonCancellableContext {
         try {
             libraryUpdateErrorRepository.deleteAll()
             Result.Success
@@ -19,9 +19,9 @@ class DeleteLibraryUpdateErrors(
         }
     }
 
-    suspend fun await(errorId: Long) = withNonCancellableContext {
+    suspend fun delete(errorIds: List<Long>) = withNonCancellableContext {
         try {
-            libraryUpdateErrorRepository.delete(errorId)
+            libraryUpdateErrorRepository.delete(errorIds)
             Result.Success
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
@@ -29,9 +29,9 @@ class DeleteLibraryUpdateErrors(
         }
     }
 
-    suspend fun deleteMangaError(mangaId: Long) = withNonCancellableContext {
+    suspend fun deleteMangaError(mangaIds: List<Long>) = withNonCancellableContext {
         try {
-            libraryUpdateErrorRepository.deleteMangaError(mangaId)
+            libraryUpdateErrorRepository.deleteMangaError(mangaIds)
             Result.Success
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/model/LibraryUpdateErrorWithRelations.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/model/LibraryUpdateErrorWithRelations.kt
@@ -1,12 +1,12 @@
 package tachiyomi.domain.libraryUpdateError.model
 
-import tachiyomi.domain.manga.model.MangaCover
-
 data class LibraryUpdateErrorWithRelations(
     val mangaId: Long,
     val mangaTitle: String,
     val mangaSource: Long,
-    val mangaCover: MangaCover,
+    val favorite: Boolean,
+    val mangaThumbnail: String?,
+    val coverLastModified: Long,
     val errorId: Long,
     val messageId: Long,
     val lastUpdate: Long,

--- a/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/libraryUpdateError/repository/LibraryUpdateErrorRepository.kt
@@ -11,9 +11,9 @@ interface LibraryUpdateErrorRepository {
 
     suspend fun deleteAll()
 
-    suspend fun delete(errorId: Long)
+    suspend fun delete(errorIds: List<Long>)
 
-    suspend fun deleteMangaError(mangaId: Long)
+    suspend fun deleteMangaError(mangaIds: List<Long>)
 
     suspend fun cleanUnrelevantMangaErrors()
 

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/ListGroupHeader.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/ListGroupHeader.kt
@@ -1,11 +1,14 @@
 package tachiyomi.presentation.core.components
 
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Badge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -18,6 +21,7 @@ fun ListGroupHeader(
     modifier: Modifier = Modifier,
     // KMK -->
     tonalElevation: Dp = 0.dp,
+    count: Int? = null,
     // KMK <--
 ) {
     // KMK -->
@@ -26,17 +30,32 @@ fun ListGroupHeader(
             .fillMaxWidth(),
         tonalElevation = tonalElevation,
     ) {
-        // KMK <--
-        Text(
-            text = text,
-            modifier = Modifier
-                .padding(
-                    horizontal = MaterialTheme.padding.medium,
-                    vertical = MaterialTheme.padding.small,
-                ),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontWeight = FontWeight.SemiBold,
-            style = MaterialTheme.typography.bodyMedium,
-        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier.fillMaxWidth(),
+        ) {
+            // KMK <--
+            Text(
+                text = text,
+                modifier = Modifier
+                    .padding(
+                        horizontal = MaterialTheme.padding.medium,
+                        vertical = MaterialTheme.padding.small,
+                    ),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.SemiBold,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            // KMK -->
+            if (count != null) {
+                Badge(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                ) {
+                    Text("$count")
+                }
+            }
+            // KMK <--
+        }
     }
 }

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/ListGroupHeader.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/ListGroupHeader.kt
@@ -32,7 +32,7 @@ fun ListGroupHeader(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
         ) {
             // KMK <--
             Text(


### PR DESCRIPTION
Delete all/selected errors or swipe one by one

## Summary by Sourcery

Implement manual deletion of library update errors by adding swipe-to-delete and bulk delete actions, and update underlying repository and interactor methods to handle multiple error deletions.

New Features:
- Enable swipe-to-delete for individual update errors in the library error list
- Add bulk deletion of selected update errors via a delete action in the toolbar

Enhancements:
- Extend repository and interactor layers to support deleting multiple error IDs
- Refactor UI items to use SwipeableActionsBox with haptic feedback and consistent styling

## Summary by Sourcery

Add manual deletion of library update errors via swipe gestures and a bulk delete toolbar action, updating data and domain layers to handle multi-error deletions and enhancing the UI to show counts and feedback.

New Features:
- Enable swipe-to-delete for individual library update errors
- Add bulk delete action in the toolbar to remove selected update errors

Enhancements:
- Extend repository and interactor layers to support deleting multiple error IDs
- Display group header counts with badges
- Refactor UI items to use SwipeToDismissBox with haptic feedback and consistent styling
- Move MangaCover mapping from data layer to UI model for display