### PR TITLE
fix(migration): Fix issue preventing migration dialog to be shown up

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateDialog.kt
@@ -31,6 +31,8 @@ import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.ui.browse.migration.MigrationFlags
+import exh.log.LogLevel
+import exh.log.xLog
 import kotlinx.coroutines.flow.update
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.util.lang.launchIO
@@ -183,9 +185,12 @@ internal class MigrateDialogScreenModel(
                 replace = replace,
                 presetFlags = flags,
             )
-        } catch (_: Throwable) {
-            // Explicitly stop if an error occurred; the dialog normally gets popped at the end
-            // anyway
+        } catch (e: Throwable) {
+            // Explicitly stop if an error occurred; the dialog normally gets popped at the end anyway
+            // KMK -->
+            xLog(LogLevel.Error, "Failed to migrate manga ${oldManga.title} to ${newManga.title}", e)
+        } finally {
+            // KMK <--
             mutableState.update { it.copy(isMigrating = false) }
         }
     }


### PR DESCRIPTION
Fixes an issue that prevented the migration dialog from being shown. Improved error handling and logging during the migration process.

## Summary by Sourcery

Improve migration dialog reliability by explicitly handling errors and ensuring the migrating state is reset, preventing the dialog from getting stuck on failures and adding error logging for better visibility.

Bug Fixes:
- Reset the migration state in a finally block to prevent the dialog from remaining in a migrating state and ensure it displays or closes correctly on errors

Enhancements:
- Add error logging with xLog and LogLevel.Error to capture details of migration failures