### PR TITLE
feat(library): Keep tabs when exclude-only categories filtering

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -322,7 +322,7 @@ class LibraryScreenModel(
                 ) + trackFilter.values
                 ).any { it != TriState.DISABLED } ||
                 // KMK -->
-                state.value.filterCategory
+                prefs.filterCategories
             // KMK <--
         }
             .distinctUntilChanged()
@@ -650,6 +650,7 @@ class LibraryScreenModel(
             // KMK -->
             libraryPreferences.sourceBadge().changes(),
             libraryPreferences.useLangIcon().changes(),
+            libraryPreferences.filterCategories().changes(),
             // KMK <--
         ) {
             ItemPreferences(
@@ -671,6 +672,7 @@ class LibraryScreenModel(
                 // KMK -->
                 sourceBadge = it[13] as Boolean,
                 useLangIcon = it[14] as Boolean,
+                filterCategories = it[15] as Boolean,
             )
         }
     }
@@ -1602,6 +1604,9 @@ class LibraryScreenModel(
         // SY -->
         val filterLewd: TriState,
         // SY <--
+        // KMK -->
+        val filterCategories: Boolean,
+        // KMK <--
     )
 
     @Immutable

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -367,18 +367,21 @@ class LibraryScreenModel(
 
         // KMK -->
         libraryPreferences.filterCategories().changes()
+            .distinctUntilChanged()
             .onEach {
                 mutableState.update { state ->
                     state.copy(filterCategory = it)
                 }
             }.launchIn(screenModelScope)
         libraryPreferences.filterCategoriesInclude().changes()
+            .distinctUntilChanged()
             .onEach {
                 mutableState.update { state ->
                     state.copy(includedCategories = it.mapNotNull(String::toLongOrNull).toImmutableSet())
                 }
             }.launchIn(screenModelScope)
         libraryPreferences.filterCategoriesExclude().changes()
+            .distinctUntilChanged()
             .onEach {
                 mutableState.update { state ->
                     state.copy(excludedCategories = it.mapNotNull(String::toLongOrNull).toImmutableSet())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -198,21 +198,41 @@ class LibraryScreenModel(
                 combine(
                     state.map { it.groupType }.distinctUntilChanged(),
                     libraryPreferences.sortingMode().changes(),
-                    ::Pair,
+                    // KMK -->
+                    state.map { it.searchQuery.isNullOrBlank() && !it.hasActiveFilters }.distinctUntilChanged(),
+                    ::Triple,
+                    // KMK <--
                 ),
                 // SY <--
                 // KMK -->
                 combine(
-                    getCategoriesPerLibraryManga.subscribe(),
-                    state.map { it.filterCategory }.distinctUntilChanged(),
-                    state.map { it.searchQuery.isNullOrBlank() && !it.hasActiveFilters }.distinctUntilChanged(),
-                    ::Triple,
+                    combine(
+                        getCategoriesPerLibraryManga.subscribe(),
+                        state.map { it.filterCategory }.distinctUntilChanged(),
+                        ::Pair,
+                    ),
+                    combine(
+                        state.map { it.includedCategories }.distinctUntilChanged(),
+                        state.map { it.excludedCategories }.distinctUntilChanged(),
+                        ::Pair,
+                    ),
+                    ::Pair,
                 ),
                 // KMK <--
-            ) { (searchQuery, library, _), (tracks, trackingFilter), (groupType, sort), (categoriesPerManga, filterCategory, noActiveFilterOrSearch) ->
+            ) { (searchQuery, library, _), (tracks, trackingFilter), (groupType, sort, noActiveFilterOrSearch), (categoryFilters, filteredCategories) ->
+                val (categoriesPerManga, filterCategory) = categoryFilters
+                val (includedCategories, _) = filteredCategories
                 library
                     // SY -->
-                    .applyGrouping(/* KMK --> */ if (filterCategory) LibraryGroup.UNGROUPED else /* KMK <-- */ groupType)
+                    .applyGrouping(
+                        // KMK -->
+                        if (filterCategory && includedCategories.isNotEmpty()) {
+                            LibraryGroup.UNGROUPED
+                        } else {
+                            // KMK <--
+                            groupType
+                        },
+                    )
                     // SY <--
                     .applyFilters(
                         tracks,
@@ -302,7 +322,7 @@ class LibraryScreenModel(
                 ) + trackFilter.values
                 ).any { it != TriState.DISABLED } ||
                 // KMK -->
-                prefs.filterCategories
+                state.value.filterCategory
             // KMK <--
         }
             .distinctUntilChanged()
@@ -350,6 +370,18 @@ class LibraryScreenModel(
             .onEach {
                 mutableState.update { state ->
                     state.copy(filterCategory = it)
+                }
+            }.launchIn(screenModelScope)
+        libraryPreferences.filterCategoriesInclude().changes()
+            .onEach {
+                mutableState.update { state ->
+                    state.copy(includedCategories = it.mapNotNull(String::toLongOrNull).toImmutableSet())
+                }
+            }.launchIn(screenModelScope)
+        libraryPreferences.filterCategoriesExclude().changes()
+            .onEach {
+                mutableState.update { state ->
+                    state.copy(excludedCategories = it.mapNotNull(String::toLongOrNull).toImmutableSet())
                 }
             }.launchIn(screenModelScope)
 
@@ -400,12 +432,6 @@ class LibraryScreenModel(
         // SY -->
         val filterLewd = prefs.filterLewd
         // SY <--
-
-        // KMK -->
-        val filterCategories = prefs.filterCategories
-        val includedCategories = prefs.filterCategoriesInclude
-        val excludedCategories = prefs.filterCategoriesExclude
-        // KMK <--
 
         val filterFnDownloaded: (LibraryItem) -> Boolean = {
             applyFilter(filterDownloaded) {
@@ -460,12 +486,12 @@ class LibraryScreenModel(
 
         // KMK -->
         val filterFnCategories: (LibraryItem) -> Boolean = categories@{ item ->
-            if (!filterCategories) return@categories true
+            if (!state.value.filterCategory) return@categories true
 
             val mangaCategories = categoriesPerManga[item.libraryManga.id].orEmpty()
 
-            val isExcluded = excludedCategories.any { it in mangaCategories }
-            val isIncluded = includedCategories.isEmpty() || includedCategories.all { it in mangaCategories }
+            val isExcluded = state.value.excludedCategories.any { it in mangaCategories }
+            val isIncluded = state.value.includedCategories.isEmpty() || state.value.includedCategories.all { it in mangaCategories }
 
             !isExcluded && isIncluded
         }
@@ -624,9 +650,6 @@ class LibraryScreenModel(
             // KMK -->
             libraryPreferences.sourceBadge().changes(),
             libraryPreferences.useLangIcon().changes(),
-            libraryPreferences.filterCategories().changes(),
-            libraryPreferences.filterCategoriesInclude().changes(),
-            libraryPreferences.filterCategoriesExclude().changes(),
             // KMK <--
         ) {
             ItemPreferences(
@@ -648,10 +671,6 @@ class LibraryScreenModel(
                 // KMK -->
                 sourceBadge = it[13] as Boolean,
                 useLangIcon = it[14] as Boolean,
-                filterCategories = it[15] as Boolean,
-                filterCategoriesInclude = (it[16] as Set<*>).filterIsInstance<String>().mapNotNull(String::toLongOrNull).toImmutableSet(),
-                filterCategoriesExclude = (it[17] as Set<*>).filterIsInstance<String>().mapNotNull(String::toLongOrNull).toImmutableSet(),
-                // KMK <--
             )
         }
     }
@@ -1583,11 +1602,6 @@ class LibraryScreenModel(
         // SY -->
         val filterLewd: TriState,
         // SY <--
-        // KMK -->
-        val filterCategories: Boolean,
-        val filterCategoriesInclude: ImmutableSet<Long>,
-        val filterCategoriesExclude: ImmutableSet<Long>,
-        // KMK <--
     )
 
     @Immutable
@@ -1610,6 +1624,8 @@ class LibraryScreenModel(
         // KMK -->
         val libraryCategories: List<Category> = emptyList(),
         val filterCategory: Boolean = false,
+        val includedCategories: ImmutableSet<Long> = emptySet<Long>().toImmutableSet(),
+        val excludedCategories: ImmutableSet<Long> = emptySet<Long>().toImmutableSet(),
         // KMK <--
     ) {
         private val libraryCount by lazy {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -65,6 +65,7 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.mutate
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -1632,8 +1633,8 @@ class LibraryScreenModel(
         // KMK -->
         val libraryCategories: List<Category> = emptyList(),
         val filterCategory: Boolean = false,
-        val includedCategories: ImmutableSet<Long> = emptySet<Long>().toImmutableSet(),
-        val excludedCategories: ImmutableSet<Long> = emptySet<Long>().toImmutableSet(),
+        val includedCategories: ImmutableSet<Long> = persistentSetOf(),
+        val excludedCategories: ImmutableSet<Long> = persistentSetOf(),
         // KMK <--
     ) {
         private val libraryCount by lazy {


### PR DESCRIPTION
When filtering library with exclude-only categories, it should keep original grouped tabs.

Close #968

## Summary by Sourcery

Introduce distinct include/exclude category filtering in the library and maintain original grouping tabs when only exclusion filters are applied

New Features:
- Add separate include and exclude category filters for library items
- Preserve original library grouping tabs when filtering by excluded categories only

Enhancements:
- Refactor LibraryScreenModel to track includedCategories and excludedCategories in state
- Remove legacy filterCategories flag and streamline preference flows
- Update filter logic to use new include/exclude category state values

## Summary by Sourcery

Separate category filtering into include and exclude sets, refactor state handling accordingly, and maintain original library grouping tabs when only exclusion filters are active

New Features:
- Introduce separate include and exclude category filters for library items
- Preserve original grouping tabs when filtering by excluded categories only

Enhancements:
- Refactor LibraryScreenModel to track includedCategories and excludedCategories in state and remove legacy filterCategories flag
- Streamline category filter logic to use distinct include/exclude sets