### PR TITLE
Use median to determine smart update interval (mihonapp/mihon#2251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Surface image loading error in Reader ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#1981](https://github.com/mihonapp/mihon/pull/1981))
 - Include source headers when opening failed images from reader ([@AwkwardPeak7](https://github.com/AwkwardPeak7)) ([#2004](https://github.com/mihonapp/mihon/pull/2004))
 - Added autofill support to tracker login dialog ([@AntsyLich](https://github.com/AntsyLich)) ([#2069](https://github.com/mihonapp/mihon/pull/2069))
+- Added option to hide missing chapter count ([@User826](https://github.com/User826), [@AntsyLich](https://github.com/AntsyLich)) ([#2108](https://github.com/mihonapp/mihon/pull/2108))
+- Use median to determine smart update interval, making it more resilient to long hiatuses ([@Kladki](https://github.com/Kladki)) ([#2251](https://github.com/mihonapp/mihon/pull/2251))
 
 ### Changed
 - Display all similarly named duplicates in duplicate manga dialogue ([@NarwhalHorns](https://github.com/NarwhalHorns), [@AntsyLich](https://github.com/AntsyLich)) ([#1861](https://github.com/mihonapp/mihon/pull/1861))
@@ -39,6 +41,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Switch default user agent to Android Chrome ([@AntsyLich](https://github.com/AntsyLich)) ([#2048](https://github.com/mihonapp/mihon/pull/2048))
 - Changed log in button text when processing tracker login ([@AntsyLich](https://github.com/AntsyLich)) ([#2069](https://github.com/mihonapp/mihon/pull/2069))
 - Disable reader's 'Keep screen on' setting by default ([@AntsyLich](https://github.com/AntsyLich)) ([#2095](https://github.com/mihonapp/mihon/pull/2095))
+- Update manga without chapters even if restricted by source ([@AntsyLich](https://github.com/AntsyLich)) ([#2224](https://github.com/mihonapp/mihon/pull/224))
 
 ### Fixes
 - Fix Bangumi search results including novels ([@MajorTanya](https://github.com/MajorTanya)) ([#1885](https://github.com/mihonapp/mihon/pull/1885))

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/FetchInterval.kt
@@ -69,15 +69,13 @@ class FetchInterval(
         val interval = when {
             // Enough upload date from source
             uploadDates.size >= 3 -> {
-                val uploadDelta = uploadDates.last().until(uploadDates.first(), ChronoUnit.DAYS)
-                val uploadPeriod = uploadDates.indexOf(uploadDates.last())
-                uploadDelta.floorDiv(uploadPeriod).toInt()
+                val ranges = uploadDates.windowed(2).map { x -> x[1].until(x[0], ChronoUnit.DAYS) }.sorted()
+                ranges[(ranges.size - 1) / 2].toInt()
             }
             // Enough fetch date from client
             fetchDates.size >= 3 -> {
-                val fetchDelta = fetchDates.last().until(fetchDates.first(), ChronoUnit.DAYS)
-                val uploadPeriod = fetchDates.indexOf(fetchDates.last())
-                fetchDelta.floorDiv(uploadPeriod).toInt()
+                val ranges = fetchDates.windowed(2).map { x -> x[1].until(x[0], ChronoUnit.DAYS) }.sorted()
+                ranges[(ranges.size - 1) / 2].toInt()
             }
             // Default to 7 days
             else -> 7

--- a/domain/src/test/java/tachiyomi/domain/manga/interactor/FetchIntervalTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/manga/interactor/FetchIntervalTest.kt
@@ -125,11 +125,11 @@ class FetchIntervalTest {
     }
 
     @Test
-    fun `returns interval of 1 day when chapters are released just below every 2 days`() {
+    fun `returns interval of 2 days when chapters are released just below every 2 days`() {
         val chapters = (1..20).map {
             chapterWithTime(chapter, (43 * it).hours)
         }
-        fetchInterval.calculateInterval(chapters, testZoneId) shouldBe 1
+        fetchInterval.calculateInterval(chapters, testZoneId) shouldBe 2
     }
 
     private fun chapterWithTime(chapter: Chapter, duration: Duration): Chapter {


### PR DESCRIPTION
## Summary by Sourcery

Compute smart update intervals using the median of release intervals rather than the average to better handle irregular publication patterns.

Enhancements:
- Use median of consecutive upload and fetch date intervals instead of average to calculate smart update interval, improving resilience to long hiatuses.

Documentation:
- Add changelog entry for median-based smart update interval calculation.

Tests:
- Update interval calculation test to expect median-based result (2 days).