### PR TITLE
feat(ui): Improve migration bottom sheet layout with scrollable content

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -5,7 +5,6 @@ import android.widget.CompoundButton
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import android.widget.Toast
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
@@ -54,48 +53,54 @@ fun MigrationBottomSheetDialog(
     // KMK <--
 
     AdaptiveSheet(onDismissRequest = onDismissRequest) {
-        Box(modifier = Modifier.fillMaxWidth()) {
-            // Wrap AndroidView in a scrollable Column using verticalScroll
-            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                AndroidView(
-                    factory = { factoryContext ->
-                        val binding = MigrationBottomSheetBinding.inflate(LayoutInflater.from(factoryContext))
-                        state.initPreferences(binding)
-                        // KMK -->
-                        binding.migrateBtn.setBackgroundColor(colorScheme.primary)
-                        binding.dataLabel.setTextColor(colorScheme.primary)
-                        binding.optionsLabel.setTextColor(colorScheme.primary)
+        // Wrap AndroidView in a scrollable Column using verticalScroll
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .fillMaxWidth(),
+        ) {
+            AndroidView(
+                factory = { factoryContext ->
+                    val binding = MigrationBottomSheetBinding.inflate(LayoutInflater.from(factoryContext))
+                    state.initPreferences(binding)
+                    // KMK -->
+                    with(binding) {
+                        migrateBtn.setBackgroundColor(colorScheme.primary)
+                        dataLabel.setTextColor(colorScheme.primary)
+                        optionsLabel.setTextColor(colorScheme.primary)
 
-                        binding.migChapters.buttonTintList = colorScheme.checkboxTintList
-                        binding.migCategories.buttonTintList = colorScheme.checkboxTintList
-                        binding.migTracking.buttonTintList = colorScheme.checkboxTintList
-                        binding.migCustomCover.buttonTintList = colorScheme.checkboxTintList
-                        binding.migExtra.buttonTintList = colorScheme.checkboxTintList
-                        binding.migDeleteDownloaded.buttonTintList = colorScheme.checkboxTintList
+                        listOf(
+                            migChapters,
+                            migCategories,
+                            migTracking,
+                            migCustomCover,
+                            migExtra,
+                            migDeleteDownloaded,
+                            radioButton,
+                            radioButton2,
+                        ).forEach {
+                            it.buttonTintList = colorScheme.checkboxTintList
+                        }
 
-                        binding.radioButton.buttonTintList = colorScheme.checkboxTintList
-                        binding.radioButton2.buttonTintList = colorScheme.checkboxTintList
+                        listOf(
+                            useSmartSearch,
+                            extraSearchParam,
+                            skipStep,
+                            hideNotFoundManga,
+                            onlyShowUpdates,
+                        ).forEach {
+                            it.trackTintList = colorScheme.trackTintList
+                            it.thumbTintList = colorScheme.thumbTintList
+                        }
 
-                        binding.useSmartSearch.trackTintList = colorScheme.trackTintList
-                        binding.extraSearchParam.trackTintList = colorScheme.trackTintList
-                        binding.skipStep.trackTintList = colorScheme.trackTintList
-                        binding.HideNotFoundManga.trackTintList = colorScheme.trackTintList
-                        binding.OnlyShowUpdates.trackTintList = colorScheme.trackTintList
-
-                        binding.useSmartSearch.thumbTintList = colorScheme.thumbTintList
-                        binding.extraSearchParam.thumbTintList = colorScheme.thumbTintList
-                        binding.skipStep.thumbTintList = colorScheme.thumbTintList
-                        binding.HideNotFoundManga.thumbTintList = colorScheme.thumbTintList
-                        binding.OnlyShowUpdates.thumbTintList = colorScheme.thumbTintList
-
-                        colorScheme.setTextInputLayoutColor(binding.extraSearchParamInputLayout)
-                        colorScheme.setEditTextColor(binding.extraSearchParamText)
-                        // KMK <--
-                        binding.root
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
+                        colorScheme.setTextInputLayoutColor(extraSearchParamInputLayout)
+                        colorScheme.setEditTextColor(extraSearchParamText)
+                    }
+                    // KMK <--
+                    binding.root
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }
@@ -114,72 +119,77 @@ class MigrationBottomSheetDialogState(
     fun initPreferences(binding: MigrationBottomSheetBinding) {
         val flags = preferences.migrateFlags().get()
 
-        binding.migChapters.isChecked = MigrationFlags.hasChapters(flags)
-        binding.migCategories.isChecked = MigrationFlags.hasCategories(flags)
-        binding.migTracking.isChecked = MigrationFlags.hasTracks(flags)
-        binding.migCustomCover.isChecked = MigrationFlags.hasCustomCover(flags)
-        binding.migExtra.isChecked = MigrationFlags.hasExtra(flags)
-        binding.migDeleteDownloaded.isChecked = MigrationFlags.hasDeleteDownloaded(flags)
+        with(binding) {
+            migChapters.isChecked = MigrationFlags.hasChapters(flags)
+            migCategories.isChecked = MigrationFlags.hasCategories(flags)
+            migTracking.isChecked = MigrationFlags.hasTracks(flags)
+            migCustomCover.isChecked = MigrationFlags.hasCustomCover(flags)
+            migExtra.isChecked = MigrationFlags.hasExtra(flags)
+            migDeleteDownloaded.isChecked = MigrationFlags.hasDeleteDownloaded(flags)
 
-        binding.migChapters.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-        binding.migCategories.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-        binding.migTracking.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-        binding.migCustomCover.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-        binding.migExtra.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-        binding.migDeleteDownloaded.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
+            migChapters.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
+            migCategories.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
+            migTracking.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
+            migCustomCover.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
+            migExtra.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
+            migDeleteDownloaded.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
 
-        binding.useSmartSearch.bindToPreference(preferences.smartMigration())
-        binding.extraSearchParamInputLayout.isVisible = false
-        binding.extraSearchParam.setOnCheckedChangeListener { _, isChecked ->
-            binding.extraSearchParamInputLayout.isVisible = isChecked
-        }
-        binding.sourceGroup.bindToPreference(preferences.useSourceWithMost())
+            useSmartSearch.bindToPreference(preferences.smartMigration())
+            extraSearchParamInputLayout.isVisible = false
+            extraSearchParam.setOnCheckedChangeListener { _, isChecked ->
+                extraSearchParamInputLayout.isVisible = isChecked
+            }
+            sourceGroup.bindToPreference(preferences.useSourceWithMost())
 
-        binding.skipStep.isChecked = preferences.skipPreMigration().get()
-        binding.HideNotFoundManga.isChecked = preferences.hideNotFoundMigration().get()
-        binding.OnlyShowUpdates.isChecked = preferences.showOnlyUpdatesMigration().get()
-        binding.skipStep.setOnCheckedChangeListener { _, isChecked ->
-            if (isChecked) {
-                binding.root.context.toast(
-                    SYMR.strings.pre_migration_skip_toast,
-                    Toast.LENGTH_LONG,
+            skipStep.isChecked = preferences.skipPreMigration().get()
+            hideNotFoundManga.isChecked = preferences.hideNotFoundMigration().get()
+            onlyShowUpdates.isChecked = preferences.showOnlyUpdatesMigration().get()
+            skipStep.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    root.context.toast(
+                        SYMR.strings.pre_migration_skip_toast,
+                        Toast.LENGTH_LONG,
+                    )
+                }
+            }
+
+            migrateBtn.setOnClickListener {
+                preferences.skipPreMigration().set(skipStep.isChecked)
+                preferences.hideNotFoundMigration().set(hideNotFoundManga.isChecked)
+                preferences.showOnlyUpdatesMigration().set(onlyShowUpdates.isChecked)
+                onStartMigration.value(
+                    if (useSmartSearch.isChecked && !extraSearchParamText.text.isNullOrBlank()) {
+                        extraSearchParamText.text.toString()
+                    } else {
+                        null
+                    },
                 )
             }
-        }
 
-        binding.migrateBtn.setOnClickListener {
-            preferences.skipPreMigration().set(binding.skipStep.isChecked)
-            preferences.hideNotFoundMigration().set(binding.HideNotFoundManga.isChecked)
-            preferences.showOnlyUpdatesMigration().set(binding.OnlyShowUpdates.isChecked)
-            onStartMigration.value(
-                if (binding.useSmartSearch.isChecked && !binding.extraSearchParamText.text.isNullOrBlank()) {
-                    binding.extraSearchParamText.text.toString()
-                } else {
-                    null
-                },
-            )
+            // KMK -->
+            if (!fullSettings) {
+                useSmartSearch.isVisible = false
+                extraSearchParam.isVisible = false
+                extraSearchParamInputLayout.isVisible = false
+                sourceGroup.isVisible = false
+                skipStep.isVisible = false
+                migrateBtn.text = root.context.stringResource(MR.strings.action_save)
+            }
+            // KMK <--
         }
-
-        // KMK -->
-        if (!fullSettings) {
-            binding.useSmartSearch.isVisible = false
-            binding.extraSearchParam.isVisible = false
-            binding.extraSearchParamInputLayout.isVisible = false
-            binding.sourceGroup.isVisible = false
-            binding.skipStep.isVisible = false
-            binding.migrateBtn.text = binding.root.context.stringResource(MR.strings.action_save)
-        }
-        // KMK <--
     }
 
     private fun setFlags(binding: MigrationBottomSheetBinding) {
         var flags = 0
-        if (binding.migChapters.isChecked) flags = flags or MigrationFlags.CHAPTERS
-        if (binding.migCategories.isChecked) flags = flags or MigrationFlags.CATEGORIES
-        if (binding.migTracking.isChecked) flags = flags or MigrationFlags.TRACK
-        if (binding.migCustomCover.isChecked) flags = flags or MigrationFlags.CUSTOM_COVER
-        if (binding.migExtra.isChecked) flags = flags or MigrationFlags.EXTRA
-        if (binding.migDeleteDownloaded.isChecked) flags = flags or MigrationFlags.DELETE_DOWNLOADED
+        with(binding) {
+            @Suppress("KotlinConstantConditions")
+            if (migChapters.isChecked) flags = flags or MigrationFlags.CHAPTERS
+            if (migCategories.isChecked) flags = flags or MigrationFlags.CATEGORIES
+            if (migTracking.isChecked) flags = flags or MigrationFlags.TRACK
+            if (migCustomCover.isChecked) flags = flags or MigrationFlags.CUSTOM_COVER
+            if (migExtra.isChecked) flags = flags or MigrationFlags.EXTRA
+            if (migDeleteDownloaded.isChecked) flags = flags or MigrationFlags.DELETE_DOWNLOADED
+        }
         preferences.migrateFlags().set(flags)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -5,7 +5,11 @@ import android.widget.CompoundButton
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import android.widget.Toast
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -50,44 +54,49 @@ fun MigrationBottomSheetDialog(
     // KMK <--
 
     AdaptiveSheet(onDismissRequest = onDismissRequest) {
-        AndroidView(
-            factory = { factoryContext ->
-                val binding = MigrationBottomSheetBinding.inflate(LayoutInflater.from(factoryContext))
-                state.initPreferences(binding)
-                // KMK -->
-                binding.migrateBtn.setBackgroundColor(colorScheme.primary)
-                binding.dataLabel.setTextColor(colorScheme.primary)
-                binding.optionsLabel.setTextColor(colorScheme.primary)
+        Box(modifier = Modifier.fillMaxWidth()) {
+            // Wrap AndroidView in a scrollable Column using verticalScroll
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                AndroidView(
+                    factory = { factoryContext ->
+                        val binding = MigrationBottomSheetBinding.inflate(LayoutInflater.from(factoryContext))
+                        state.initPreferences(binding)
+                        // KMK -->
+                        binding.migrateBtn.setBackgroundColor(colorScheme.primary)
+                        binding.dataLabel.setTextColor(colorScheme.primary)
+                        binding.optionsLabel.setTextColor(colorScheme.primary)
 
-                binding.migChapters.buttonTintList = colorScheme.checkboxTintList
-                binding.migCategories.buttonTintList = colorScheme.checkboxTintList
-                binding.migTracking.buttonTintList = colorScheme.checkboxTintList
-                binding.migCustomCover.buttonTintList = colorScheme.checkboxTintList
-                binding.migExtra.buttonTintList = colorScheme.checkboxTintList
-                binding.migDeleteDownloaded.buttonTintList = colorScheme.checkboxTintList
+                        binding.migChapters.buttonTintList = colorScheme.checkboxTintList
+                        binding.migCategories.buttonTintList = colorScheme.checkboxTintList
+                        binding.migTracking.buttonTintList = colorScheme.checkboxTintList
+                        binding.migCustomCover.buttonTintList = colorScheme.checkboxTintList
+                        binding.migExtra.buttonTintList = colorScheme.checkboxTintList
+                        binding.migDeleteDownloaded.buttonTintList = colorScheme.checkboxTintList
 
-                binding.radioButton.buttonTintList = colorScheme.checkboxTintList
-                binding.radioButton2.buttonTintList = colorScheme.checkboxTintList
+                        binding.radioButton.buttonTintList = colorScheme.checkboxTintList
+                        binding.radioButton2.buttonTintList = colorScheme.checkboxTintList
 
-                binding.useSmartSearch.trackTintList = colorScheme.trackTintList
-                binding.extraSearchParam.trackTintList = colorScheme.trackTintList
-                binding.skipStep.trackTintList = colorScheme.trackTintList
-                binding.HideNotFoundManga.trackTintList = colorScheme.trackTintList
-                binding.OnlyShowUpdates.trackTintList = colorScheme.trackTintList
+                        binding.useSmartSearch.trackTintList = colorScheme.trackTintList
+                        binding.extraSearchParam.trackTintList = colorScheme.trackTintList
+                        binding.skipStep.trackTintList = colorScheme.trackTintList
+                        binding.HideNotFoundManga.trackTintList = colorScheme.trackTintList
+                        binding.OnlyShowUpdates.trackTintList = colorScheme.trackTintList
 
-                binding.useSmartSearch.thumbTintList = colorScheme.thumbTintList
-                binding.extraSearchParam.thumbTintList = colorScheme.thumbTintList
-                binding.skipStep.thumbTintList = colorScheme.thumbTintList
-                binding.HideNotFoundManga.thumbTintList = colorScheme.thumbTintList
-                binding.OnlyShowUpdates.thumbTintList = colorScheme.thumbTintList
+                        binding.useSmartSearch.thumbTintList = colorScheme.thumbTintList
+                        binding.extraSearchParam.thumbTintList = colorScheme.thumbTintList
+                        binding.skipStep.thumbTintList = colorScheme.thumbTintList
+                        binding.HideNotFoundManga.thumbTintList = colorScheme.thumbTintList
+                        binding.OnlyShowUpdates.thumbTintList = colorScheme.thumbTintList
 
-                colorScheme.setTextInputLayoutColor(binding.extraSearchParamInputLayout)
-                colorScheme.setEditTextColor(binding.extraSearchParamText)
-                // KMK <--
-                binding.root
-            },
-            modifier = Modifier.fillMaxWidth(),
-        )
+                        colorScheme.setTextInputLayoutColor(binding.extraSearchParamInputLayout)
+                        colorScheme.setEditTextColor(binding.extraSearchParamText)
+                        // KMK <--
+                        binding.root
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -99,7 +99,6 @@ fun MigrationBottomSheetDialog(
                     // KMK <--
                     binding.root
                 },
-                modifier = Modifier.fillMaxWidth(),
             )
         }
     }
@@ -127,12 +126,16 @@ class MigrationBottomSheetDialogState(
             migExtra.isChecked = MigrationFlags.hasExtra(flags)
             migDeleteDownloaded.isChecked = MigrationFlags.hasDeleteDownloaded(flags)
 
-            migChapters.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-            migCategories.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-            migTracking.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-            migCustomCover.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-            migExtra.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
-            migDeleteDownloaded.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
+            listOf(
+                migChapters,
+                migCategories,
+                migTracking,
+                migCustomCover,
+                migExtra,
+                migDeleteDownloaded,
+            ).forEach { checkBox ->
+                checkBox.setOnCheckedChangeListener { _, _ -> setFlags(binding) }
+            }
 
             useSmartSearch.bindToPreference(preferences.smartMigration())
             extraSearchParamInputLayout.isVisible = false

--- a/app/src/main/res/layout/migration_bottom_sheet.xml
+++ b/app/src/main/res/layout/migration_bottom_sheet.xml
@@ -3,231 +3,220 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/constraintLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:clipToPadding="false"
     android:paddingVertical="8dp"
     android:orientation="vertical">
 
+    <TextView
+        android:id="@+id/data_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:layout_marginStart="16dp"
+        android:text="@string/data_to_include_in_migration"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textColor="?attr/colorPrimary"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/constraintLayout2"
+        android:id="@+id/migration_data_group"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@android:color/transparent"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:paddingHorizontal="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0">
+        app:layout_constraintTop_toBottomOf="@+id/data_label">
 
-        <TextView
-            android:id="@+id/data_label"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.helper.widget.Flow
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:paddingTop="8dp"
-            android:layout_marginStart="8dp"
-            android:text="@string/data_to_include_in_migration"
-            android:textAppearance="?attr/textAppearanceTitleMedium"
-            android:textColor="?attr/colorPrimary"
+            android:orientation="horizontal"
+            app:constraint_referenced_ids="mig_chapters,mig_categories,mig_tracking,mig_custom_cover,mig_extra,mig_delete_downloaded"
+            app:flow_horizontalBias="0"
+            app:flow_horizontalGap="8dp"
+            app:flow_horizontalStyle="packed"
+            app:flow_verticalGap="2dp"
+            app:flow_wrapMode="chain"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/migration_data_group"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/data_label">
-
-            <androidx.constraintlayout.helper.widget.Flow
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                app:constraint_referenced_ids="mig_chapters,mig_categories,mig_tracking,mig_custom_cover,mig_extra,mig_delete_downloaded"
-                app:flow_horizontalBias="0"
-                app:flow_horizontalGap="8dp"
-                app:flow_horizontalStyle="packed"
-                app:flow_verticalGap="2dp"
-                app:flow_wrapMode="chain"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <CheckBox
-                android:id="@+id/mig_chapters"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="@string/chapters" />
-
-            <CheckBox
-                android:id="@+id/mig_categories"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="@string/categories" />
-
-            <CheckBox
-                android:id="@+id/mig_tracking"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="@string/track" />
-
-            <CheckBox
-                android:id="@+id/mig_custom_cover"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="@string/custom_cover" />
-
-            <CheckBox
-                android:id="@+id/mig_extra"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="@string/log_extra" />
-
-            <CheckBox
-                android:id="@+id/mig_delete_downloaded"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:checked="true"
-                android:text="@string/delete_downloaded" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <View
-            android:id="@+id/migration_data_divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="4dp"
-            android:background="?android:attr/divider"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/migration_data_group"/>
-
-        <TextView
-            android:id="@+id/options_label"
+        <CheckBox
+            android:id="@+id/mig_chapters"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:layout_marginStart="8dp"
-            android:text="@string/action_settings"
-            android:textAppearance="?attr/textAppearanceTitleMedium"
-            android:textColor="?attr/colorPrimary"
-            app:layout_constraintStart_toStartOf="@+id/migration_data_group"
-            app:layout_constraintTop_toBottomOf="@+id/migration_data_divider" />
+            android:checked="true"
+            android:text="@string/chapters" />
 
-        <RadioGroup
-            android:id="@+id/sourceGroup"
-            android:layout_width="0dp"
+        <CheckBox
+            android:id="@+id/mig_categories"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:orientation="vertical"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@+id/options_label"
-            app:layout_constraintTop_toBottomOf="@+id/options_label">
+            android:checked="true"
+            android:text="@string/categories" />
 
-            <RadioButton
-                android:id="@+id/radioButton"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingStart="0dp"
-                android:paddingEnd="8dp"
-                android:text="@string/use_first_source" />
-
-            <RadioButton
-                android:id="@+id/radioButton2"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/use_most_chapters" />
-
-        </RadioGroup>
-
-        <View
-            android:id="@+id/sourceGroup_divider"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="4dp"
-            android:background="?android:attr/divider"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/sourceGroup"/>
-
-        <LinearLayout
-            android:layout_width="match_parent"
+        <CheckBox
+            android:id="@+id/mig_tracking"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/sourceGroup_divider">
+            android:checked="true"
+            android:text="@string/track" />
 
-            <com.google.android.material.materialswitch.MaterialSwitch
-                android:id="@+id/use_smart_search"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="16dp"
-                android:paddingHorizontal="16.dp"
-                android:paddingVertical="16dp"
-                android:text="@string/use_intelligent_search" />
+        <CheckBox
+            android:id="@+id/mig_custom_cover"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="@string/custom_cover" />
 
-            <com.google.android.material.materialswitch.MaterialSwitch
-                android:id="@+id/extra_search_param"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:paddingHorizontal="16.dp"
-                android:paddingVertical="16dp"
-                android:text="@string/include_extra_search_parameter" />
+        <CheckBox
+            android:id="@+id/mig_extra"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="@string/log_extra" />
 
-
-            <com.google.android.material.textfield.TextInputLayout
-                app:boxBackgroundMode="none"
-                android:id="@+id/extra_search_param_input_layout"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/extra_search_param_text"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/search_parameter"
-                    android:importantForAutofill="no"
-                    android:inputType="textPersonName"
-                    android:textSize="14sp"/>
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.materialswitch.MaterialSwitch
-                android:id="@+id/skip_step"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:paddingHorizontal="16.dp"
-                android:paddingVertical="16dp"
-                android:text="@string/skip_this_step_next_time" />
-
-            <com.google.android.material.materialswitch.MaterialSwitch
-                android:id="@+id/Hide_not_found_manga"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:paddingHorizontal="16.dp"
-                android:paddingVertical="16dp"
-                android:text="@string/hide_not_found_entries" />
-
-            <com.google.android.material.materialswitch.MaterialSwitch
-                android:id="@+id/Only_show_updates"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="82dp"
-                android:paddingHorizontal="16.dp"
-                android:paddingVertical="16dp"
-                android:text="@string/only_show_updated_entries" />
-        </LinearLayout>
-
+        <CheckBox
+            android:id="@+id/mig_delete_downloaded"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            android:text="@string/delete_downloaded" />
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <View
+        android:id="@+id/migration_data_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="4dp"
+        android:background="?android:attr/divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/migration_data_group"/>
+
+    <TextView
+        android:id="@+id/options_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_marginStart="16dp"
+        android:text="@string/action_settings"
+        android:textAppearance="?attr/textAppearanceTitleMedium"
+        android:textColor="?attr/colorPrimary"
+        app:layout_constraintStart_toStartOf="@+id/migration_data_group"
+        app:layout_constraintTop_toBottomOf="@+id/migration_data_divider" />
+
+    <RadioGroup
+        android:id="@+id/sourceGroup"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/options_label"
+        app:layout_constraintTop_toBottomOf="@+id/options_label">
+
+        <RadioButton
+            android:id="@+id/radioButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="0dp"
+            android:paddingEnd="8dp"
+            android:text="@string/use_first_source" />
+
+        <RadioButton
+            android:id="@+id/radioButton2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/use_most_chapters" />
+
+    </RadioGroup>
+
+    <View
+        android:id="@+id/sourceGroup_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="4dp"
+        android:background="?android:attr/divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/sourceGroup"/>
+
+    <LinearLayout
+        android:id="@+id/switches"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/sourceGroup_divider">
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/use_smart_search"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="16dp"
+            android:text="@string/use_intelligent_search" />
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/extra_search_param"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="16dp"
+            android:text="@string/include_extra_search_parameter" />
+
+
+        <com.google.android.material.textfield.TextInputLayout
+            app:boxBackgroundMode="none"
+            android:id="@+id/extra_search_param_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/extra_search_param_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/search_parameter"
+                android:importantForAutofill="no"
+                android:inputType="textPersonName"
+                android:textSize="14sp"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/skip_step"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="16dp"
+            android:text="@string/skip_this_step_next_time" />
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/Hide_not_found_manga"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="16dp"
+            android:text="@string/hide_not_found_entries" />
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/Only_show_updates"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="16dp"
+            android:text="@string/only_show_updated_entries" />
+    </LinearLayout>
 
     <View
         android:id="@+id/migrate_btn_divider"
@@ -237,7 +226,7 @@
         android:background="?android:attr/divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/migrate_btn" />
+        app:layout_constraintTop_toBottomOf="@+id/switches" />
 
     <Button
         android:id="@+id/migrate_btn"
@@ -245,10 +234,11 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
+        android:layout_marginTop="12dp"
         android:layout_marginBottom="12dp"
         android:text="@string/action_migrate"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="@id/constraintLayout2" />
+        app:layout_constraintTop_toBottomOf="@id/migrate_btn_divider"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/migration_bottom_sheet.xml
+++ b/app/src/main/res/layout/migration_bottom_sheet.xml
@@ -27,7 +27,7 @@
         android:paddingHorizontal="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/data_label">
+        app:layout_constraintTop_toBottomOf="@id/data_label">
 
         <androidx.constraintlayout.helper.widget.Flow
             android:layout_width="0dp"
@@ -106,7 +106,7 @@
         android:textAppearance="?attr/textAppearanceTitleMedium"
         android:textColor="?attr/colorPrimary"
         app:layout_constraintStart_toStartOf="@id/migration_data_group"
-        app:layout_constraintTop_toBottomOf="@+id/migration_data_divider" />
+        app:layout_constraintTop_toBottomOf="@id/migration_data_divider" />
 
     <RadioGroup
         android:id="@+id/sourceGroup"
@@ -115,8 +115,8 @@
         android:layout_marginEnd="8dp"
         android:orientation="vertical"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/options_label"
-        app:layout_constraintTop_toBottomOf="@+id/options_label">
+        app:layout_constraintStart_toStartOf="@id/options_label"
+        app:layout_constraintTop_toBottomOf="@id/options_label">
 
         <RadioButton
             android:id="@+id/radioButton"
@@ -153,7 +153,7 @@
         android:paddingEnd="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/sourceGroup_divider">
+        app:layout_constraintTop_toBottomOf="@id/sourceGroup_divider">
 
         <com.google.android.material.materialswitch.MaterialSwitch
             android:id="@+id/use_smart_search"
@@ -226,7 +226,7 @@
         android:background="?android:attr/divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/switches" />
+        app:layout_constraintTop_toBottomOf="@id/switches" />
 
     <Button
         android:id="@+id/migrate_btn"

--- a/app/src/main/res/layout/migration_bottom_sheet.xml
+++ b/app/src/main/res/layout/migration_bottom_sheet.xml
@@ -105,7 +105,7 @@
         android:text="@string/action_settings"
         android:textAppearance="?attr/textAppearanceTitleMedium"
         android:textColor="?attr/colorPrimary"
-        app:layout_constraintStart_toStartOf="@+id/migration_data_group"
+        app:layout_constraintStart_toStartOf="@id/migration_data_group"
         app:layout_constraintTop_toBottomOf="@+id/migration_data_divider" />
 
     <RadioGroup
@@ -199,7 +199,7 @@
             android:text="@string/skip_this_step_next_time" />
 
         <com.google.android.material.materialswitch.MaterialSwitch
-            android:id="@+id/Hide_not_found_manga"
+            android:id="@+id/hide_not_found_manga"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
@@ -208,7 +208,7 @@
             android:text="@string/hide_not_found_entries" />
 
         <com.google.android.material.materialswitch.MaterialSwitch
-            android:id="@+id/Only_show_updates"
+            android:id="@+id/only_show_updates"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"


### PR DESCRIPTION
Enhance the layout of the migration bottom sheet to support scrollable content and streamline the code by utilizing `with(binding)` to reduce redundancy.

## Summary by Sourcery

Improve the migration bottom sheet UI by making its content scrollable, reorganizing sections in the XML, and consolidating binding setup in the Compose dialog code.

Enhancements:
- Change bottom sheet height to wrap_content and restructure the XML into labeled sections with dividers, a Flow layout for checkboxes, radio buttons, and switches.
- Wrap the AndroidView in a vertically scrollable Compose Column to support longer content.
- Refactor the binding setup to use with(binding) and list iterations for applying tints and listeners, reducing code redundancy.