### PR TITLE
fix(release-notes): Fix Github Release Notes incorrectly displayed with Markdown

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/ComingUpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/ComingUpdatesScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import eu.kanade.presentation.manga.components.MarkdownRender
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.kmk.KMR
 import tachiyomi.i18n.sy.SYMR
@@ -46,7 +47,10 @@ fun ComingUpdatesScreen(
                 .fillMaxWidth()
                 .padding(vertical = MaterialTheme.padding.large),
         ) {
-            MarkdownRender(content = changelogInfo)
+            MarkdownRender(
+                content = changelogInfo.trimIndent(),
+                flavour = GFMFlavourDescriptor(),
+            )
 
             TextButton(
                 onClick = onOpenInBrowser,

--- a/app/src/main/java/eu/kanade/presentation/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/NewUpdateScreen.kt
@@ -47,7 +47,7 @@ fun NewUpdateScreen(
                 .padding(vertical = MaterialTheme.padding.large),
         ) {
             MarkdownRender(
-                content = changelogInfo,
+                content = changelogInfo.trimIndent(),
                 flavour = GFMFlavourDescriptor(),
             )
 

--- a/app/src/main/java/eu/kanade/presentation/more/WhatsNewScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/WhatsNewScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import eu.kanade.presentation.manga.components.MarkdownRender
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.kmk.KMR
 import tachiyomi.i18n.sy.SYMR
@@ -45,7 +46,10 @@ fun WhatsNewScreen(
                 .fillMaxWidth()
                 .padding(vertical = MaterialTheme.padding.large),
         ) {
-            MarkdownRender(content = changelogInfo)
+            MarkdownRender(
+                content = changelogInfo.trimIndent(),
+                flavour = GFMFlavourDescriptor(),
+            )
 
             TextButton(
                 onClick = onOpenInBrowser,
@@ -67,14 +71,43 @@ private fun WhatsNewScreenPreview() {
             currentVersion = "v0.99.9",
             versionName = "v1.00.0",
             changelogInfo = """
-                ## Yay
-                Foobar
+                ## v1.13.1
 
-                ### More info
-                [komikku-app/komikku@23d862d17...48fb4a2e6](https://github.com/komikku-app/komikku/compare/23d862d17...48fb4a2e6)
-                - Hello ([@cuong-tran](@https://github.com/cuong-tran))
-                - World
-            """.trimIndent(),
+
+                #### What's Changed
+                ##### Fix
+
+                - Fix mark existing duplicate read chapters as read option not working in some cases ([@AntsyLich](https://github.com/AntsyLich))
+                - Fix: NaN when dragging `Start/Resume` reading button in MangaScreen ([@cuong-tran](https://github.com/cuong-tran))
+
+
+                **Full Changelog**: [komikku-app/komikku@v1.13.0...v1.13.1](https://github.com/komikku-app/komikku/compare/v1.13.0...v1.13.1)
+
+
+                ---
+                ## v1.12.6
+
+
+                #### What's Changed
+                ##### Fix
+                - bump version ([@cuong-tran](https://github.com/cuong-tran))
+                - rename repo ([@cuong-tran](https://github.com/cuong-tran))
+
+                **Full Changelog**: [komikku-app/komikku@v1.12.5...v1.12.6](https://github.com/komikku-app/komikku/compare/v1.12.5...v1.12.6)
+
+
+                ---
+                ## v1.12.5
+
+
+
+                #### What's Changed
+                ##### Fix
+
+                - Fix (MangasPage): crash when extensions trying to destructuring MangasPage ([@cuong-tran](https://github.com/cuong-tran))
+
+                **Full Changelog**: [komikku-app/komikku@v1.12.4...v1.12.5](https://github.com/komikku-app/komikku/compare/v1.12.4...v1.12.5)
+            """,
             onOpenInBrowser = {},
             onAcceptUpdate = {},
         )


### PR DESCRIPTION
Correct the display of GitHub Release Notes by ensuring proper Markdown formatting across multiple screens. This change enhances the presentation of changelog information.

## Summary by Sourcery

Improve rendering of GitHub Release Notes by enabling GFM parsing and trimming indentation in all update screens, and refresh preview sample with realistic multi-version changelogs.

Bug Fixes:
- Fix incorrect Markdown rendering in WhatsNewScreen, ComingUpdatesScreen, and NewUpdateScreen.

Enhancements:
- Trim leading indentation and pass GFMFlavourDescriptor to MarkdownRender in all release note screens.
- Update preview sample in WhatsNewScreen to include realistic, multi-version changelog entries.