### PR TITLE
feat(bulk-favorite): Show progress indicator when running `bulk-favorite`

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
@@ -226,20 +226,23 @@ private fun BulkAllowDuplicateDialog(
 fun bulkSelectionButton(
     isRunning: Boolean,
     toggleSelectionMode: () -> Unit,
-) = if (isRunning) {
-    AppBar.ActionCompose(
-        title = stringResource(KMR.strings.action_bulk_select),
-    ) {
-        CircularProgressIndicator(
-            modifier = Modifier
-                .size(24.dp),
-            strokeWidth = 2.dp,
+): AppBar.AppBarAction {
+    val title = stringResource(KMR.strings.action_bulk_select)
+    return if (isRunning) {
+        AppBar.ActionCompose(
+            title = title,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier
+                    .size(24.dp),
+                strokeWidth = 2.dp,
+            )
+        }
+    } else {
+        AppBar.Action(
+            title = title,
+            icon = Icons.Outlined.Checklist,
+            onClick = toggleSelectionMode,
         )
     }
-} else {
-    AppBar.Action(
-        title = stringResource(KMR.strings.action_bulk_select),
-        icon = Icons.Outlined.Checklist,
-        onClick = toggleSelectionMode,
-    )
 }


### PR DESCRIPTION
Implement a progress indicator in the bulk-favorite button to enhance user experience during long-running operations.

## Summary by Sourcery

Enhancements:
- Display a circular progress indicator in the bulk select button while the bulk-favorite operation is running.