### PR TITLE
chore(source-feed): Also hide entries already in library

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/feed/SourceFeedScreenModel.kt
@@ -221,6 +221,10 @@ open class SourceFeedScreenModel(
             .toImmutableList()
     }
 
+    // KMK -->
+    private val hideInLibraryFeedItems = sourcePreferences.hideInLibraryFeedItems().get()
+    // KMK <--
+
     /**
      * Initiates get manga per feed.
      */
@@ -252,6 +256,9 @@ open class SourceFeedScreenModel(
                         page.map { it.toDomainManga(source.id) }
                             .distinctBy { it.url }
                             .let { networkToLocalManga(it) }
+                            // KMK -->
+                            .filter { !hideInLibraryFeedItems || !it.favorite }
+                        // KMK <--
                     }
 
                     mutableState.update { state ->


### PR DESCRIPTION
Filter out entries that are already marked as favorites in the source feed, enhancing the user experience by preventing duplicates in the library view.

## Summary by Sourcery

Add a user preference to hide entries already in the library from the source feed and apply the filter when enabled

Enhancements:
- Introduce hideInLibraryFeedItems preference to control filtering
- Filter out favorited (library) entries from source feed results when preference is enabled