### PR TITLE
feat(duplicate-manga): Show target manga name in duplicate dialogs

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
@@ -155,6 +155,7 @@ private fun AddDuplicateMangaDialog(
         },
         onOpenManga = { navigator?.push(MangaScreen(it.id)) },
         onMigrate = { showMigrateDialog(dialog.manga, it) },
+        targetManga = dialog.manga,
     )
 }
 
@@ -206,6 +207,7 @@ private fun BulkAllowDuplicateDialog(
         onConfirm = { addFavorite(dialog.currentIdx + 1) },
         onOpenManga = { navigator?.push(MangaScreen(it.id)) },
         onMigrate = { showMigrateDialog(dialog.manga, it) },
+        targetManga = dialog.manga,
         bulkFavoriteManga = dialog.manga,
         onAllowAllDuplicate = { addFavoriteDuplicate(false) },
         onSkipAllDuplicate = { addFavoriteDuplicate(true) },

--- a/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/DuplicateMangaDialog.kt
@@ -92,6 +92,7 @@ fun DuplicateMangaDialog(
     onMigrate: (manga: Manga) -> Unit,
     modifier: Modifier = Modifier,
     // KMK -->
+    targetManga: Manga,
     bulkFavoriteManga: Manga? = null,
     onAllowAllDuplicate: () -> Unit = {},
     onSkipAllDuplicate: () -> Unit = {},
@@ -127,6 +128,14 @@ fun DuplicateMangaDialog(
                     .then(horizontalPaddingModifier)
                     .padding(top = MaterialTheme.padding.small),
             )
+
+            // KMK -->
+            Text(
+                text = targetManga.title,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.then(horizontalPaddingModifier),
+            )
+            // KMK <--
 
             Text(
                 text = stringResource(MR.strings.possible_duplicates_summary),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -471,6 +471,9 @@ data class BrowseSourceScreen(
                     onConfirm = { screenModel.addFavorite(dialog.manga) },
                     onOpenManga = { navigator.push(MangaScreen(it.id)) },
                     onMigrate = { screenModel.setDialog(BrowseSourceScreenModel.Dialog.Migrate(dialog.manga, it)) },
+                    // KMK -->
+                    targetManga = dialog.manga,
+                    // KMK <--
                 )
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -122,6 +122,9 @@ data object HistoryTab : Tab {
                     },
                     onOpenManga = { navigator.push(MangaScreen(it.id)) },
                     onMigrate = { screenModel.showMigrateDialog(dialog.manga, it) },
+                    // KMK -->
+                    targetManga = dialog.manga,
+                    // KMK <--
                 )
             }
             is HistoryScreenModel.Dialog.ChangeCategory -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -470,6 +470,9 @@ class MangaScreen(
                     onConfirm = { screenModel.toggleFavorite(onRemoved = {}, checkDuplicate = false) },
                     onOpenManga = { navigator.push(MangaScreen(it.id)) },
                     onMigrate = { screenModel.showMigrateDialog(it) },
+                    // KMK -->
+                    targetManga = dialog.manga,
+                    // KMK <--
                 )
             }
 

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -175,6 +175,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                     onConfirm = { screenModel.addFavorite(dialog.manga) },
                     onOpenManga = { navigator.push(MangaScreen(it.id)) },
                     // KMK -->
+                    targetManga = dialog.manga,
                     onMigrate = { screenModel.setDialog(BrowseSourceScreenModel.Dialog.Migrate(dialog.manga, it)) },
                     // KMK <--
                 )


### PR DESCRIPTION
Include the target manga name in various duplicate dialogs to enhance user experience and provide clearer context when managing duplicates.

## Summary by Sourcery

New Features:
- Display the target manga’s title in duplicate dialogs to provide clearer context