### PR TITLE
fix(scroller): Fix crash when no visible items are found in VerticalFastScroller

### DIFF
--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/VerticalFastScroller.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/VerticalFastScroller.kt
@@ -403,7 +403,10 @@ private fun computeScrollOffset(state: LazyListState): Int {
     if (state.layoutInfo.totalItemsCount == 0) return 0
     val visibleItems = state.layoutInfo.visibleItemsInfo
     val startChild = visibleItems
-        .fastFirstOrNull { (it.key as? String)?.startsWith(STICKY_HEADER_KEY_PREFIX)?.not() ?: true }!!
+        .fastFirstOrNull { (it.key as? String)?.startsWith(STICKY_HEADER_KEY_PREFIX)?.not() ?: true }
+        // KMK -->
+        ?: return 0
+    // KMK <--
     val endChild = visibleItems.last()
     val minPosition = min(startChild.index, endChild.index)
     val maxPosition = max(startChild.index, endChild.index)
@@ -419,7 +422,10 @@ private fun computeScrollRange(state: LazyListState): Int {
     if (state.layoutInfo.totalItemsCount == 0) return 0
     val visibleItems = state.layoutInfo.visibleItemsInfo
     val startChild = visibleItems
-        .fastFirstOrNull { (it.key as? String)?.startsWith(STICKY_HEADER_KEY_PREFIX)?.not() ?: true }!!
+        .fastFirstOrNull { (it.key as? String)?.startsWith(STICKY_HEADER_KEY_PREFIX)?.not() ?: true }
+        // KMK -->
+        ?: return 0
+    // KMK <--
     val endChild = visibleItems.last()
     val laidOutArea = endChild.bottom - startChild.top
     val laidOutRange = abs(startChild.index - endChild.index) + 1


### PR DESCRIPTION
Handle the case where no visible items are present in the VerticalFastScroller to prevent crashes. Return early with a default value when no items are found.

- Reproduce:
  1. Set phone's language to any language but English
  2. Install some extensions, not English or Multi
  3. Clear app data
  4. Start app, don't add Repo, go to Extensions to Trust 1 ext
  5. Back to Sources tab, click Filter

- Causes: When click Filter to show `SourcesFilterScreen`, the `VerticalFastScroll` only has 1 entry (which is one disabled language), but somehow when `computeScrollOffset` && `computeScrollRange` it got empty and assert null access