### PR TITLE
fix(bottom-action-menu): Properly close dropdown menu when refreshing selected mangas

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -267,9 +267,9 @@ fun LibraryBottomActionMenu(
     // SY <--
     // KMK -->
     onClickMerge: (() -> Unit)?,
-    modifier: Modifier = Modifier,
-    onClickRefreshSelected: (() -> Unit)? = null,
+    onClickRefreshSelected: (() -> Unit)?,
     // KMK <--
+    modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -406,7 +406,10 @@ fun LibraryBottomActionMenu(
                         if (onClickRefreshSelected != null) {
                             DropdownMenuItem(
                                 text = { Text(stringResource(KMR.strings.action_update)) },
-                                onClick = onClickRefreshSelected,
+                                onClick = {
+                                    overFlowOpen = false
+                                    onClickRefreshSelected()
+                                },
                             )
                         }
                         // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -269,10 +269,10 @@ data object LibraryTab : Tab {
                             } else {
                                 MR.strings.update_already_running
                             }
-                            snackbarHostState.showSnackbar(context.stringResource(msgRes))
                             if (started) {
                                 screenModel.clearSelection()
                             }
+                            snackbarHostState.showSnackbar(context.stringResource(msgRes))
                         }
                     },
                     // KMK <--


### PR DESCRIPTION
Ensure the dropdown menu closes properly when refreshing selected mangas. Adjustments made to the action menu and library tab components enhance user experience by preventing the menu from remaining open during the refresh process.

## Summary by Sourcery

Close the bottom action menu when refreshing selected mangas and ensure the manga selection is cleared before displaying the refresh notification.

Bug Fixes:
- Add logic to close the MangaBottomActionMenu dropdown before invoking the refresh callback.
- Clear selected mangas prior to showing the snackbar notification in the library tab.

Enhancements:
- Make the onClickRefreshSelected callback parameter required and reposition the modifier argument for consistency in MangaBottomActionMenu.