### PR TITLE
fix (delegate): Fix E-Hentai Jump/Seek match for detailed date

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
@@ -985,6 +985,8 @@ class EHentai(
             AdvancedGroup(),
             ReverseFilter(),
             JumpSeekFilter(),
+            Filter.Header("Seek to specific date: YYYY, (YY)YY-MM, (YY)YY-MM-DD"),
+            Filter.Header("or Jump by number of days/weeks/months/years: 7d, 4w, 12m, 10y"),
         )
     }
 
@@ -1391,7 +1393,7 @@ class EHentai(
         private const val BLANK_PREVIEW_THUMB = "https://$THUMB_DOMAIN/g/$BLANK_THUMB"
 
         private val MATCH_YEAR_REGEX = "^\\d{4}\$".toRegex()
-        private val MATCH_SEEK_REGEX = "^\\d{2,4}-\\d{1,2}(-\\d{1,2})?".toRegex()
+        private val MATCH_SEEK_REGEX = "^\\d{2,4}-\\d{1,2}(-\\d{1,2})?\$".toRegex()
         private val MATCH_JUMP_REGEX = "^\\d+(\$|d\$|w\$|m\$|y\$|-\$)".toRegex()
 
         private const val EH_API_BASE = "https://api.e-hentai.org/api.php"

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/EHentai.kt
@@ -1391,7 +1391,7 @@ class EHentai(
         private const val BLANK_PREVIEW_THUMB = "https://$THUMB_DOMAIN/g/$BLANK_THUMB"
 
         private val MATCH_YEAR_REGEX = "^\\d{4}\$".toRegex()
-        private val MATCH_SEEK_REGEX = "^\\d{2,4}-\\d{1,2}".toRegex()
+        private val MATCH_SEEK_REGEX = "^\\d{2,4}-\\d{1,2}(-\\d{1,2})?".toRegex()
         private val MATCH_JUMP_REGEX = "^\\d+(\$|d\$|w\$|m\$|y\$|-\$)".toRegex()
 
         private const val EH_API_BASE = "https://api.e-hentai.org/api.php"


### PR DESCRIPTION
Fixes #918 

To match the date in the YYYY-MM-DD format, only the MATCH_SEEK_REGEX was modified.

## Summary by Sourcery

Bug Fixes:
- Fix regex to support YYYY-MM-DD date matching in seek operations.