### PR TITLE
fix(searching): fix filter-list param when doing search with some ext while doing:

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -180,7 +180,7 @@ private fun ColumnScope.FilterPage(
     )
     // SY <--
 
-    // KMY -->
+    // KMK -->
     CategoriesFilter(
         libraryPreferences = screenModel.libraryPreferences,
         categories = categories,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mdlist/MdList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mdlist/MdList.kt
@@ -8,7 +8,6 @@ import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
-import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
 import exh.md.network.MangaDexAuthInterceptor
 import exh.md.utils.FollowStatus
@@ -149,7 +148,7 @@ class MdList(id: Long) : BaseTracker(id, "MDList") {
     override suspend fun search(query: String): List<TrackSearch> {
         return withIOContext {
             val mdex = mdex ?: throw MangaDexNotFoundException()
-            mdex.getSearchManga(1, query, FilterList())
+            mdex.getSearchManga(1, query, mdex.getFilterList())
                 .mangas
                 .map {
                     toTrackSearch(mdex.getMangaDetails(it))

--- a/app/src/main/java/exh/smartsearch/SmartSourceSearchEngine.kt
+++ b/app/src/main/java/exh/smartsearch/SmartSourceSearchEngine.kt
@@ -1,7 +1,6 @@
 package exh.smartsearch
 
 import eu.kanade.tachiyomi.source.CatalogueSource
-import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
 import mihon.domain.manga.model.toDomainManga
 import tachiyomi.domain.manga.model.Manga
@@ -23,5 +22,5 @@ class SmartSourceSearchEngine(
         }
 
     private fun makeSearchAction(source: CatalogueSource): SearchAction<SManga> =
-        { query -> source.getSearchManga(1, query, FilterList()).mangas }
+        { query -> source.getSearchManga(1, query, source.getFilterList()).mangas }
 }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/CatalogueSource.kt
@@ -185,10 +185,11 @@ interface CatalogueSource : Source {
         if (words.isEmpty()) return
 
         coroutineScope {
+            val filterList = getFilterList()
             words.map { keyword ->
                 launch {
                     runCatching {
-                        getSearchManga(1, keyword.sanitize(), FilterList()).mangas
+                        getSearchManga(1, keyword.sanitize(), filterList).mangas
                     }
                         .onSuccess { if (it.isNotEmpty()) pushResults(Pair(keyword, it), false) }
                         .onFailure { e ->


### PR DESCRIPTION
Searching with an empty filter-list might cause issue with extensions

## Summary by Sourcery

Use the actual filter list when performing searches instead of passing an empty FilterList to prevent issues with extensions, and correct a minor comment typo in the library settings dialog.

Bug Fixes:
- Use source.getFilterList() instead of a newly instantiated FilterList() in MdList, SmartSourceSearchEngine, and catalogue-wide searches to ensure extensions receive the proper filters.

Enhancements:
- Cache the result of getFilterList() in concurrent catalogue searches to avoid repeated calls.

Chores:
- Fix the comment marker in LibrarySettingsDialog from "KMY -->" to "KMK -->".