### PR TITLE
feat(notification): Add separate channel for sync notifications

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -51,7 +51,7 @@ object Notifications {
     const val GROUP_NEW_CHAPTERS = "eu.kanade.tachiyomi.NEW_CHAPTERS"
 
     /**
-     * Notification channel and ids used by the backup/restore system.
+     * Notification channel and ids used by the backup/restore/sync system.
      */
     private const val GROUP_BACKUP_RESTORE = "group_backup_restore"
     const val CHANNEL_BACKUP_RESTORE_PROGRESS = "backup_restore_progress_channel"
@@ -60,6 +60,9 @@ object Notifications {
     const val CHANNEL_BACKUP_RESTORE_COMPLETE = "backup_restore_complete_channel_v2"
     const val ID_BACKUP_COMPLETE = -502
     const val ID_RESTORE_COMPLETE = -504
+    const val CHANNEL_SYNC_LIBRARY = "syncing_library_channel"
+    const val ID_SYNC_PROGRESS = -505
+    const val ID_SYNC_COMPLETE = -506
 
     /**
      * Notification channel used for Incognito Mode
@@ -164,6 +167,11 @@ object Notifications {
                     setGroup(GROUP_BACKUP_RESTORE)
                     setShowBadge(false)
                     setSound(null, null)
+                },
+                buildNotificationChannel(CHANNEL_SYNC_LIBRARY, IMPORTANCE_LOW) {
+                    setName(context.stringResource(MR.strings.syncing_library))
+                    setGroup(GROUP_BACKUP_RESTORE)
+                    setShowBadge(false)
                 },
                 buildNotificationChannel(CHANNEL_INCOGNITO_MODE, IMPORTANCE_LOW) {
                     setName(context.stringResource(MR.strings.pref_incognito_mode))

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncDataJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncDataJob.kt
@@ -15,7 +15,6 @@ import androidx.work.WorkerParameters
 import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.tachiyomi.data.SyncStatus
 import eu.kanade.tachiyomi.data.notification.Notifications
-import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.isOnline
 import eu.kanade.tachiyomi.util.system.isRunning
 import eu.kanade.tachiyomi.util.system.setForegroundSafely
@@ -61,7 +60,6 @@ class SyncDataJob(private val context: Context, workerParams: WorkerParameters) 
             notifier.showSyncError(e.message)
             Result.success() // try again next time
         } finally {
-            context.cancelNotification(Notifications.ID_SYNC_PROGRESS)
             // KMK -->
             syncStatus.stop()
             // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncDataJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncDataJob.kt
@@ -61,7 +61,7 @@ class SyncDataJob(private val context: Context, workerParams: WorkerParameters) 
             notifier.showSyncError(e.message)
             Result.success() // try again next time
         } finally {
-            context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
+            context.cancelNotification(Notifications.ID_SYNC_PROGRESS)
             // KMK -->
             syncStatus.stop()
             // KMK <--
@@ -70,7 +70,7 @@ class SyncDataJob(private val context: Context, workerParams: WorkerParameters) 
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
         return ForegroundInfo(
-            Notifications.ID_RESTORE_PROGRESS,
+            Notifications.ID_SYNC_PROGRESS,
             notifier.showSyncProgress().build(),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncNotifier.kt
@@ -86,7 +86,7 @@ class SyncNotifier(private val context: Context) {
             setContentTitle(context.getString(R.string.sync_error))
             setContentText(error)
 
-            show(Notifications.ID_RESTORE_COMPLETE)
+            show(Notifications.ID_SYNC_COMPLETE)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncNotifier.kt
@@ -25,7 +25,7 @@ class SyncNotifier(private val context: Context) {
     // KMK <--
 
     private val progressNotificationBuilder = context.notificationBuilder(
-        Notifications.CHANNEL_BACKUP_RESTORE_PROGRESS,
+        Notifications.CHANNEL_SYNC_LIBRARY,
     ) {
         setSmallIcon(R.drawable.ic_komikku)
         setColor(ContextCompat.getColor(context, R.color.ic_launcher))
@@ -36,7 +36,7 @@ class SyncNotifier(private val context: Context) {
     }
 
     private val completeNotificationBuilder = context.notificationBuilder(
-        Notifications.CHANNEL_BACKUP_RESTORE_COMPLETE,
+        Notifications.CHANNEL_SYNC_LIBRARY,
     ) {
         setSmallIcon(R.drawable.ic_komikku)
         setColor(ContextCompat.getColor(context, R.color.ic_launcher))
@@ -70,17 +70,17 @@ class SyncNotifier(private val context: Context) {
             addAction(
                 R.drawable.ic_close_24dp,
                 context.getString(R.string.action_cancel),
-                NotificationReceiver.cancelSyncPendingBroadcast(context, Notifications.ID_RESTORE_PROGRESS),
+                NotificationReceiver.cancelSyncPendingBroadcast(context, Notifications.ID_SYNC_PROGRESS),
             )
         }
 
-        builder.show(Notifications.ID_RESTORE_PROGRESS)
+        builder.show(Notifications.ID_SYNC_PROGRESS)
 
         return builder
     }
 
     fun showSyncError(error: String?) {
-        context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
+        context.cancelNotification(Notifications.ID_SYNC_PROGRESS)
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.sync_error))
@@ -91,13 +91,13 @@ class SyncNotifier(private val context: Context) {
     }
 
     fun showSyncSuccess(message: String?) {
-        context.cancelNotification(Notifications.ID_RESTORE_PROGRESS)
+        context.cancelNotification(Notifications.ID_SYNC_PROGRESS)
 
         with(completeNotificationBuilder) {
             setContentTitle(context.getString(R.string.sync_complete))
             setContentText(message)
 
-            show(Notifications.ID_RESTORE_COMPLETE)
+            show(Notifications.ID_SYNC_COMPLETE)
         }
     }
 }


### PR DESCRIPTION
Introduce a dedicated notification channel for sync operations, enhancing the backup/restore system with specific sync progress notifications.

## Summary by Sourcery

Introduce a separate sync notification channel by defining new channel and IDs, migrating existing sync notifications from the backup/restore channels, and cleaning up related code references.

New Features:
- Add a dedicated notification channel and IDs for library sync progress and completion

Enhancements:
- Update SyncNotifier to route sync progress and completion notifications to the new channel and identifiers
- Replace backup/restore IDs with sync-specific IDs and remove obsolete cancellation calls in SyncDataJob

Build:
- Register the new sync notification channel in Notifications configuration