### PR TITLE
fix(track): wrongly set track's status when start tracking

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/interactor/AddTracks.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/AddTracks.kt
@@ -53,10 +53,17 @@ class AddTracks(
                     ?.chapterNumber ?: -1.0
 
                 if (latestLocalReadChapterNumber > track.lastChapterRead) {
+                    /* KMK -->
+                    // This code causes issue NOT settings remote-track's status
                     track = track.copy(
                         lastChapterRead = latestLocalReadChapterNumber,
                     )
+                    KMK <-- */
                     tracker.setRemoteLastChapterRead(track.toDbTrack(), latestLocalReadChapterNumber.toInt())
+                        // KMK -->
+                        .toDomainTrack(idRequired = false)
+                        ?.let { track = it }
+                    // KMK <--
                 }
 
                 if (track.startDate <= 0) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/BaseTracker.kt
@@ -93,7 +93,7 @@ abstract class BaseTracker(
         updateRemote(track)
     }
 
-    override suspend fun setRemoteLastChapterRead(track: Track, chapterNumber: Int) {
+    override suspend fun setRemoteLastChapterRead(track: Track, chapterNumber: Int): /* KMK --> */ Track /* KMK <-- */ {
         if (
             track.last_chapter_read == 0.0 &&
             track.last_chapter_read < chapterNumber &&
@@ -107,6 +107,9 @@ abstract class BaseTracker(
             track.finished_reading_date = System.currentTimeMillis()
         }
         updateRemote(track)
+        // KMK -->
+        return track
+        // KMK <--
     }
 
     override suspend fun setRemoteScore(track: Track, scoreString: String) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/Tracker.kt
@@ -78,7 +78,7 @@ interface Tracker {
 
     suspend fun setRemoteStatus(track: Track, status: Long)
 
-    suspend fun setRemoteLastChapterRead(track: Track, chapterNumber: Int)
+    suspend fun setRemoteLastChapterRead(track: Track, chapterNumber: Int): /* KMK --> */ Track /* KMK <-- */
 
     suspend fun setRemoteScore(track: Track, scoreString: String)
 

--- a/app/src/main/java/eu/kanade/test/DummyTracker.kt
+++ b/app/src/main/java/eu/kanade/test/DummyTracker.kt
@@ -105,7 +105,7 @@ data class DummyTracker(
     override suspend fun setRemoteLastChapterRead(
         track: eu.kanade.tachiyomi.data.database.models.Track,
         chapterNumber: Int,
-    ) = Unit
+    ) /* KMK --> */ = track /* KMK <-- */
 
     override suspend fun setRemoteScore(
         track: eu.kanade.tachiyomi.data.database.models.Track,


### PR DESCRIPTION
Track's status was wrongly set when start tracking.

- Reproduce:
  1. Set entry on tracker's website as `Wish List` or something other from Reading
  2. Read a few chapters in the App
  3. Start tracking

- Expected behavior:
  - Track status should be `Reading`
  - Track chapter should be same as current read in App
  - Tracker's website should show same information

- Actual behavior:
  - Right after adding, Track's dialog shows: `Wish List` instead of `Reading`, but with correct readin progress.
  - Close the dialog and open again, it now shows `Wish List` with reading progress 0.

- Causes:
  - After found the remote track, App was trying to set reading progress with `setRemoteLastChapterRead` but wrongly set `lastChapterRead` to `latestLocalReadChapterNumber` before the comparision, making it didn't update remote track's status to `Reading`
  - Even if correctly updated remote track's status to `Reading` with `setRemoteLastChapterRead`, it continued with using old track's info to `setRemoteStartDate` which causing the remote status to revert back to `Wish List` and reading progress to 0

This was tested with MangaUpdates, which doesn't allow setting reading progress if status is `Wish List`. Other trackers might automatically set status to `Reading` when `setRemoteLastChapterRead` so the issue does not appear.

## Summary by Sourcery

Ensure track status transitions to "Reading" properly by capturing and using the updated Track returned from remote chapter updates, removing premature local state overrides.

Bug Fixes:
- Prevent track status and progress from reverting to the original status by capturing and propagating the updated Track returned by setRemoteLastChapterRead.

Enhancements:
- Change setRemoteLastChapterRead to return the updated Track and update the Tracker interface, BaseTracker, and DummyTracker implementations accordingly