### PR TITLE
chore(gemini): Add default Gemini Assists configurations

### DIFF
--- a/.gimini/config.yaml
+++ b/.gimini/config.yaml
@@ -1,0 +1,10 @@
+have_fun: true
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+ignore_patterns: []

--- a/.gimini/config.yaml
+++ b/.gimini/config.yaml
@@ -1,7 +1,7 @@
 have_fun: true
 code_review:
   disable: false
-  comment_severity_threshold: MEDIUM
+  comment_severity_threshold: LOW
   max_review_comments: -1
   pull_request_opened:
     help: false


### PR DESCRIPTION
Introduce a default configuration file with settings for code review, including a comment severity threshold set to LOW.