### PR TITLE
fix(updates): Fix date order in updates list

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -99,12 +99,15 @@ class UpdatesScreenModel(
                             isLoading = false,
                             items = updates.toUpdateItems()
                                 // KMK -->
-                                .groupBy { it.update.mangaId }
-                                .values
-                                .flatMap { mangaChapters ->
-                                    val (unread, read) = mangaChapters.partition { !it.update.read }
-                                    unread.sortedBy { it.update.dateFetch } +
-                                        read.sortedByDescending { it.update.dateFetch }
+                                .groupBy { it.update.dateFetch.toLocalDate() }
+                                .flatMap { (_, mangas) ->
+                                    mangas.groupBy { it.update.mangaId }
+                                        .values
+                                        .flatMap { mangaChapters ->
+                                            val (unread, read) = mangaChapters.partition { !it.update.read }
+                                            unread.sortedBy { it.update.dateFetch } +
+                                                read.sortedByDescending { it.update.dateFetch }
+                                        }
                                 }
                                 .toPersistentList(),
                             // KMK <--


### PR DESCRIPTION
Correct the ordering of updates by grouping them first by date and then by manga ID, ensuring the updates display in the intended chronological order.

## Summary by Sourcery

Bug Fixes:
- Correct the grouping logic to group updates by date before grouping by manga ID instead of the other way around