### PR TITLE
feat(MangaDex): use tracker links to associate mangas automatically with trackers (jobobby04/TachiyomiSY#1387)

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
@@ -43,6 +43,13 @@ class TrackPreferences(
         AutoTrackState.ALWAYS,
     )
 
+    // SY -->
+    fun resolveUsingSourceMetadata() = preferenceStore.getBoolean(
+        "pref_resolve_using_source_metadata_key",
+        true,
+    )
+    // SY <--
+
     // KMK -->
     fun autoSyncProgressFromTrackers() = preferenceStore.getBoolean("pref_auto_sync_progress_from_trackers_key", true)
     // KMK <--

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -63,6 +63,7 @@ import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.kmk.KMR
+import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
@@ -146,6 +147,13 @@ object SettingsTrackingScreen : SearchableSettings {
                 title = stringResource(KMR.strings.pref_auto_sync_progress_from_trackers),
             ),
             // KMK <--
+            // SY -->
+            Preference.PreferenceItem.SwitchPreference(
+                preference = trackPreferences.resolveUsingSourceMetadata(),
+                title = stringResource(SYMR.strings.pref_tracker_resolve_using_source_metadata),
+                subtitle = stringResource(SYMR.strings.pref_tracker_resolve_using_source_metadata_summary),
+            ),
+            // SY <--
             Preference.PreferenceGroup(
                 title = stringResource(MR.strings.services),
                 preferenceItems = persistentListOf(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
@@ -7,6 +7,7 @@ import eu.kanade.domain.track.model.toDomainTrack
 import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.flow.Flow
@@ -131,6 +132,12 @@ abstract class BaseTracker(
     override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
         throw NotImplementedError("Not implemented.")
     }
+
+    // SY -->
+    override suspend fun searchById(id: String): TrackSearch? {
+        throw NotImplementedError("Not implemented.")
+    }
+    // SY <--
 
     private suspend fun updateRemote(track: Track): Unit = withIOContext {
         try {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
@@ -90,6 +90,8 @@ interface Tracker {
 
     // SY -->
     suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata
+
+    suspend fun searchById(id: String): TrackSearch?
     // SY <--
 
     // KMK -->

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.data.track.DeletableTracker
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import exh.log.xLogW
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -239,8 +240,13 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker {
     }
 
     // SY -->
-    override suspend fun searchById(id: String): TrackSearch {
-        return api.searchById(id)
+    override suspend fun searchById(id: String): TrackSearch? {
+        return try {
+            api.searchById(id)
+        } catch (e: Exception) {
+            xLogW("Error during searchById '$id': ${e.message}", e)
+            null
+        }
     }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -238,6 +238,12 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker {
         return api.getMangaMetadata(track)
     }
 
+    // SY -->
+    override suspend fun searchById(id: String): TrackSearch {
+        return api.searchById(id)
+    }
+    // SY <--
+
     fun saveOAuth(alOAuth: ALOAuth?) {
         trackPreferences.trackToken(this).set(json.encodeToString(alOAuth))
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALSearch.kt
@@ -18,3 +18,16 @@ data class ALSearchPage(
 data class ALSearchMedia(
     val media: List<ALSearchItem>,
 )
+
+// SY -->
+@Serializable
+data class ALIdSearchResult(
+    val data: ALIdSearchMedia,
+)
+
+@Serializable
+data class ALIdSearchMedia(
+    @SerialName("Media")
+    val media: ALSearchItem,
+)
+// SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdates.kt
@@ -13,6 +13,7 @@ import eu.kanade.tachiyomi.data.track.mangaupdates.dto.toTrackSearch
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.util.lang.htmlDecode
+import exh.log.xLogW
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import tachiyomi.i18n.MR
@@ -152,8 +153,13 @@ class MangaUpdates(id: Long) : BaseTracker(id, "MangaUpdates"), DeletableTracker
             id
         }
 
-        return base36Id.toLong(36).let { longId ->
-            api.getSeries(longId).toTrackSearch(this.id)
+        return try {
+            base36Id.toLong(36).let { longId ->
+                api.getSeries(longId).toTrackSearch(this.id)
+            }
+        } catch (e: Exception) {
+            xLogW("Error during searchById '$id': ${e.message}", e)
+            null
         }
     }
     // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
@@ -210,14 +210,16 @@ class MangaUpdatesApi(
             .build()
             .newCall(GET("https://www.mangaupdates.com/series.html?id=$legacyId"))
             .await()
-            .takeIf(Response::isRedirect)
-            ?.header("Location")
-            ?.let {
-                // Extract the new id from the redirected URL
-                Regex("""/series/(\w+)(/([\w-]+)?)?/?${'$'}""")
-                    .find(it)
-                    ?.groups?.get(1)
-                    ?.value
+            .use { response ->
+                response.takeIf(Response::isRedirect)
+                    ?.header("Location")
+                    ?.let { location ->
+                        // Extract the new id from the redirected URL
+                        Regex("""/series/(\w+)(/([\w-]+)?)?/?${'$'}""")
+                            .find(location)
+                            ?.groups?.get(1)
+                            ?.value
+                    }
             }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
@@ -27,6 +27,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import tachiyomi.core.common.util.lang.withIOContext
 import uy.kohesive.injekt.injectLazy
 import tachiyomi.domain.track.model.Track as DomainTrack
 
@@ -204,7 +205,7 @@ class MangaUpdatesApi(
         }
     }
 
-    suspend fun convertToNewId(legacyId: Int): String? =
+    suspend fun convertToNewId(legacyId: Int): String? = withIOContext {
         client.newBuilder()
             .followRedirects(false)
             .build()
@@ -221,6 +222,7 @@ class MangaUpdatesApi(
                             ?.value
                     }
             }
+    }
     // SY <--
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
@@ -215,7 +215,7 @@ class MangaUpdatesApi(
                     ?.header("Location")
                     ?.let { location ->
                         // Extract the new id from the redirected URL
-                        Regex("""/series/(\w+)(/([\w-]+)?)?/?${'$'}""")
+                        Regex("""/series/(\w+)""")
                             .find(location)
                             ?.groups?.get(1)
                             ?.value

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.data.track.DeletableTracker
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALOAuth
+import exh.log.xLogW
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.json.Json
@@ -161,8 +162,18 @@ class MyAnimeList(id: Long) : BaseTracker(id, "MyAnimeList"), DeletableTracker {
     }
 
     // SY -->
-    override suspend fun searchById(id: String): TrackSearch {
-        return api.getMangaDetails(id.toInt())
+    override suspend fun searchById(id: String): TrackSearch? {
+        val searchId = id.toIntOrNull()
+            ?: run {
+                xLogW("Invalid ID format for searchById: $id")
+                return null
+            }
+        return try {
+            api.getMangaDetails(searchId)
+        } catch (e: Exception) {
+            xLogW("Error during searchById '$id': ${e.message}", e)
+            null
+        }
     }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -160,6 +160,12 @@ class MyAnimeList(id: Long) : BaseTracker(id, "MyAnimeList"), DeletableTracker {
         return api.getMangaMetadata(track)
     }
 
+    // SY -->
+    override suspend fun searchById(id: String): TrackSearch {
+        return api.getMangaDetails(id.toInt())
+    }
+    // SY <--
+
     fun getIfAuthExpired(): Boolean {
         return trackPreferences.trackAuthExpired(this).get()
     }

--- a/app/src/main/java/eu/kanade/test/DummyTracker.kt
+++ b/app/src/main/java/eu/kanade/test/DummyTracker.kt
@@ -131,6 +131,8 @@ data class DummyTracker(
     override suspend fun getMangaMetadata(
         track: Track,
     ): TrackMangaMetadata = TrackMangaMetadata(0, "test", "test", "test", "test", "test")
+
+    override suspend fun searchById(id: String) = null
     // SY <--
 
     // KMK -->

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -176,6 +176,10 @@
     <string name="pref_hide_history_button">Show history in the nav</string>
     <string name="pref_show_bottom_bar_labels">Always show nav labels</string>
 
+    <!-- Tracker settings -->
+    <string name="pref_tracker_resolve_using_source_metadata">Select entries using source metadata</string>
+    <string name="pref_tracker_resolve_using_source_metadata_summary">Automatically selects the matching title if the source provides links to trackers. Currently supported by MangaDex</string>
+
     <!-- Library settings -->
     <string name="pref_sorting_settings">Sorting Settings</string>
     <string name="pref_skip_pre_migration_summary">Use last saved pre-migration preferences and sources to mass migrate</string>

--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/MangaDexSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/MangaDexSearchMetadata.kt
@@ -4,13 +4,14 @@ import android.content.Context
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.copy
 import exh.md.utils.MangaDexRelation
+import exh.metadata.metadata.base.TrackerIdMetadata
 import kotlinx.serialization.Serializable
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.sy.SYMR
 
 @Serializable
-class MangaDexSearchMetadata : RaisedSearchMetadata() {
+class MangaDexSearchMetadata : RaisedSearchMetadata(), TrackerIdMetadata {
     var mdUuid: String? = null
 
     // var mdUrl: String? = null
@@ -31,11 +32,11 @@ class MangaDexSearchMetadata : RaisedSearchMetadata() {
     var rating: Float? = null
     // var users: String? = null
 
-    var anilistId: String? = null
-    var kitsuId: String? = null
-    var myAnimeListId: String? = null
-    var mangaUpdatesId: String? = null
-    var animePlanetId: String? = null
+    override var anilistId: String? = null
+    override var kitsuId: String? = null
+    override var myAnimeListId: String? = null
+    override var mangaUpdatesId: String? = null
+    override var animePlanetId: String? = null
 
     var status: Int? = null
 

--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/base/TrackerIdMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/base/TrackerIdMetadata.kt
@@ -1,0 +1,9 @@
+package exh.metadata.metadata.base
+
+interface TrackerIdMetadata {
+    var anilistId: String?
+    var kitsuId: String?
+    var myAnimeListId: String?
+    var mangaUpdatesId: String?
+    var animePlanetId: String?
+}


### PR DESCRIPTION
Introduce features to automatically link mangas with trackers by utilizing source metadata. Add support for searching by ID across multiple trackers and provide preferences for auto-selection of tracker items. Refactor existing code for better maintainability.

## Summary by Sourcery

Enable automatic tracker entry registration by leveraging source metadata IDs with a new searchById flow and configurable preference

New Features:
- Enable automatic linking of manga tracking entries by ID using source-provided metadata
- Add searchById support and implement it for AniList, MangaUpdates, and MyAnimeList trackers
- Introduce a settings preference to toggle automatic resolution of tracker entries via source metadata

Enhancements:
- Refactor TrackInfoDialog to include a loading state and integrate the new auto-registration flow
- Define TrackerIdMetadata interface and extend MangaDex metadata to carry tracker IDs

Documentation:
- Add user-facing preference strings and descriptions for tracker auto-resolution in settings

Tests:
- Update DummyTracker to include a stubbed searchById implementation