### PR TITLE
chore(manga-repository): Revert (in-memory) fast browsing

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import eu.kanade.domain.source.model.installedExtension
 import eu.kanade.presentation.browse.components.GlobalSearchCardRow
@@ -22,7 +21,6 @@ import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import kotlinx.collections.immutable.ImmutableMap
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.domain.source.model.Source as DomainSource
@@ -45,7 +43,6 @@ fun GlobalSearchScreen(
     // KMK <--
 ) {
     // KMK -->
-    val scope = rememberCoroutineScope()
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     // KMK <--
 
@@ -62,24 +59,13 @@ fun GlobalSearchScreen(
                         state.filteredItems.values
                             .filterIsInstance<SearchItemResult.Success>()
                             .flatMap { it.result }
-                            .let {
-                                scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                        .forEach { bulkFavoriteScreenModel.select(it) }
-                                }
-                            }
+                            .forEach { bulkFavoriteScreenModel.select(it) }
                     },
                     onReverseSelection = {
                         state.filteredItems.values
                             .filterIsInstance<SearchItemResult.Success>()
                             .flatMap { it.result }
-                            .let {
-                                scope.launchIO {
-                                    bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                    )
-                                }
-                            }
+                            .let { bulkFavoriteScreenModel.reverseSelection(it) }
                     },
                 )
             } else {

--- a/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/GlobalSearchScreen.kt
@@ -64,7 +64,7 @@ fun GlobalSearchScreen(
                             .flatMap { it.result }
                             .let {
                                 scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga(it)
+                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                         .forEach { bulkFavoriteScreenModel.select(it) }
                                 }
                             }
@@ -76,7 +76,7 @@ fun GlobalSearchScreen(
                             .let {
                                 scope.launchIO {
                                     bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga(it),
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                     )
                                 }
                             }

--- a/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import eu.kanade.presentation.browse.components.GlobalSearchToolbar
 import eu.kanade.presentation.components.BulkSelectionToolbar
 import eu.kanade.tachiyomi.source.CatalogueSource
@@ -12,7 +11,6 @@ import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchItemResult
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.SourceFilter
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.presentation.core.components.material.Scaffold
 
@@ -35,7 +33,6 @@ fun MigrateSearchScreen(
     // KMK <--
 ) {
     // KMK -->
-    val scope = rememberCoroutineScope()
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     // KMK <--
 
@@ -52,24 +49,13 @@ fun MigrateSearchScreen(
                         state.filteredItems.values
                             .filterIsInstance<SearchItemResult.Success>()
                             .flatMap { it.result }
-                            .let {
-                                scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                        .forEach { bulkFavoriteScreenModel.select(it) }
-                                }
-                            }
+                            .forEach { bulkFavoriteScreenModel.select(it) }
                     },
                     onReverseSelection = {
                         state.filteredItems.values
                             .filterIsInstance<SearchItemResult.Success>()
                             .flatMap { it.result }
-                            .let {
-                                scope.launchIO {
-                                    bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                    )
-                                }
-                            }
+                            .let { bulkFavoriteScreenModel.reverseSelection(it) }
                     },
                 )
             } else {

--- a/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/MigrateSearchScreen.kt
@@ -54,7 +54,7 @@ fun MigrateSearchScreen(
                             .flatMap { it.result }
                             .let {
                                 scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga(it)
+                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                         .forEach { bulkFavoriteScreenModel.select(it) }
                                 }
                             }
@@ -66,7 +66,7 @@ fun MigrateSearchScreen(
                             .let {
                                 scope.launchIO {
                                     bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga(it),
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                     )
                                 }
                             }

--- a/app/src/main/java/eu/kanade/presentation/browse/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourceFeedScreen.kt
@@ -132,7 +132,7 @@ fun SourceFeedScreen(
                             .flatten()
                             .let {
                                 scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga(it)
+                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                         .forEach { bulkFavoriteScreenModel.select(it) }
                                 }
                             }
@@ -143,7 +143,7 @@ fun SourceFeedScreen(
                             .let {
                                 scope.launchIO {
                                     bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga(it),
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                     )
                                 }
                             }

--- a/app/src/main/java/eu/kanade/presentation/browse/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourceFeedScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.presentation.browse.components.BrowseSourceFloatingActionButton
@@ -27,7 +26,6 @@ import eu.kanade.presentation.components.SearchToolbar
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.model.FeedSavedSearch
 import tachiyomi.domain.source.model.SavedSearch
@@ -114,7 +112,6 @@ fun SourceFeedScreen(
     // KMK <--
 ) {
     // KMK -->
-    val scope = rememberCoroutineScope()
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     // KMK <--
 
@@ -130,23 +127,12 @@ fun SourceFeedScreen(
                     onSelectAll = {
                         items.mapNotNull { it.results }
                             .flatten()
-                            .let {
-                                scope.launchIO {
-                                    bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                        .forEach { bulkFavoriteScreenModel.select(it) }
-                                }
-                            }
+                            .forEach { bulkFavoriteScreenModel.select(it) }
                     },
                     onReverseSelection = {
                         items.mapNotNull { it.results }
                             .flatten()
-                            .let {
-                                scope.launchIO {
-                                    bulkFavoriteScreenModel.reverseSelection(
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                    )
-                                }
-                            }
+                            .let { bulkFavoriteScreenModel.reverseSelection(it) }
                     },
                 )
             } else {

--- a/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasComfortableGrid.kt
@@ -80,7 +80,7 @@ fun RelatedMangasComfortableGrid(
                     )
                 }
                 items(
-                    key = { "related-comfort-${relatedManga.mangaList[it].url.hashCode()}" },
+                    key = { "related-comfort-${relatedManga.mangaList[it].id}" },
                     count = relatedManga.mangaList.size,
                 ) { index ->
                     val manga by getManga(relatedManga.mangaList[index])

--- a/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasCompactGrid.kt
@@ -79,7 +79,7 @@ fun RelatedMangasCompactGrid(
                     )
                 }
                 items(
-                    key = { "related-compact-${relatedManga.mangaList[it].url.hashCode()}" },
+                    key = { "related-compact-${relatedManga.mangaList[it].id}" },
                     count = relatedManga.mangaList.size,
                 ) { index ->
                     val manga by getManga(relatedManga.mangaList[index])

--- a/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/RelatedMangasList.kt
@@ -82,7 +82,7 @@ fun RelatedMangasList(
                     )
                 }
                 items(
-                    key = { "related-list-${relatedManga.mangaList[it].url.hashCode()}" },
+                    key = { "related-list-${relatedManga.mangaList[it].id}" },
                     count = relatedManga.mangaList.size,
                 ) { index ->
                     val manga by getManga(relatedManga.mangaList[index])

--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
@@ -71,7 +71,7 @@ fun TabbedScreen(
                                 .flatten()
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -84,7 +84,7 @@ fun TabbedScreen(
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                         )
                                     }
                                 }

--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
@@ -29,7 +29,6 @@ import eu.kanade.tachiyomi.ui.browse.feed.FeedScreenModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.components.material.TabText
 import tachiyomi.presentation.core.i18n.stringResource
@@ -69,25 +68,14 @@ fun TabbedScreen(
                         feedState.items?.let { result ->
                             result.mapNotNull { it.results }
                                 .flatten()
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                            .forEach { bulkFavoriteScreenModel.select(it) }
-                                    }
-                                }
+                                .forEach { bulkFavoriteScreenModel.select(it) }
                         }
                     },
                     onReverseSelection = {
                         feedState.items?.let { result ->
                             result.mapNotNull { it.results }
                                 .flatten()
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                        )
-                                    }
-                                }
+                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
                         }
                     },
                 )

--- a/app/src/main/java/eu/kanade/presentation/manga/components/RelatedMangasRow.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/RelatedMangasRow.kt
@@ -66,7 +66,7 @@ fun RelatedMangaCardRow(
         contentPadding = PaddingValues(MaterialTheme.padding.small),
         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),
     ) {
-        items(mangas, key = { "related-row-${it.url.hashCode()}" }) {
+        items(mangas, key = { "related-row-${it.id}" }) {
             val manga by getManga(it)
             MangaItem(
                 title = manga.title,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -34,7 +34,6 @@ import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.chapter.interactor.SetMangaDefaultChapterFlags
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
-import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.manga.model.toMangaUpdate
@@ -54,10 +53,6 @@ class BulkFavoriteScreenModel(
     private val coverCache: CoverCache = Injekt.get(),
     private val setMangaDefaultChapterFlags: SetMangaDefaultChapterFlags = Injekt.get(),
     private val addTracks: AddTracks = Injekt.get(),
-
-    // KMK -->
-    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
-    // KMK <--
 ) : StateScreenModel<BulkFavoriteScreenModel.State>(initialState) {
 
     fun backHandler() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedScreenModel.kt
@@ -61,7 +61,7 @@ open class FeedScreenModel(
     val sourceManager: SourceManager = Injekt.get(),
     val sourcePreferences: SourcePreferences = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
-    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     getFeedSavedSearchGlobal: GetFeedSavedSearchGlobal = Injekt.get(),
     private val getSavedSearchGlobalFeed: GetSavedSearchGlobalFeed = Injekt.get(),
     private val countFeedSavedSearchGlobal: CountFeedSavedSearchGlobal = Injekt.get(),
@@ -305,8 +305,8 @@ open class FeedScreenModel(
                             results = page
                                 .map { it.toDomainManga(itemUI.source!!.id) }
                                 .distinctBy { it.url }
+                                .let { networkToLocalManga(it) }
                                 // KMK -->
-                                // .let { networkToLocalManga(it) }
                                 .filter { !hideInLibraryFeedItems.get() || !it.favorite },
                             // KMK <--
                         )
@@ -344,11 +344,8 @@ open class FeedScreenModel(
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
                 .collectLatest { manga ->
-                    /* KMK --> if (manga == null) return@collectLatest KMK <-- */
+                    if (manga == null) return@collectLatest
                     value = manga
-                        // KMK -->
-                        ?: initialManga
-                    // KMK <--
                 }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalHapticFeedback
 import cafe.adriel.voyager.core.screen.Screen
@@ -37,7 +36,6 @@ import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.source.interactor.GetRemoteManga
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.kmk.KMR
@@ -55,7 +53,6 @@ fun Screen.feedTab(
     val state by screenModel.state.collectAsState()
 
     // KMK -->
-    val scope = rememberCoroutineScope()
     val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
     val showingFeedOrderScreen = rememberSaveable { mutableStateOf(false) }
 
@@ -168,27 +165,21 @@ fun Screen.feedTab(
                         // KMK -->
                         onLongClickFeed = screenModel::openActionsDialog,
                         // KMK <--
-                        onClickManga = {
+                        onClickManga = { manga ->
                             // KMK -->
-                            scope.launchIO {
-                                val manga = screenModel.networkToLocalManga.getLocal(it)
-                                if (bulkFavoriteState.selectionMode) {
-                                    bulkFavoriteScreenModel.toggleSelection(manga)
-                                } else {
-                                    // KMK <--
-                                    navigator.push(MangaScreen(manga.id, true))
-                                }
+                            if (bulkFavoriteState.selectionMode) {
+                                bulkFavoriteScreenModel.toggleSelection(manga)
+                            } else {
+                                // KMK <--
+                                navigator.push(MangaScreen(manga.id, true))
                             }
                         },
                         // KMK -->
-                        onLongClickManga = {
-                            scope.launchIO {
-                                val manga = screenModel.networkToLocalManga.getLocal(it)
-                                if (!bulkFavoriteState.selectionMode) {
-                                    bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                                } else {
-                                    navigator.push(MangaScreen(manga.id, true))
-                                }
+                        onLongClickManga = { manga ->
+                            if (!bulkFavoriteState.selectionMode) {
+                                bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                            } else {
+                                navigator.push(MangaScreen(manga.id, true))
                             }
                         },
                         selection = bulkFavoriteState.selection,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
@@ -171,7 +171,7 @@ fun Screen.feedTab(
                         onClickManga = {
                             // KMK -->
                             scope.launchIO {
-                                val manga = screenModel.networkToLocalManga(it)
+                                val manga = screenModel.networkToLocalManga.getLocal(it)
                                 if (bulkFavoriteState.selectionMode) {
                                     bulkFavoriteScreenModel.toggleSelection(manga)
                                 } else {
@@ -183,7 +183,7 @@ fun Screen.feedTab(
                         // KMK -->
                         onLongClickManga = {
                             scope.launchIO {
-                                val manga = screenModel.networkToLocalManga(it)
+                                val manga = screenModel.networkToLocalManga.getLocal(it)
                                 if (!bulkFavoriteState.selectionMode) {
                                     bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                                 } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
@@ -58,7 +58,7 @@ class MigrateSearchScreen(private val mangaId: Long, private val validSources: L
             onClickItem = {
                 // KMK -->
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga(it)
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
                     if (bulkFavoriteState.selectionMode) {
                         bulkFavoriteScreenModel.toggleSelection(manga)
                     } else
@@ -77,7 +77,7 @@ class MigrateSearchScreen(private val mangaId: Long, private val validSources: L
             onLongClickItem = {
                 // KMK -->
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga(it)
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
                     // KMK <--
                     navigator.push(MangaScreen(manga.id, true))
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -14,7 +13,6 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationListScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
-import tachiyomi.core.common.util.lang.launchIO
 
 /**
  * Manual search [validSources] for manga to migrate to.
@@ -32,7 +30,6 @@ class MigrateSearchScreen(private val mangaId: Long, private val validSources: L
         val dialogState by dialogScreenModel.state.collectAsState()
 
         // KMK -->
-        val scope = rememberCoroutineScope()
         val bulkFavoriteScreenModel = rememberScreenModel { BulkFavoriteScreenModel() }
         val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
 
@@ -55,33 +52,23 @@ class MigrateSearchScreen(private val mangaId: Long, private val validSources: L
                 navigator.push(SourceSearchScreen(dialogState.manga!!, it.id, state.searchQuery))
                 // SY <--
             },
-            onClickItem = {
+            onClickItem = { manga ->
                 // KMK -->
-                scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
-                    if (bulkFavoriteState.selectionMode) {
-                        bulkFavoriteScreenModel.toggleSelection(manga)
-                    } else
-                        // KMK <--
-                        {
-                            // SY -->
-                            navigator.items
-                                .filterIsInstance<MigrationListScreen>()
-                                .last()
-                                .newSelectedItem = mangaId to manga.id
-                            navigator.popUntil { it is MigrationListScreen }
-                            // SY <--
-                        }
-                }
-            },
-            onLongClickItem = {
-                // KMK -->
-                scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
+                if (bulkFavoriteState.selectionMode) {
+                    bulkFavoriteScreenModel.toggleSelection(manga)
+                } else
                     // KMK <--
-                    navigator.push(MangaScreen(manga.id, true))
-                }
+                    {
+                        // SY -->
+                        navigator.items
+                            .filterIsInstance<MigrationListScreen>()
+                            .last()
+                            .newSelectedItem = mangaId to manga.id
+                        navigator.popUntil { it is MigrationListScreen }
+                        // SY <--
+                    }
             },
+            onLongClickItem = { navigator.push(MangaScreen(it.id, true)) },
             // KMK -->
             bulkFavoriteScreenModel = bulkFavoriteScreenModel,
             hasPinnedSources = screenModel.hasPinnedSources(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
@@ -94,7 +94,7 @@ data class SourceSearchScreen(
                                 .map { it.value.first }
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -105,7 +105,7 @@ data class SourceSearchScreen(
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                         )
                                     }
                                 }
@@ -178,7 +178,7 @@ data class SourceSearchScreen(
                 onMangaClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga(it)
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
                         if (bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.toggleSelection(manga)
                         } else {
@@ -190,7 +190,7 @@ data class SourceSearchScreen(
                 onMangaLongClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga(it)
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
                         // KMK <--
                         navigator.push(MangaScreen(manga.id, true))
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/SourceSearchScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -34,7 +33,6 @@ import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.persistentListOf
 import mihon.presentation.core.util.collectAsLazyPagingItems
 import tachiyomi.core.common.Constants
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.material.Scaffold
@@ -68,7 +66,6 @@ data class SourceSearchScreen(
 
         // KMK -->
         val context = LocalContext.current
-        val scope = rememberCoroutineScope()
 
         val bulkFavoriteScreenModel = rememberScreenModel { BulkFavoriteScreenModel() }
         val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
@@ -92,23 +89,12 @@ data class SourceSearchScreen(
                         onSelectAll = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                            .forEach { bulkFavoriteScreenModel.select(it) }
-                                    }
-                                }
+                                .forEach { bulkFavoriteScreenModel.select(it) }
                         },
                         onReverseSelection = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                        )
-                                    }
-                                }
+                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
                         },
                     )
                 } else {
@@ -175,26 +161,16 @@ data class SourceSearchScreen(
                 },
                 onHelpClick = { uriHandler.openUri(Constants.URL_HELP) },
                 onLocalSourceHelpClick = { uriHandler.openUri(LocalSource.HELP_URL) },
-                onMangaClick = {
+                onMangaClick = { manga ->
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.toggleSelection(manga)
-                        } else {
-                            // KMK <--
-                            openMigrateDialog(manga)
-                        }
-                    }
-                },
-                onMangaLongClick = {
-                    // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
+                    if (bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.toggleSelection(manga)
+                    } else {
                         // KMK <--
-                        navigator.push(MangaScreen(manga.id, true))
+                        openMigrateDialog(manga)
                     }
                 },
+                onMangaLongClick = { navigator.push(MangaScreen(it.id, true)) },
                 // KMK -->
                 selection = bulkFavoriteState.selection,
                 // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -202,23 +202,12 @@ data class BrowseSourceScreen(
                             onSelectAll = {
                                 mangaList.itemSnapshotList.items
                                     .map { it.value.first }
-                                    .let {
-                                        scope.launchIO {
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                                .forEach { bulkFavoriteScreenModel.select(it) }
-                                        }
-                                    }
+                                    .forEach { bulkFavoriteScreenModel.select(it) }
                             },
                             onReverseSelection = {
                                 mangaList.itemSnapshotList.items
                                     .map { it.value.first }
-                                    .let {
-                                        scope.launchIO {
-                                            bulkFavoriteScreenModel.reverseSelection(
-                                                bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                            )
-                                        }
-                                    }
+                                    .let { bulkFavoriteScreenModel.reverseSelection(it) }
                             },
                         )
                     } else {
@@ -367,36 +356,32 @@ data class BrowseSourceScreen(
                 onWebViewClick = onWebViewClick,
                 onHelpClick = { uriHandler.openUri(Constants.URL_HELP) },
                 onLocalSourceHelpClick = onHelpClick,
-                onMangaClick = {
+                onMangaClick = { manga ->
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.toggleSelection(manga)
-                        } else {
-                            // KMK <--
-                            navigator.push(
-                                MangaScreen(
-                                    mangaId = manga.id,
-                                    // KMK -->
-                                    // Finding the entry to be merged to, so we don't want to expand description
-                                    // so that user can see the `Merge to another` button
-                                    fromSource = smartSearchConfig == null,
-                                    // KMK <--
-                                    smartSearchConfig = smartSearchConfig,
-                                ),
-                            )
-                        }
+                    if (bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.toggleSelection(manga)
+                    } else {
+                        // KMK <--
+                        navigator.push(
+                            MangaScreen(
+                                mangaId = manga.id,
+                                // KMK -->
+                                // Finding the entry to be merged to, so we don't want to expand description
+                                // so that user can see the `Merge to another` button
+                                fromSource = smartSearchConfig == null,
+                                // KMK <--
+                                smartSearchConfig = smartSearchConfig,
+                            ),
+                        )
                     }
                 },
-                onMangaLongClick = {
+                onMangaLongClick = { manga ->
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (bulkFavoriteState.selectionMode) {
-                            navigator.push(MangaScreen(manga.id, true))
-                        } else {
-                            // KMK <--
+                    if (bulkFavoriteState.selectionMode) {
+                        navigator.push(MangaScreen(manga.id, true))
+                    } else {
+                        // KMK <--
+                        scope.launchIO {
                             val duplicates = screenModel.getDuplicateLibraryManga(manga)
                             when {
                                 manga.favorite -> screenModel.setDialog(BrowseSourceScreenModel.Dialog.RemoveManga(manga))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -204,7 +204,7 @@ data class BrowseSourceScreen(
                                     .map { it.value.first }
                                     .let {
                                         scope.launchIO {
-                                            bulkFavoriteScreenModel.networkToLocalManga(it)
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                                 .forEach { bulkFavoriteScreenModel.select(it) }
                                         }
                                     }
@@ -215,7 +215,7 @@ data class BrowseSourceScreen(
                                     .let {
                                         scope.launchIO {
                                             bulkFavoriteScreenModel.reverseSelection(
-                                                bulkFavoriteScreenModel.networkToLocalManga(it),
+                                                bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                             )
                                         }
                                     }
@@ -370,7 +370,7 @@ data class BrowseSourceScreen(
                 onMangaClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga(it)
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
                         if (bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.toggleSelection(manga)
                         } else {
@@ -392,7 +392,7 @@ data class BrowseSourceScreen(
                 onMangaLongClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga(it)
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
                         if (bulkFavoriteState.selectionMode) {
                             navigator.push(MangaScreen(manga.id, true))
                         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -70,7 +70,6 @@ import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
 import tachiyomi.domain.manga.interactor.GetFlatMetadataById
 import tachiyomi.domain.manga.interactor.GetManga
-import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.model.MangaWithChapterCount
 import tachiyomi.domain.manga.model.toMangaUpdate
@@ -115,9 +114,6 @@ open class BrowseSourceScreenModel(
     private val extensionManager: ExtensionManager = Injekt.get(),
     // KMK <--
 
-    // KMK -->
-    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
-    // KMK <--
     // SY -->
     unsortedPreferences: UnsortedPreferences = Injekt.get(),
     uiPreferences: UiPreferences = Injekt.get(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
@@ -129,7 +129,7 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
                     onClickManga = {
                         // KMK -->
                         scope.launchIO {
-                            val manga = screenModel.networkToLocalManga(it)
+                            val manga = screenModel.networkToLocalManga.getLocal(it)
                             if (bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.toggleSelection(manga)
                             } else {
@@ -172,7 +172,7 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
                         },
                     onLongClickManga = {
                         scope.launchIO {
-                            val manga = screenModel.networkToLocalManga(it)
+                            val manga = screenModel.networkToLocalManga.getLocal(it)
                             if (!bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                             } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -40,7 +39,6 @@ import exh.md.follows.MangaDexFollowsScreen
 import exh.source.anyIs
 import exh.source.isEhBasedSource
 import exh.util.nullIfBlank
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.UnsortedPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.interactor.GetRemoteManga
@@ -67,7 +65,6 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
         val context = LocalContext.current
 
         // KMK -->
-        val scope = rememberCoroutineScope()
         screenModel.source.let {
             if (it is StubSource) {
                 MissingSourceScreen(
@@ -126,16 +123,13 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
                     // onClickDelete = screenModel::openDeleteFeed,
                     onLongClickFeed = screenModel::openActionsDialog,
                     // KMK <--
-                    onClickManga = {
+                    onClickManga = { manga ->
                         // KMK -->
-                        scope.launchIO {
-                            val manga = screenModel.networkToLocalManga.getLocal(it)
-                            if (bulkFavoriteState.selectionMode) {
-                                bulkFavoriteScreenModel.toggleSelection(manga)
-                            } else {
-                                // KMK <--
-                                onMangaClick(navigator, manga)
-                            }
+                        if (bulkFavoriteState.selectionMode) {
+                            bulkFavoriteScreenModel.toggleSelection(manga)
+                        } else {
+                            // KMK <--
+                            onMangaClick(navigator, manga)
                         }
                     },
                     onClickSearch = { onSearchClick(navigator, screenModel.source, it) },
@@ -170,14 +164,11 @@ class SourceFeedScreen(val sourceId: Long) : Screen() {
                                 .filterIsInstance<SourceFeedUI.SourceSavedSearch>()
                                 .isNotEmpty()
                         },
-                    onLongClickManga = {
-                        scope.launchIO {
-                            val manga = screenModel.networkToLocalManga.getLocal(it)
-                            if (!bulkFavoriteState.selectionMode) {
-                                bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                            } else {
-                                navigator.push(MangaScreen(manga.id, true))
-                            }
+                    onLongClickManga = { manga ->
+                        if (!bulkFavoriteState.selectionMode) {
+                            bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                        } else {
+                            navigator.push(MangaScreen(manga.id, true))
                         }
                     },
                     bulkFavoriteScreenModel = bulkFavoriteScreenModel,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
@@ -74,7 +74,7 @@ open class SourceFeedScreenModel(
     uiPreferences: UiPreferences = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
-    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val getFeedSavedSearchBySourceId: GetFeedSavedSearchBySourceId = Injekt.get(),
     private val getSavedSearchBySourceIdFeed: GetSavedSearchBySourceIdFeed = Injekt.get(),
     private val countFeedSavedSearchBySourceId: CountFeedSavedSearchBySourceId = Injekt.get(),
@@ -251,7 +251,7 @@ open class SourceFeedScreenModel(
                     val titles = withIOContext {
                         page.map { it.toDomainManga(source.id) }
                             .distinctBy { it.url }
-                        /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
+                            .let { networkToLocalManga(it) }
                     }
 
                     mutableState.update { state ->
@@ -285,11 +285,8 @@ open class SourceFeedScreenModel(
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
                 .collectLatest { manga ->
-                    /* KMK --> if (manga == null) return@collectLatest KMK <-- */
+                    if (manga == null) return@collectLatest
                     value = manga
-                        // KMK -->
-                        ?: initialManga
-                    // KMK <--
                 }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
@@ -71,7 +71,7 @@ class GlobalSearchScreen(
                         if (manga != null) {
                             // KMK -->
                             scope.launchIO {
-                                val localManga = screenModel.networkToLocalManga(manga)
+                                val localManga = screenModel.networkToLocalManga.getLocal(manga)
                                 // KMK <--
                                 navigator.replace(MangaScreen(localManga.id, true))
                             }
@@ -98,7 +98,7 @@ class GlobalSearchScreen(
                 onClickItem = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga(it)
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
                         if (bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.toggleSelection(manga)
                         } else {
@@ -110,7 +110,7 @@ class GlobalSearchScreen(
                 onLongClickItem = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga(it)
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
                         if (!bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalHapticFeedback
 import cafe.adriel.voyager.core.model.rememberScreenModel
@@ -20,7 +19,6 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.presentation.core.screens.LoadingScreen
 
 class GlobalSearchScreen(
@@ -49,7 +47,6 @@ class GlobalSearchScreen(
         }
 
         // KMK -->
-        val scope = rememberCoroutineScope()
         val bulkFavoriteScreenModel = rememberScreenModel { BulkFavoriteScreenModel() }
         val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
 
@@ -69,12 +66,7 @@ class GlobalSearchScreen(
                     is SearchItemResult.Success -> {
                         val manga = result.result.singleOrNull()
                         if (manga != null) {
-                            // KMK -->
-                            scope.launchIO {
-                                val localManga = screenModel.networkToLocalManga.getLocal(manga)
-                                // KMK <--
-                                navigator.replace(MangaScreen(localManga.id, true))
-                            }
+                            navigator.replace(MangaScreen(manga.id, true))
                         } else {
                             // Backoff to result screen
                             showSingleLoadingScreen = false
@@ -95,28 +87,22 @@ class GlobalSearchScreen(
                 onClickSource = {
                     navigator.push(BrowseSourceScreen(it.id, state.searchQuery))
                 },
-                onClickItem = {
+                onClickItem = { manga ->
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.toggleSelection(manga)
-                        } else {
-                            // KMK <--
-                            navigator.push(MangaScreen(manga.id, true))
-                        }
+                    if (bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.toggleSelection(manga)
+                    } else {
+                        // KMK <--
+                        navigator.push(MangaScreen(manga.id, true))
                     }
                 },
-                onLongClickItem = {
+                onLongClickItem = { manga ->
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (!bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                        } else {
-                            // KMK <--
-                            navigator.push(MangaScreen(manga.id, true))
-                        }
+                    if (!bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                    } else {
+                        // KMK <--
+                        navigator.push(MangaScreen(manga.id, true))
                     }
                 },
                 // KMK -->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -391,18 +391,8 @@ class MangaScreen(
                 }
                 showRelatedMangasScreen()
             },
-            onRelatedMangaClick = {
-                scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
-                    navigator.push(MangaScreen(manga.id, true))
-                }
-            },
-            onRelatedMangaLongClick = {
-                scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
-                    bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                }
-            },
+            onRelatedMangaClick = { navigator.push(MangaScreen(it.id, true)) },
+            onRelatedMangaLongClick = { bulkFavoriteScreenModel.addRemoveManga(it, haptic) },
             onSourceClick = {
                 if (successState.source !is StubSource) {
                     val screen = when {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -393,13 +393,13 @@ class MangaScreen(
             },
             onRelatedMangaClick = {
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga(it)
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
                     navigator.push(MangaScreen(manga.id, true))
                 }
             },
             onRelatedMangaLongClick = {
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga(it)
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
                     bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                 }
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1218,7 +1218,7 @@ class MangaScreenModel(
                         mangaList
                             .map { it.toDomainManga(state.source.id) }
                             .distinctBy { it.url }
-                            .let { networkToLocalManga(it) }
+                            .let { networkToLocalManga(it, false) }
                     }
 
                     updateSuccessState { successState ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -97,6 +97,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -202,7 +203,7 @@ class MangaScreenModel(
     private val smartSearchMerge: SmartSearchMerge = Injekt.get(),
     // KMK <--
     private val updateMergedSettings: UpdateMergedSettings = Injekt.get(),
-    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    private val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
     private val deleteMergeById: DeleteMergeById = Injekt.get(),
     private val getFlatMetadata: GetFlatMetadataById = Injekt.get(),
     private val getPagePreviews: GetPagePreviews = Injekt.get(),
@@ -740,13 +741,10 @@ class MangaScreenModel(
     fun getManga(initialManga: Manga): RuntimeState<Manga> {
         return produceState(initialValue = initialManga) {
             getManga.subscribe(initialManga.url, initialManga.source)
-                /* KMK --> .filterNotNull() KMK <-- */
+                .filterNotNull()
                 .flowWithLifecycle(lifecycle)
                 .collectLatest { manga ->
                     value = manga
-                        // KMK -->
-                        ?: initialManga
-                    // KMK <--
                 }
         }
     }
@@ -1220,7 +1218,7 @@ class MangaScreenModel(
                         mangaList
                             .map { it.toDomainManga(state.source.id) }
                             .distinctBy { it.url }
-                        /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
+                            .let { networkToLocalManga(it) }
                     }
 
                     updateSuccessState { successState ->
@@ -2073,14 +2071,14 @@ sealed interface RelatedManga {
         }
 
         internal fun List<RelatedManga>.removeDuplicates(manga: Manga): List<RelatedManga> {
-            val mangaHashes = HashSet<Int>().apply { add(manga.url.hashCode()) }
+            val mangaIds = HashSet<Long>().apply { add(manga.id) }
 
             return map { relatedManga ->
                 if (relatedManga is Success) {
                     Success(
                         relatedManga.keyword,
                         relatedManga.mangaList
-                            .filter { mangaHashes.add(it.url.hashCode()) },
+                            .filter { mangaIds.add(it.id) },
                     )
                 } else {
                     relatedManga

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
@@ -60,7 +60,7 @@ fun RelatedMangasScreen(
                                 .flatMap { it.mangaList }
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -73,7 +73,7 @@ fun RelatedMangasScreen(
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                         )
                                     }
                                 }
@@ -102,7 +102,7 @@ fun RelatedMangasScreen(
             contentPadding = paddingValues,
             onMangaClick = {
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga(it)
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
                     if (bulkFavoriteState.selectionMode) {
                         bulkFavoriteScreenModel.toggleSelection(manga)
                     } else {
@@ -112,7 +112,7 @@ fun RelatedMangasScreen(
             },
             onMangaLongClick = {
                 scope.launchIO {
-                    val manga = screenModel.networkToLocalManga(it)
+                    val manga = screenModel.networkToLocalManga.getLocal(it)
                     if (!bulkFavoriteState.selectionMode) {
                         bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                     } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/RelatedMangasScreen.kt
@@ -22,7 +22,6 @@ import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import kotlinx.coroutines.CoroutineScope
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.presentation.core.components.material.Scaffold
 import uy.kohesive.injekt.Injekt
@@ -58,25 +57,14 @@ fun RelatedMangasScreen(
                         successState.relatedMangasSorted?.let { result ->
                             result.map { it as RelatedManga.Success }
                                 .flatMap { it.mangaList }
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                            .forEach { bulkFavoriteScreenModel.select(it) }
-                                    }
-                                }
+                                .forEach { bulkFavoriteScreenModel.select(it) }
                         }
                     },
                     onReverseSelection = {
                         successState.relatedMangasSorted?.let { result ->
                             result.map { it as RelatedManga.Success }
                                 .flatMap { it.mangaList }
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                        )
-                                    }
-                                }
+                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
                         }
                     },
                 )
@@ -100,24 +88,18 @@ fun RelatedMangasScreen(
             columns = getColumnsPreference(LocalConfiguration.current.orientation),
             displayMode = displayMode,
             contentPadding = paddingValues,
-            onMangaClick = {
-                scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
-                    if (bulkFavoriteState.selectionMode) {
-                        bulkFavoriteScreenModel.toggleSelection(manga)
-                    } else {
-                        navigator.push(MangaScreen(manga.id, true))
-                    }
+            onMangaClick = { manga ->
+                if (bulkFavoriteState.selectionMode) {
+                    bulkFavoriteScreenModel.toggleSelection(manga)
+                } else {
+                    navigator.push(MangaScreen(manga.id, true))
                 }
             },
-            onMangaLongClick = {
-                scope.launchIO {
-                    val manga = screenModel.networkToLocalManga.getLocal(it)
-                    if (!bulkFavoriteState.selectionMode) {
-                        bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                    } else {
-                        navigator.push(MangaScreen(manga.id, true))
-                    }
+            onMangaLongClick = { manga ->
+                if (!bulkFavoriteState.selectionMode) {
+                    bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
+                } else {
+                    navigator.push(MangaScreen(manga.id, true))
                 }
             },
             onKeywordClick = { query ->

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -77,23 +77,12 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                         onSelectAll = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                            .forEach { bulkFavoriteScreenModel.select(it) }
-                                    }
-                                }
+                                .forEach { bulkFavoriteScreenModel.select(it) }
                         },
                         onReverseSelection = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                        )
-                                    }
-                                }
+                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
                         },
                     )
                 } else {
@@ -128,26 +117,22 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                 onWebViewClick = null,
                 onHelpClick = null,
                 onLocalSourceHelpClick = null,
-                onMangaClick = {
+                onMangaClick = { manga ->
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (bulkFavoriteState.selectionMode) {
-                            bulkFavoriteScreenModel.toggleSelection(manga)
-                        } else {
-                            // KMK <--
-                            navigator.push(MangaScreen(manga.id, true))
-                        }
+                    if (bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.toggleSelection(manga)
+                    } else {
+                        // KMK <--
+                        navigator.push(MangaScreen(manga.id, true))
                     }
                 },
-                onMangaLongClick = {
+                onMangaLongClick = { manga ->
                     // KMK -->
-                    scope.launchIO {
-                        val manga = screenModel.networkToLocalManga.getLocal(it)
-                        if (bulkFavoriteState.selectionMode) {
-                            navigator.push(MangaScreen(manga.id, true))
-                        } else {
-                            // KMK <--
+                    if (bulkFavoriteState.selectionMode) {
+                        navigator.push(MangaScreen(manga.id, true))
+                    } else {
+                        // KMK <--
+                        scope.launchIO {
                             val duplicates = screenModel.getDuplicateLibraryManga(manga)
                             when {
                                 manga.favorite -> screenModel.setDialog(BrowseSourceScreenModel.Dialog.RemoveManga(manga))

--- a/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
+++ b/app/src/main/java/exh/md/follows/MangaDexFollowsScreen.kt
@@ -79,7 +79,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                                 .map { it.value.first }
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -90,7 +90,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                         )
                                     }
                                 }
@@ -131,7 +131,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                 onMangaClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga(it)
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
                         if (bulkFavoriteState.selectionMode) {
                             bulkFavoriteScreenModel.toggleSelection(manga)
                         } else {
@@ -143,7 +143,7 @@ class MangaDexFollowsScreen(private val sourceId: Long) : Screen() {
                 onMangaLongClick = {
                     // KMK -->
                     scope.launchIO {
-                        val manga = screenModel.networkToLocalManga(it)
+                        val manga = screenModel.networkToLocalManga.getLocal(it)
                         if (bulkFavoriteState.selectionMode) {
                             navigator.push(MangaScreen(manga.id, true))
                         } else {

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -99,7 +99,7 @@ class BrowseRecommendsScreen(
                                 .map { it.value.first }
                                 .let {
                                     scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga(it)
+                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
                                             .forEach { bulkFavoriteScreenModel.select(it) }
                                     }
                                 }
@@ -110,7 +110,7 @@ class BrowseRecommendsScreen(
                                 .let {
                                     scope.launchIO {
                                         bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga(it),
+                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
                                         )
                                     }
                                 }
@@ -159,7 +159,7 @@ class BrowseRecommendsScreen(
                         onClickItem(it)
                     } else {
                         scope.launchIO {
-                            val manga = screenModel.networkToLocalManga(it)
+                            val manga = screenModel.networkToLocalManga.getLocal(it)
                             if (bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.toggleSelection(manga)
                             } else {
@@ -175,7 +175,7 @@ class BrowseRecommendsScreen(
                         onLongClickItem(it)
                     } else {
                         scope.launchIO {
-                            val manga = screenModel.networkToLocalManga(it)
+                            val manga = screenModel.networkToLocalManga.getLocal(it)
                             if (!bulkFavoriteState.selectionMode) {
                                 bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                             } else {

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -25,7 +24,6 @@ import eu.kanade.tachiyomi.ui.browse.source.SourcesScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import mihon.presentation.core.util.collectAsLazyPagingItems
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.screens.LoadingScreen
@@ -52,7 +50,6 @@ class BrowseRecommendsScreen(
         }
 
         // KMK -->
-        val scope = rememberCoroutineScope()
         val bulkFavoriteScreenModel = rememberScreenModel { BulkFavoriteScreenModel() }
         val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
 
@@ -97,23 +94,12 @@ class BrowseRecommendsScreen(
                         onSelectAll = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.networkToLocalManga.getLocal(it)
-                                            .forEach { bulkFavoriteScreenModel.select(it) }
-                                    }
-                                }
+                                .forEach { bulkFavoriteScreenModel.select(it) }
                         },
                         onReverseSelection = {
                             mangaList.itemSnapshotList.items
                                 .map { it.value.first }
-                                .let {
-                                    scope.launchIO {
-                                        bulkFavoriteScreenModel.reverseSelection(
-                                            bulkFavoriteScreenModel.networkToLocalManga.getLocal(it),
-                                        )
-                                    }
-                                }
+                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
                         },
                     )
                 } else {
@@ -153,37 +139,23 @@ class BrowseRecommendsScreen(
                 onWebViewClick = null,
                 onHelpClick = null,
                 onLocalSourceHelpClick = null,
-                onMangaClick = {
+                onMangaClick = { manga ->
                     // KMK -->
-                    if (isExternalSource) {
-                        onClickItem(it)
+                    if (bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.toggleSelection(manga)
                     } else {
-                        scope.launchIO {
-                            val manga = screenModel.networkToLocalManga.getLocal(it)
-                            if (bulkFavoriteState.selectionMode) {
-                                bulkFavoriteScreenModel.toggleSelection(manga)
-                            } else {
-                                // KMK <--
-                                onClickItem(manga)
-                            }
-                        }
+                        // KMK <--
+                        onClickItem(manga)
                     }
                 },
-                onMangaLongClick = {
+                onMangaLongClick = { manga ->
                     // KMK -->
-                    if (isExternalSource) {
-                        onLongClickItem(it)
+                    if (!bulkFavoriteState.selectionMode) {
+                        bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                     } else {
-                        scope.launchIO {
-                            val manga = screenModel.networkToLocalManga.getLocal(it)
-                            if (!bulkFavoriteState.selectionMode) {
-                                bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
-                            } else {
-                                onLongClickItem(manga)
-                            }
-                        }
-                        // KMK <--
+                        onLongClickItem(manga)
                     }
+                    // KMK <--
                 },
                 // KMK -->
                 selection = bulkFavoriteState.selection,

--- a/app/src/main/java/exh/recs/RecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreen.kt
@@ -59,7 +59,7 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
                 else -> {
                     // KMK -->
                     scope.launchIO {
-                        val localManga = screenModel.networkToLocalManga(manga)
+                        val localManga = screenModel.networkToLocalManga.getLocal(manga)
                         navigator.push(
                             // KMK <--
                             MangaScreen(localManga.id, true),
@@ -75,7 +75,7 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
                 else -> {
                     // KMK -->
                     scope.launchIO {
-                        val localManga = screenModel.networkToLocalManga(manga)
+                        val localManga = screenModel.networkToLocalManga.getLocal(manga)
                         bulkFavoriteScreenModel.addRemoveManga(
                             localManga,
                             haptic,

--- a/app/src/main/java/exh/recs/RecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import cafe.adriel.voyager.core.model.rememberScreenModel
@@ -18,7 +17,6 @@ import eu.kanade.tachiyomi.ui.browse.source.SourcesScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import exh.recs.components.RecommendsScreen
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.presentation.core.screens.LoadingScreen
 
@@ -40,7 +38,6 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
         val state by screenModel.state.collectAsState()
 
         // KMK -->
-        val scope = rememberCoroutineScope()
         val bulkFavoriteScreenModel = rememberScreenModel { BulkFavoriteScreenModel() }
         val bulkFavoriteState by bulkFavoriteScreenModel.state.collectAsState()
 
@@ -52,21 +49,12 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
         // KMK <--
 
         val onClickItem = { manga: Manga ->
-            when (manga.source) {
-                RECOMMENDS_SOURCE -> navigator.push(
-                    SourcesScreen(SourcesScreen.SmartSearchConfig(manga.ogTitle)),
-                )
-                else -> {
-                    // KMK -->
-                    scope.launchIO {
-                        val localManga = screenModel.networkToLocalManga.getLocal(manga)
-                        navigator.push(
-                            // KMK <--
-                            MangaScreen(localManga.id, true),
-                        )
-                    }
-                }
-            }
+            navigator.push(
+                when (manga.source) {
+                    RECOMMENDS_SOURCE -> SourcesScreen(SourcesScreen.SmartSearchConfig(manga.ogTitle))
+                    else -> MangaScreen(manga.id, true)
+                },
+            )
         }
 
         val onLongClickItem = { manga: Manga ->
@@ -74,13 +62,11 @@ class RecommendsScreen(val mangaId: Long, val sourceId: Long) : Screen() {
                 RECOMMENDS_SOURCE -> WebViewActivity.newIntent(context, manga.url, title = manga.title).let(context::startActivity)
                 else -> {
                     // KMK -->
-                    scope.launchIO {
-                        val localManga = screenModel.networkToLocalManga.getLocal(manga)
-                        bulkFavoriteScreenModel.addRemoveManga(
-                            localManga,
-                            haptic,
-                        )
-                    }
+                    // Add to favorite
+                    bulkFavoriteScreenModel.addRemoveManga(
+                        manga,
+                        haptic,
+                    )
                     // KMK <--
                 }
             }

--- a/app/src/main/java/exh/recs/RecommendsScreenModel.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreenModel.kt
@@ -32,7 +32,7 @@ open class RecommendsScreenModel(
     val mangaId: Long,
     val sourceId: Long,
     private val getManga: GetManga = Injekt.get(),
-    val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
+    protected val networkToLocalManga: NetworkToLocalManga = Injekt.get(),
 ) : StateScreenModel<RecommendsScreenModel.State>(State()) {
 
     // KMK -->
@@ -78,14 +78,14 @@ open class RecommendsScreenModel(
                         }
 
                         val recSourceId = recSource.associatedSourceId
-                        // KMK -->
-                        val titles = page.mangas.map {
+                        val titles = if (recSourceId != null) {
                             // If the recommendation is associated with a source, resolve it
+                            page.mangas.map { it.toDomainManga(recSourceId) }
+                                .let { networkToLocalManga(it) }
+                        } else {
                             // Otherwise, skip this step. The user will be prompted to choose a source via SmartSearch
-                            it.toDomainManga(recSourceId ?: RECOMMENDS_SOURCE)
+                            page.mangas.map { it.toDomainManga(RECOMMENDS_SOURCE) }
                         }
-                            /* KMK --> .let { networkToLocalManga(it) } KMK <-- */
-                            // KMK <--
                             .distinctBy { it.url }
 
                         if (isActive) {

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -118,7 +118,7 @@ class MangaRepositoryImpl(
         }
     }
 
-    override suspend fun insertNetworkManga(manga: List<Manga>): List<Manga> {
+    override suspend fun insertNetworkManga(manga: List<Manga>, updateInfo: Boolean): List<Manga> {
         return handler.await(inTransaction = true) {
             manga.map {
                 mangasQueries.insertNetworkManga(
@@ -149,6 +149,9 @@ class MangaRepositoryImpl(
                     updateCover = !it.ogThumbnailUrl.isNullOrBlank(),
                     // SY <--
                     updateDetails = it.initialized,
+                    // KMK -->
+                    updateInfo = updateInfo,
+                    // KMK <--
                     mapper = MangaMapper::mapManga,
                 )
                     .executeAsOne()

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -149,11 +149,8 @@ class MangaRepositoryImpl(
                     updateCover = !it.ogThumbnailUrl.isNullOrBlank(),
                     // SY <--
                     updateDetails = it.initialized,
-                    // KMK -->
-                    // mapper = MangaMapper::mapManga,
+                    mapper = MangaMapper::mapManga,
                 )
-                mangasQueries.getMangaByUrlAndSource(it.url, it.source, MangaMapper::mapManga)
-                    // KMK <--
                     .executeAsOne()
             }
         }

--- a/data/src/main/java/tachiyomi/data/source/EHentaiPagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/EHentaiPagingSource.kt
@@ -23,8 +23,8 @@ abstract class EHentaiPagingSource(
         val manga = mangasPage.mangas
             .mapIndexed { index, sManga -> sManga.toDomainManga(source.id) to metadata.getOrNull(index) }
             .filter { seenManga.add(it.first.url) }
-        // KMK -->
-        // .let { pairs -> pairs.zip(networkToLocalManga(pairs.map { it.first })).map { it.second to it.first.second } }
+            // KMK -->
+            .let { pairs -> networkToLocalManga(pairs.map { it.first }).zip(pairs.map { it.second }) }
         // KMK <--
 
         return LoadResult.Page(

--- a/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourcePagingSource.kt
@@ -94,8 +94,8 @@ abstract class BaseSourcePagingSource(
             // SY -->
             .mapIndexed { index, sManga -> sManga.toDomainManga(source!!.id) to metadata.getOrNull(index) }
             .filter { seenManga.add(it.first.url) }
-        // KMK -->
-        // .let { pairs -> pairs.zip(networkToLocalManga(pairs.map { it.first })).map { it.second to it.first.second } }
+            // KMK -->
+            .let { pairs -> networkToLocalManga(pairs.map { it.first }).zip(pairs.map { it.second }) }
         // KMK <--
         // SY <--
 

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -246,13 +246,12 @@ insertNetworkManga {
     AND url = :url
     AND favorite = 0;
 
--- KMK : Disabled the following SELECT as it will cause `getMangaByUrlAndSource` flow not triggered
---     -- Finally return the manga
---     SELECT *
---     FROM mangas
---     WHERE source = :source
---     AND url = :url
---     LIMIT 1;
+    -- Finally return the manga
+    SELECT *
+    FROM mangas
+    WHERE source = :source
+    AND url = :url
+    LIMIT 1;
 }
 
 getEhMangaWithMetadata:

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -242,7 +242,7 @@ insertNetworkManga {
         status = CASE WHEN :updateDetails THEN :status ELSE status END,
         update_strategy = CASE WHEN :updateDetails THEN :updateStrategy ELSE update_strategy END,
         initialized = :updateDetails
-    WHERE source = :source
+    WHERE source = :source AND :updateInfo
     AND url = :url
     AND favorite = 0;
 

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
@@ -7,11 +7,11 @@ class NetworkToLocalManga(
     private val mangaRepository: MangaRepository,
 ) {
 
-    suspend operator fun invoke(manga: Manga): Manga {
-        return invoke(listOf(manga)).single()
+    suspend operator fun invoke(manga: Manga, updateInfo: Boolean = true): Manga {
+        return invoke(listOf(manga), updateInfo).single()
     }
 
-    suspend operator fun invoke(manga: List<Manga>): List<Manga> {
-        return mangaRepository.insertNetworkManga(manga)
+    suspend operator fun invoke(manga: List<Manga>, updateInfo: Boolean = true): List<Manga> {
+        return mangaRepository.insertNetworkManga(manga, updateInfo)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
@@ -14,22 +14,4 @@ class NetworkToLocalManga(
     suspend operator fun invoke(manga: List<Manga>): List<Manga> {
         return mangaRepository.insertNetworkManga(manga)
     }
-
-    // KMK -->
-    suspend fun getLocal(manga: Manga): Manga = if (manga.id <= 0) {
-        invoke(manga)
-    } else {
-        manga
-    }
-
-    suspend fun getLocal(mangas: List<Manga>): List<Manga> {
-        return mangas.map { manga ->
-            if (manga.id <= 0) {
-                invoke(manga)
-            } else {
-                manga
-            }
-        }
-    }
-    // KMK <--
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/NetworkToLocalManga.kt
@@ -8,10 +8,28 @@ class NetworkToLocalManga(
 ) {
 
     suspend operator fun invoke(manga: Manga): Manga {
-        return if (manga.id <= 0) invoke(listOf(manga)).single() else manga
+        return invoke(listOf(manga)).single()
     }
 
     suspend operator fun invoke(manga: List<Manga>): List<Manga> {
         return mangaRepository.insertNetworkManga(manga)
     }
+
+    // KMK -->
+    suspend fun getLocal(manga: Manga): Manga = if (manga.id <= 0) {
+        invoke(manga)
+    } else {
+        manga
+    }
+
+    suspend fun getLocal(mangas: List<Manga>): List<Manga> {
+        return mangas.map { manga ->
+            if (manga.id <= 0) {
+                invoke(manga)
+            } else {
+                manga
+            }
+        }
+    }
+    // KMK <--
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -38,7 +38,7 @@ interface MangaRepository {
 
     suspend fun updateAll(mangaUpdates: List<MangaUpdate>): Boolean
 
-    suspend fun insertNetworkManga(manga: List<Manga>): List<Manga>
+    suspend fun insertNetworkManga(manga: List<Manga>, updateInfo: Boolean = true): List<Manga>
 
     // SY -->
     suspend fun getMangaBySourceId(sourceId: Long): List<Manga>


### PR DESCRIPTION
Revert previous commits that modified bulk selection behavior, network-to-local mapping, and in-memory fast browsing.

Introduce an `updateInfo` parameter to the `insertNetworkManga` method to fix the issue that manga info is overwritten when adding to favorite caused by relatedMangas.

## Summary by Sourcery

Revert previous custom in-memory fast browsing and bulk-selection mappings in UI screens, simplify selection and click handlers to operate directly on domain Manga objects, and add an `updateInfo` flag to the `insertNetworkManga` pipeline to prevent overwriting existing manga information when adding to favorites.

Bug Fixes:
- Introduce an `updateInfo` parameter to `insertNetworkManga` (and propagate it through repository, interactor, and data layers) to avoid overwriting existing manga metadata when favorites are added.

Enhancements:
- Remove coroutine-based `networkToLocalManga` calls and `rememberCoroutineScope` imports across multiple browse, search, feed, and manga screens to restore direct use of domain Manga objects in selection and navigation.
- Simplify related-manga grids and lists by using stable manga IDs for item keys instead of URL hash codes.

Chores:
- Remove `NetworkToLocalManga` injection from `BulkFavoriteScreenModel` and related screen models and revert bulk-selection behavior to previous in-memory approach.
- Update domain interactor `NetworkToLocalManga` and repository interface/method signature to accept the new `updateInfo` flag.