### PR TITLE
fix(manga-repository): Fix selected entries while bulk-selection won't show as selected

### DIFF
--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -149,8 +149,11 @@ class MangaRepositoryImpl(
                     updateCover = !it.ogThumbnailUrl.isNullOrBlank(),
                     // SY <--
                     updateDetails = it.initialized,
-                    mapper = MangaMapper::mapManga,
+                    // KMK -->
+                    // mapper = MangaMapper::mapManga,
                 )
+                mangasQueries.getMangaByUrlAndSource(it.url, it.source, MangaMapper::mapManga)
+                    // KMK <--
                     .executeAsOne()
             }
         }

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -246,12 +246,13 @@ insertNetworkManga {
     AND url = :url
     AND favorite = 0;
 
-    -- Finally return the manga
-    SELECT *
-    FROM mangas
-    WHERE source = :source
-    AND url = :url
-    LIMIT 1;
+-- KMK : Disabled the following SELECT as it will cause `getMangaByUrlAndSource` flow not triggered
+--     -- Finally return the manga
+--     SELECT *
+--     FROM mangas
+--     WHERE source = :source
+--     AND url = :url
+--     LIMIT 1;
 }
 
 getEhMangaWithMetadata:


### PR DESCRIPTION
Resolve an issue where selected entries in bulk-selection were not displayed correctly by disabling a problematic SELECT query in `insertNetworkManga` to ensure the `getMangaByUrlAndSource` flow is triggered properly.