### PR TITLE
fix(UI): Fix repo dialog width on wide screen

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/components/ExtensionReposDialogs.kt
@@ -1,6 +1,7 @@
 package eu.kanade.presentation.more.settings.screen.browse.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.OutlinedTextField
@@ -61,6 +62,7 @@ fun ExtensionRepoCreateDialog(
 
                 OutlinedTextField(
                     modifier = Modifier
+                        .fillMaxWidth()
                         .focusRequester(focusRequester),
                     value = name,
                     onValueChange = { name = it },


### PR DESCRIPTION
Adjust the width of the repository dialog to ensure proper display on wide screens.

## Summary by Sourcery

Bug Fixes:
- Add fillMaxWidth modifier to the OutlinedTextField in ExtensionRepoCreateDialog to fix dialog width on wide displays