### PR TITLE
feat(library-update-errors): add/clear error when updating manually from entry's screen

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -660,10 +660,9 @@ class LibraryUpdateJob(private val context: Context, private val workerParams: W
 
     private suspend fun writeErrorToDB(error: Pair<Manga, String?>) {
         val errorMessage = error.second ?: "???"
-        val errorMessageId = insertLibraryUpdateErrorMessages.get(errorMessage)
-            ?: insertLibraryUpdateErrorMessages.insert(
-                libraryUpdateErrorMessage = LibraryUpdateErrorMessage(-1L, errorMessage),
-            )
+        val errorMessageId = insertLibraryUpdateErrorMessages.insert(
+            libraryUpdateErrorMessage = LibraryUpdateErrorMessage(-1L, errorMessage),
+        )
 
         insertLibraryUpdateErrors.upsert(
             LibraryUpdateError(id = -1L, mangaId = error.first.id, messageId = errorMessageId),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -105,7 +105,7 @@ import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
 
 @OptIn(ExperimentalAtomicApi::class)
-class LibraryUpdateJob(private val context: Context, private val workerParams: WorkerParameters) :
+class LibraryUpdateJob(private val context: Context, workerParams: WorkerParameters) :
     CoroutineWorker(context, workerParams) {
 
     private val sourceManager: SourceManager = Injekt.get()
@@ -659,7 +659,7 @@ class LibraryUpdateJob(private val context: Context, private val workerParams: W
     }
 
     private suspend fun writeErrorToDB(error: Pair<Manga, String?>) {
-        val errorMessage = error.second ?: "???"
+        val errorMessage = error.second ?: context.stringResource(MR.strings.unknown_error)
         val errorMessageId = insertLibraryUpdateErrorMessages.insert(
             libraryUpdateErrorMessage = LibraryUpdateErrorMessage(-1L, errorMessage),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -646,7 +646,7 @@ class MangaScreenModel(
     }
 
     private suspend fun writeErrorToDB(error: Pair<Manga, String?>) {
-        val errorMessage = error.second ?: "???"
+        val errorMessage = error.second ?: context.stringResource(MR.strings.unknown_error)
         val errorMessageId = insertLibraryUpdateErrorMessages.insert(
             libraryUpdateErrorMessage = LibraryUpdateErrorMessage(-1L, errorMessage),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -647,10 +647,9 @@ class MangaScreenModel(
 
     private suspend fun writeErrorToDB(error: Pair<Manga, String?>) {
         val errorMessage = error.second ?: "???"
-        val errorMessageId = insertLibraryUpdateErrorMessages.get(errorMessage)
-            ?: insertLibraryUpdateErrorMessages.insert(
-                libraryUpdateErrorMessage = LibraryUpdateErrorMessage(-1L, errorMessage),
-            )
+        val errorMessageId = insertLibraryUpdateErrorMessages.insert(
+            libraryUpdateErrorMessage = LibraryUpdateErrorMessage(-1L, errorMessage),
+        )
 
         insertLibraryUpdateErrors.upsert(
             LibraryUpdateError(id = -1L, mangaId = error.first.id, messageId = errorMessageId),

--- a/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/libraryUpdateErrorMessage/LibraryUpdateErrorMessageRepositoryImpl.kt
@@ -37,8 +37,7 @@ class LibraryUpdateErrorMessageRepositoryImpl(
 
     override suspend fun insert(libraryUpdateErrorMessage: LibraryUpdateErrorMessage): Long {
         return handler.awaitOneExecutable(inTransaction = true) {
-            libraryUpdateErrorMessageQueries.insert(libraryUpdateErrorMessage.message)
-            libraryUpdateErrorMessageQueries.selectLastInsertedRowId()
+            libraryUpdateErrorMessageQueries.insertAndGet(libraryUpdateErrorMessage.message)
         }
     }
 
@@ -47,8 +46,7 @@ class LibraryUpdateErrorMessageRepositoryImpl(
     ): List<Pair<Long, String>> {
         return handler.await(inTransaction = true) {
             libraryUpdateErrorMessages.map {
-                libraryUpdateErrorMessageQueries.insert(it.message)
-                libraryUpdateErrorMessageQueries.selectLastInsertedRowId().executeAsOne() to it.message
+                libraryUpdateErrorMessageQueries.insertAndGet(it.message).executeAsOne() to it.message
             }
         }
     }

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
@@ -13,9 +13,8 @@ FROM libraryUpdateErrorMessage WHERE message == :message;
 
 insertAndGet {
     -- Insert the message if it doesn't exist already
-    INSERT INTO libraryUpdateErrorMessage(message)
-    SELECT :message
-    WHERE NOT EXISTS(SELECT 0 FROM libraryUpdateErrorMessage WHERE message = :message);
+    INSERT OR IGNORE INTO libraryUpdateErrorMessage(message)
+    VALUES (:message);
 
     -- Finally return the message ID
     SELECT _id
@@ -26,6 +25,3 @@ insertAndGet {
 
 deleteAllErrorMessages:
 DELETE FROM libraryUpdateErrorMessage;
-
-selectLastInsertedRowId:
-SELECT last_insert_rowid();

--- a/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/libraryUpdateErrorMessage.sq
@@ -11,8 +11,18 @@ getErrorMessages:
 SELECT *
 FROM libraryUpdateErrorMessage WHERE message == :message;
 
-insert:
-INSERT INTO libraryUpdateErrorMessage(message) VALUES (:message);
+insertAndGet {
+    -- Insert the message if it doesn't exist already
+    INSERT INTO libraryUpdateErrorMessage(message)
+    SELECT :message
+    WHERE NOT EXISTS(SELECT 0 FROM libraryUpdateErrorMessage WHERE message = :message);
+
+    -- Finally return the message ID
+    SELECT _id
+    FROM libraryUpdateErrorMessage
+    WHERE message = :message
+    LIMIT 1;
+}
 
 deleteAllErrorMessages:
 DELETE FROM libraryUpdateErrorMessage;


### PR DESCRIPTION
Implement functionality to add and clear library update errors when updating manually from the entry's screen. This includes enhancements to the database interactions for error messages.

## Summary by Sourcery

Add database-backed error handling for manual library updates, logging failures and clearing errors on success, and streamline SQL insertion for error messages.

New Features:
- Track and store manual manga update errors in the database when fetch fails
- Automatically clear stored update errors for a manga when its manual fetch succeeds

Enhancements:
- Refactor LibraryUpdateErrorMessageRepository to use a single insertAndGet query for atomic insert-and-return operations