### PR TITLE
fix: add support for `EnhancedTracker` to merged sources

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/EnhancedTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/EnhancedTracker.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.data.track
 
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.online.all.MergedSource
+import exh.source.MERGED_SOURCE_ID
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.track.model.Track
 
@@ -15,6 +17,10 @@ interface EnhancedTracker {
      * This tracker will only work with the sources that are accepted by this filter function.
      */
     fun accept(source: Source): Boolean {
+        if (source.id == MERGED_SOURCE_ID) {
+            val sources = (source as MergedSource).getSources()
+            return sources.any { it::class.qualifiedName in getAcceptedSources() }
+        }
         return source::class.qualifiedName in getAcceptedSources()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MergedSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MergedSource.kt
@@ -178,6 +178,10 @@ class MergedSource : HttpSource() {
         return LoadedMangaSource(source, manga, this)
     }
 
+    fun getSources(): List<Source> {
+        return sourceManager.getOnlineSources()
+    }
+
     data class LoadedMangaSource(val source: Source, val manga: Manga?, val reference: MergedMangaReference)
 
     override val lang = "all"

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackInfoDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/track/TrackInfoDialog.kt
@@ -53,10 +53,13 @@ import eu.kanade.tachiyomi.data.track.EnhancedTracker
 import eu.kanade.tachiyomi.data.track.Tracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.online.all.MergedSource
 import eu.kanade.tachiyomi.util.lang.convertEpochMillisZone
 import eu.kanade.tachiyomi.util.system.copyToClipboard
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toast
+import exh.source.MERGED_SOURCE_ID
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
@@ -71,6 +74,9 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.manga.interactor.GetMergedReferencesById
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.MergedMangaReference
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.track.interactor.DeleteTrack
 import tachiyomi.domain.track.interactor.GetTracks
@@ -216,7 +222,16 @@ data class TrackInfoDialogHomeScreen(
         fun registerEnhancedTracking(item: TrackItem) {
             item.tracker as EnhancedTracker
             screenModelScope.launchNonCancellable {
-                val manga = Injekt.get<GetManga>().await(mangaId) ?: return@launchNonCancellable
+                var manga = if (sourceId == MERGED_SOURCE_ID) {
+                    Injekt.get<GetMergedReferencesById>().await(mangaId).first {
+                        Injekt.get<SourceManager>().get(it.mangaSourceId)?.name?.startsWith(
+                            item.tracker.name,
+                            true,
+                        ) == true
+                    }.mangaId?.let { Injekt.get<GetManga>().await(it) } ?: return@launchNonCancellable
+                } else {
+                    Injekt.get<GetManga>().await(mangaId) ?: return@launchNonCancellable
+                }
                 try {
                     val matchResult = item.tracker.match(manga) ?: throw Exception()
                     item.tracker.register(matchResult, mangaId)


### PR DESCRIPTION
Adds merged source match to `EnhancedTracker::accept`
Adds name-based matching between source and tracker when registering enhanced trackers on merged sources.

Closes #931.

Tested with Suwayomi:

![Screenshot_20250527_020104](https://github.com/user-attachments/assets/6c2b7151-a3ff-404b-bb7d-d5f4452ca78f)



<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
