### PR TITLE
chore: Fix Discord badge & update Weblate link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Before you start, please note that the ability to use following technologies is 
 
 # Translations
 
-Translations are done externally via [Crowdin](https://crowdin.com/project/komikku).
+Translations are done externally via [Weblate](https://hosted.weblate.org/engage/komikku-app/).
 
 
 # Forks

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 *Requires Android 8.0 or higher.*
 
-[![Discord](https://img.shields.io/discord/1195734228319617024.svg?label=&labelColor=6A7EC2&color=7389D8&logo=discord&logoColor=FFFFFF)](https://discord.gg/85jB7V5AJR)
+[![Discord](https://img.shields.io/discord/1242381704459452488.svg?label=&labelColor=6A7EC2&color=7389D8&logo=discord&logoColor=FFFFFF)](https://discord.gg/85jB7V5AJR)
 [![CI](https://img.shields.io/github/actions/workflow/status/komikku-app/komikku/build_push.yml?labelColor=27303D&label=CI)](https://github.com/komikku-app/komikku/actions/workflows/build_push.yml)
 [![License: Apache-2.0](https://img.shields.io/github/license/komikku-app/komikku?labelColor=27303D&color=0877d2)](/LICENSE)
 [![Translation status](https://img.shields.io/weblate/progress/komikku-app?labelColor=27303D&color=946300)](https://hosted.weblate.org/engage/komikku-app/)
@@ -129,7 +129,7 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 [Website](https://komikku-app.github.io/)
 
 1. **Before reporting a new issue, take a look at the [FAQ](https://mihon.app/docs/faq/general), the [changelog](https://github.com/komikku-app/komikku/releases) and the already opened [issues](https://github.com/komikku-app/komikku/issues).**
-2. If you are unsure, ask here: [![Discord](https://img.shields.io/discord/1195734228319617024.svg?label=&labelColor=6A7EC2&color=7389D8&logo=discord&logoColor=FFFFFF)](https://discord.gg/85jB7V5AJR)
+2. If you are unsure, ask here: [![Discord](https://img.shields.io/discord/1242381704459452488.svg?label=&labelColor=6A7EC2&color=7389D8&logo=discord&logoColor=FFFFFF)](https://discord.gg/85jB7V5AJR)
 
 </details>
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -229,8 +229,7 @@ class AboutScreen : Screen() {
                         title = stringResource(MR.strings.help_translate),
                         onPreferenceClick = {
                             uriHandler.openUri(
-                                "https://crowdin.com/project/komikku/" +
-                                    "invite?h=f922abd4193e77309b084a08c74b89872112170",
+                                "https://hosted.weblate.org/engage/komikku-app/",
                             )
                         },
                     )


### PR DESCRIPTION
Update the Discord badge to the correct link and replace references to Crowdin with Weblate for translations.

## Summary by Sourcery

Fix Discord badge server ID and update all translation references from Crowdin to Weblate

Enhancements:
- Update in-app translation help link to point to Weblate

Documentation:
- Correct Discord badge links in README
- Replace Crowdin with Weblate link in CONTRIBUTING.md