### PR TITLE
feat(library): Hide empty library tabs when searching/filtering

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -205,10 +205,11 @@ class LibraryScreenModel(
                 combine(
                     getCategoriesPerLibraryManga.subscribe(),
                     state.map { it.filterCategory }.distinctUntilChanged(),
-                    ::Pair,
+                    state.map { it.searchQuery.isNullOrBlank() && !it.hasActiveFilters }.distinctUntilChanged(),
+                    ::Triple,
                 ),
                 // KMK <--
-            ) { (searchQuery, library, _), (tracks, trackingFilter), (groupType, sort), (categoriesPerManga, filterCategory) ->
+            ) { (searchQuery, library, _), (tracks, trackingFilter), (groupType, sort), (categoriesPerManga, filterCategory, isNotFiltering) ->
                 library
                     // SY -->
                     .applyGrouping(/* KMK --> */ if (filterCategory) LibraryGroup.UNGROUPED else /* KMK <-- */ groupType)
@@ -240,7 +241,7 @@ class LibraryScreenModel(
                     }
                     // KMK -->
                     .filter {
-                        mutableState.value.searchQuery.isNullOrBlank() && !mutableState.value.hasActiveFilters || it.value.isNotEmpty()
+                        isNotFiltering || it.value.isNotEmpty()
                     }
                 // KMK <--
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -240,11 +240,7 @@ class LibraryScreenModel(
                     }
                     // KMK -->
                     .filter {
-                        if (!mutableState.value.searchQuery.isNullOrBlank() || mutableState.value.hasActiveFilters) {
-                            it.value.isNotEmpty()
-                        } else {
-                            true
-                        }
+                        mutableState.value.searchQuery.isNullOrBlank() && !mutableState.value.hasActiveFilters || it.value.isNotEmpty()
                     }
                 // KMK <--
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -209,7 +209,7 @@ class LibraryScreenModel(
                     ::Triple,
                 ),
                 // KMK <--
-            ) { (searchQuery, library, _), (tracks, trackingFilter), (groupType, sort), (categoriesPerManga, filterCategory, isNotFiltering) ->
+            ) { (searchQuery, library, _), (tracks, trackingFilter), (groupType, sort), (categoriesPerManga, filterCategory, noActiveFilterOrSearch) ->
                 library
                     // SY -->
                     .applyGrouping(/* KMK --> */ if (filterCategory) LibraryGroup.UNGROUPED else /* KMK <-- */ groupType)
@@ -241,7 +241,7 @@ class LibraryScreenModel(
                     }
                     // KMK -->
                     .filter {
-                        isNotFiltering || it.value.isNotEmpty()
+                        noActiveFilterOrSearch || it.value.isNotEmpty()
                     }
                 // KMK <--
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -245,7 +245,6 @@ class LibraryScreenModel(
                     }
                     .let {
                         it.ifEmpty {
-                            // If no manga is left after filtering, return an empty map
                             mapOf(
                                 Category(
                                     0,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -243,6 +243,20 @@ class LibraryScreenModel(
                     .filter {
                         noActiveFilterOrSearch || it.value.isNotEmpty()
                     }
+                    .let {
+                        it.ifEmpty {
+                            // If no manga is left after filtering, return an empty map
+                            mapOf(
+                                Category(
+                                    0,
+                                    preferences.context.stringResource(MR.strings.default_category),
+                                    0,
+                                    0,
+                                    false,
+                                ) to emptyList(),
+                            )
+                        }
+                    }
                 // KMK <--
             }
                 .collectLatest {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -238,6 +238,15 @@ class LibraryScreenModel(
                             value
                         }
                     }
+                    // KMK -->
+                    .filter {
+                        if (!mutableState.value.searchQuery.isNullOrBlank() || mutableState.value.hasActiveFilters) {
+                            it.value.isNotEmpty()
+                        } else {
+                            true
+                        }
+                    }
+                // KMK <--
             }
                 .collectLatest {
                     mutableState.update { state ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.graphics.res.animatedVectorResource
 import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
 import androidx.compose.animation.graphics.vector.AnimatedImageVector
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
@@ -32,6 +33,7 @@ import cafe.adriel.voyager.navigator.tab.TabOptions
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
 import eu.kanade.presentation.library.DeleteLibraryMangaDialog
 import eu.kanade.presentation.library.LibrarySettingsDialog
+import eu.kanade.presentation.library.components.GlobalSearchItem
 import eu.kanade.presentation.library.components.LibraryContent
 import eu.kanade.presentation.library.components.LibraryToolbar
 import eu.kanade.presentation.library.components.SyncFavoritesConfirmDialog
@@ -139,6 +141,12 @@ data object LibraryTab : Tab {
             }
             started
         }
+
+        // KMK -->
+        val onGlobalSearchClicked = {
+            navigator.push(GlobalSearchScreen(screenModel.state.value.searchQuery ?: ""))
+        }
+        // KMK <--
 
         Scaffold(
             topBar = { scrollBehavior ->
@@ -294,6 +302,19 @@ data object LibraryTab : Tab {
                                 onClick = { handler.openUri(GETTING_STARTED_URL) },
                             ),
                         ),
+                        // KMK -->
+                        topInfo = {
+                            state.searchQuery.let {
+                                if (!it.isNullOrBlank()) {
+                                    GlobalSearchItem(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        searchQuery = it,
+                                        onClick = onGlobalSearchClicked,
+                                    )
+                                }
+                            }
+                        },
+                        // KMK <--
                     )
                 }
                 else -> {
@@ -326,9 +347,7 @@ data object LibraryTab : Tab {
                             haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                         },
                         onRefresh = onClickRefresh,
-                        onGlobalSearchClicked = {
-                            navigator.push(GlobalSearchScreen(screenModel.state.value.searchQuery ?: ""))
-                        },
+                        onGlobalSearchClicked = onGlobalSearchClicked,
                         getNumberOfMangaForCategory = { state.getMangaCountForCategory(it) },
                         getDisplayMode = { screenModel.getDisplayMode() },
                         getColumnsForOrientation = { screenModel.getColumnsPreferenceForCurrentOrientation(it) },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -292,8 +292,11 @@ data object LibraryTab : Tab {
                 state.isLoading -> LoadingScreen(Modifier.padding(contentPadding))
                 state.isLibraryEmpty -> {
                     val handler = LocalUriHandler.current
+                    // KMK -->
+                    val isFilteringOrSearching = state.hasActiveFilters || !state.searchQuery.isNullOrBlank()
+                    // KMK <--
                     EmptyScreen(
-                        stringRes = MR.strings.information_empty_library,
+                        stringRes = /* KMK --> */ if (isFilteringOrSearching) MR.strings.no_results_found else /* KMK <-- */ MR.strings.information_empty_library,
                         modifier = Modifier.padding(contentPadding),
                         actions = persistentListOf(
                             EmptyScreenAction(
@@ -304,14 +307,12 @@ data object LibraryTab : Tab {
                         ),
                         // KMK -->
                         topInfo = {
-                            state.searchQuery.let {
-                                if (!it.isNullOrBlank()) {
-                                    GlobalSearchItem(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        searchQuery = it,
-                                        onClick = onGlobalSearchClicked,
-                                    )
-                                }
+                            state.searchQuery?.takeIf { it.isNotBlank() }?.let { query ->
+                                GlobalSearchItem(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    searchQuery = query,
+                                    onClick = onGlobalSearchClicked,
+                                )
                             }
                         },
                         // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -282,7 +282,7 @@ data object LibraryTab : Tab {
         ) { contentPadding ->
             when {
                 state.isLoading -> LoadingScreen(Modifier.padding(contentPadding))
-                state.searchQuery.isNullOrEmpty() && !state.hasActiveFilters && state.isLibraryEmpty -> {
+                state.isLibraryEmpty -> {
                     val handler = LocalUriHandler.current
                     EmptyScreen(
                         stringRes = MR.strings.information_empty_library,
@@ -341,10 +341,6 @@ data object LibraryTab : Tab {
         when (val dialog = state.dialog) {
             is LibraryScreenModel.Dialog.SettingsSheet -> run {
                 val category = state.categories.getOrNull(screenModel.activeCategoryIndex)
-                if (category == null) {
-                    onDismissRequest()
-                    return@run
-                }
                 LibrarySettingsDialog(
                     onDismissRequest = onDismissRequest,
                     screenModel = settingsScreenModel,

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
@@ -42,24 +42,16 @@ fun EmptyScreen(
     actions: ImmutableList<EmptyScreenAction>? = null,
     // KMK -->
     help: @Composable (() -> Unit)? = null,
-    topInfo: @Composable (() -> Unit)? = null,
     // KMK <--
 ) {
-    Column(
-        modifier = modifier.fillMaxSize(),
+    EmptyScreen(
+        message = stringResource(stringRes),
+        modifier = modifier,
+        actions = actions,
         // KMK -->
-    ) {
-        topInfo?.invoke()
-
-        EmptyScreen(
-            message = stringResource(stringRes),
-            modifier = Modifier.weight(1f),
-            actions = actions,
-            // KMK -->
-            help = help,
-            // KMK <--
-        )
-    }
+        help = help,
+        // KMK <--
+    )
 }
 
 @Composable

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
@@ -45,15 +45,21 @@ fun EmptyScreen(
     topInfo: @Composable (() -> Unit)? = null,
     // KMK <--
 ) {
-    EmptyScreen(
-        message = stringResource(stringRes),
-        modifier = modifier,
-        actions = actions,
+    Column(
+        modifier = modifier.fillMaxSize(),
         // KMK -->
-        help = help,
-        topInfo = topInfo,
-        // KMK <--
-    )
+    ) {
+        topInfo?.invoke()
+
+        EmptyScreen(
+            message = stringResource(stringRes),
+            modifier = Modifier.weight(1f),
+            actions = actions,
+            // KMK -->
+            help = help,
+            // KMK <--
+        )
+    }
 }
 
 @Composable
@@ -63,60 +69,51 @@ fun EmptyScreen(
     actions: ImmutableList<EmptyScreenAction>? = null,
     // KMK -->
     help: @Composable (() -> Unit)? = null,
-    topInfo: @Composable (() -> Unit)? = null,
     // KMK <--
 ) {
     val face = remember { getRandomErrorFace() }
     Column(
-        modifier = modifier.fillMaxSize(),
-        // KMK -->
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
     ) {
-        topInfo?.invoke()
-
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                // KMK <--
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-                Text(
-                    text = face,
-                    modifier = Modifier.secondaryItemAlpha(),
-                    style = MaterialTheme.typography.displayMedium,
-                )
-            }
-
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
             Text(
-                text = message,
-                modifier = Modifier
-                    .paddingFromBaseline(top = 24.dp)
-                    .secondaryItemAlpha(),
-                style = MaterialTheme.typography.bodyMedium,
-                textAlign = TextAlign.Center,
+                text = face,
+                modifier = Modifier.secondaryItemAlpha(),
+                style = MaterialTheme.typography.displayMedium,
             )
+        }
 
-            // KMK -->
-            help?.invoke()
-            // KMK <--
+        Text(
+            text = message,
+            modifier = Modifier
+                .paddingFromBaseline(top = 24.dp)
+                .secondaryItemAlpha(),
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+        )
 
-            if (!actions.isNullOrEmpty()) {
-                Row(
-                    modifier = Modifier
-                        .padding(top = 24.dp),
-                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
-                ) {
-                    actions.fastForEach {
-                        ActionButton(
-                            modifier = Modifier.weight(1f),
-                            title = stringResource(it.stringRes),
-                            icon = it.icon,
-                            onClick = it.onClick,
-                        )
-                    }
+        // KMK -->
+        help?.invoke()
+        // KMK <--
+
+        if (!actions.isNullOrEmpty()) {
+            Row(
+                modifier = Modifier
+                    .padding(top = 24.dp),
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+            ) {
+                actions.fastForEach {
+                    ActionButton(
+                        modifier = Modifier.weight(1f),
+                        title = stringResource(it.stringRes),
+                        icon = it.icon,
+                        onClick = it.onClick,
+                    )
                 }
             }
         }

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
@@ -42,6 +42,7 @@ fun EmptyScreen(
     actions: ImmutableList<EmptyScreenAction>? = null,
     // KMK -->
     help: @Composable (() -> Unit)? = null,
+    topInfo: @Composable (() -> Unit)? = null,
     // KMK <--
 ) {
     EmptyScreen(
@@ -50,6 +51,7 @@ fun EmptyScreen(
         actions = actions,
         // KMK -->
         help = help,
+        topInfo = topInfo,
         // KMK <--
     )
 }
@@ -61,51 +63,60 @@ fun EmptyScreen(
     actions: ImmutableList<EmptyScreenAction>? = null,
     // KMK -->
     help: @Composable (() -> Unit)? = null,
+    topInfo: @Composable (() -> Unit)? = null,
     // KMK <--
 ) {
     val face = remember { getRandomErrorFace() }
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
-            Text(
-                text = face,
-                modifier = Modifier.secondaryItemAlpha(),
-                style = MaterialTheme.typography.displayMedium,
-            )
-        }
-
-        Text(
-            text = message,
-            modifier = Modifier
-                .paddingFromBaseline(top = 24.dp)
-                .secondaryItemAlpha(),
-            style = MaterialTheme.typography.bodyMedium,
-            textAlign = TextAlign.Center,
-        )
-
+        modifier = modifier.fillMaxSize(),
         // KMK -->
-        help?.let { help() }
-        // KMK <--
+    ) {
+        topInfo?.let { topInfo() }
 
-        if (!actions.isNullOrEmpty()) {
-            Row(
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                // KMK <--
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                Text(
+                    text = face,
+                    modifier = Modifier.secondaryItemAlpha(),
+                    style = MaterialTheme.typography.displayMedium,
+                )
+            }
+
+            Text(
+                text = message,
                 modifier = Modifier
-                    .padding(top = 24.dp),
-                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
-            ) {
-                actions.fastForEach {
-                    ActionButton(
-                        modifier = Modifier.weight(1f),
-                        title = stringResource(it.stringRes),
-                        icon = it.icon,
-                        onClick = it.onClick,
-                    )
+                    .paddingFromBaseline(top = 24.dp)
+                    .secondaryItemAlpha(),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+            )
+
+            // KMK -->
+            help?.let { help() }
+            // KMK <--
+
+            if (!actions.isNullOrEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .padding(top = 24.dp),
+                    horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+                ) {
+                    actions.fastForEach {
+                        ActionButton(
+                            modifier = Modifier.weight(1f),
+                            title = stringResource(it.stringRes),
+                            icon = it.icon,
+                            onClick = it.onClick,
+                        )
+                    }
                 }
             }
         }

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/screens/EmptyScreen.kt
@@ -71,7 +71,7 @@ fun EmptyScreen(
         modifier = modifier.fillMaxSize(),
         // KMK -->
     ) {
-        topInfo?.let { topInfo() }
+        topInfo?.invoke()
 
         Column(
             modifier = Modifier
@@ -100,7 +100,7 @@ fun EmptyScreen(
             )
 
             // KMK -->
-            help?.let { help() }
+            help?.invoke()
             // KMK <--
 
             if (!actions.isNullOrEmpty()) {


### PR DESCRIPTION
- Decluster by hiding all grouped library-tabs which is empty when applying filter/query-search.

## Summary by Sourcery

Hide empty library tabs when searching or filtering and enhance the empty library screen with a global search prompt.

Enhancements:
- Filter out and hide empty library tabs during searches or when filters are applied by updating the grouping logic in LibraryScreenModel

## Summary by Sourcery

Hide empty library tabs when a search query or filters are active and update the empty library screen to correctly invoke the help callback for a global search prompt

New Features:
- Hide empty library groups during search or filters to declutter the library view

Enhancements:
- Return a default empty category when all groups are filtered out
- Invoke the help callback in the empty-library screen via help?.invoke() to enable a global search prompt