### PR TITLE
feat(library): Added a button to refresh selected manga entries

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.outlined.DoneAll
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Merge
 import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.RemoveDone
 import androidx.compose.material.icons.outlined.SwapCalls
 import androidx.compose.material3.DropdownMenuItem
@@ -81,6 +82,7 @@ fun MangaBottomActionMenu(
     onMarkPreviousAsReadClicked: (() -> Unit)? = null,
     onDownloadClicked: (() -> Unit)? = null,
     onDeleteClicked: (() -> Unit)? = null,
+    onClickRefreshSelected: (() -> Unit)? = null,
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -94,11 +96,11 @@ fun MangaBottomActionMenu(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
         ) {
             val haptic = LocalHapticFeedback.current
-            val confirm = remember { mutableStateListOf(false, false, false, false, false, false, false) }
+            val confirm = remember { mutableStateListOf(false, false, false, false, false, false, false, false) }
             var resetJob: Job? = remember { null }
             val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                (0..<7).forEach { i -> confirm[i] = i == toConfirmIndex }
+                (0..<8).forEach { i -> confirm[i] = i == toConfirmIndex }
                 resetJob?.cancel()
                 resetJob = scope.launch {
                     delay(1.seconds)
@@ -175,6 +177,15 @@ fun MangaBottomActionMenu(
                         toConfirm = confirm[6],
                         onLongClick = { onLongClickItem(6) },
                         onClick = onDeleteClicked,
+                    )
+                }
+                if (onClickRefreshSelected != null) {
+                    Button(
+                        title = stringResource(MR.strings.action_update_category),
+                        icon = Icons.Outlined.Refresh,
+                        toConfirm = confirm[7],
+                        onLongClick = { onLongClickItem(7) },
+                        onClick = onClickRefreshSelected,
                     )
                 }
             }
@@ -266,6 +277,7 @@ fun LibraryBottomActionMenu(
     // SY <--
     // KMK -->
     onClickMerge: (() -> Unit)?,
+    onClickRefreshSelected: (() -> Unit)? = null,
     // KMK <--
     modifier: Modifier = Modifier,
 ) {
@@ -283,12 +295,12 @@ fun LibraryBottomActionMenu(
             val haptic = LocalHapticFeedback.current
             val confirm =
                 remember {
-                    mutableStateListOf(false, false, false, false, false /* SY --> */, false, false, false /* SY <-- */)
+                    mutableStateListOf(false, false, false, false, false /* SY --> */, false, false, false, false /* SY <-- */)
                 }
             var resetJob: Job? = remember { null }
             val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                (0..<8).forEach { i -> confirm[i] = i == toConfirmIndex }
+                (0..<9).forEach { i -> confirm[i] = i == toConfirmIndex }
                 resetJob?.cancel()
                 resetJob = scope.launch {
                     delay(1.seconds)
@@ -361,6 +373,16 @@ fun LibraryBottomActionMenu(
                     onLongClick = { onLongClickItem(2) },
                     onClick = onMarkAsUnreadClicked,
                 )
+                // Add refresh button here
+                if (onClickRefreshSelected != null) {
+                    Button(
+                        title = stringResource(MR.strings.action_update_category),
+                        icon = Icons.Outlined.Refresh,
+                        toConfirm = confirm[8],
+                        onLongClick = { onLongClickItem(8) },
+                        onClick = onClickRefreshSelected,
+                    )
+                }
                 // SY -->
                 if (showOverflow) {
                     if (isTabletUi) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.util.fastFilter
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.util.fastMapNotNull
+import androidx.work.WorkManager
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.core.preference.PreferenceMutableState
@@ -38,6 +39,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.source.online.all.MergedSource
 import eu.kanade.tachiyomi.util.chapter.getNextUnread
 import eu.kanade.tachiyomi.util.removeCovers
+import eu.kanade.tachiyomi.util.system.isRunning
 import exh.favorites.FavoritesSyncHelper
 import exh.log.xLogE
 import exh.md.utils.FollowStatus
@@ -929,6 +931,24 @@ class LibraryScreenModel(
             setCustomMangaInfo.set(mangaInfo)
         }
         clearSelection()
+    }
+
+    /**
+     *Update Selected Mangas
+     */
+    fun refreshSelectedManga(): Boolean {
+        val selectedMangas = state.value.selection.map { it.manga }
+        val wm = WorkManager.getInstance(preferences.context)
+        val isUpdateRunning = wm.isRunning("LibraryUpdate")
+        if (isUpdateRunning) {
+            return false
+        }
+        val mangaIds = selectedMangas.map { it.id }
+        return eu.kanade.tachiyomi.data.library.LibraryUpdateJob.startNow(
+            context = preferences.context,
+            mangaIds = mangaIds,
+            target = eu.kanade.tachiyomi.data.library.LibraryUpdateJob.Target.CHAPTERS,
+        )
     }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -256,6 +256,20 @@ data object LibraryTab : Tab {
                             context.toast(SYMR.strings.no_valid_entry)
                         }
                     },
+                    onClickRefreshSelected = {
+                        scope.launch {
+                            val started = screenModel.refreshSelectedManga()
+                            val message = if (started) {
+                                context.stringResource(MR.strings.updating_category)
+                            } else {
+                                context.stringResource(MR.strings.update_already_running)
+                            }
+                            snackbarHostState.showSnackbar(message)
+                            if (started) {
+                                screenModel.clearSelection()
+                            }
+                        }
+                    },
                     // KMK <--
                 )
             },


### PR DESCRIPTION
This PR is to introduce new feature for selected manga refresh button.
It resolve [ongoing issue](https://github.com/komikku-app/komikku/issues/1036)

## Changes Made

### 1. LibraryUpdateJob.kt
- **Added `KEY_MANGA_IDS` constant** for passing specific manga IDs in work data
- **Extended `startNow()` function** with optional `mangaIds: List<Long>?` parameter
- **Enhanced `addMangaToQueue()`** with targeted update logic:
  - When `mangaIds` are provided, filters library to only those specific manga

### 2. LibraryScreenModel.kt  
- **Added `refreshSelectedManga()`**
  - Extracts manga IDs from selected manga
  - Calls `LibraryUpdateJob.startNow()` with `mangaIds` parameter

### 3. LibraryTab.kt
- **Refresh button click handler**:
  - Only clears selection **after** successful update start
  - Preserves selection if update is blocked (already running)

### 4. MangaBottomActionMenu.kt
- **Added refresh button** to library bottom action menu

## How It Works

1. **User selects manga** → clicks refresh button in bottom action menu
2. **LibraryScreenModel.refreshSelectedManga()** → extracts manga IDs and calls LibraryUpdateJob
3. **LibraryUpdateJob.addMangaToQueue()** → detects manga IDs and filters to only those manga
4. **Same update process** → uses existing infrastructure for actual updates (notifications, rate limiting, error handling)
5. **UI handling** → only clears selection if update actually started, preserves selection if blocked


<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
