### PR TITLE
chore(db): Remove unused filtered_scanlators field

### DIFF
--- a/app/src/main/baseline-prof.txt
+++ b/app/src/main/baseline-prof.txt
@@ -33013,7 +33013,6 @@ Ltachiyomi/domain/manga/interactor/SetFetchInterval;
 HSPLtachiyomi/domain/manga/interactor/SetFetchInterval;-><init>(Ltachiyomi/domain/chapter/interactor/GetChapterByMangaId;)V
 PLtachiyomi/domain/manga/interactor/SetFetchInterval;-><init>(Ltachiyomi/domain/chapter/interactor/GetChapterByMangaId;)V
 Ltachiyomi/domain/manga/interactor/SetMangaChapterFlags;
-Ltachiyomi/domain/manga/interactor/SetMangaFilteredScanlators;
 Ltachiyomi/domain/manga/interactor/UpdateMergedSettings;
 Ltachiyomi/domain/manga/repository/CustomMangaRepository;
 Ltachiyomi/domain/manga/repository/FavoritesEntryRepository;

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ScanlatorFilterDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ScanlatorFilterDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CheckBoxOutlineBlank
@@ -55,43 +56,45 @@ fun ScanlatorFilterDialog(
             Box {
                 val state = rememberLazyListState()
                 LazyColumn(state = state) {
-                    sortedAvailableScanlators.forEach { scanlator ->
-                        item {
-                            val isExcluded = mutableExcludedScanlators.contains(scanlator)
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier
-                                    .clickable {
-                                        if (isExcluded) {
-                                            mutableExcludedScanlators.remove(scanlator)
-                                        } else {
-                                            mutableExcludedScanlators.add(scanlator)
-                                        }
+                    items(
+                        items = sortedAvailableScanlators,
+                        contentType = { "item" },
+                        key = { it },
+                    ) { scanlator ->
+                        val isExcluded = mutableExcludedScanlators.contains(scanlator)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .clickable {
+                                    if (isExcluded) {
+                                        mutableExcludedScanlators.remove(scanlator)
+                                    } else {
+                                        mutableExcludedScanlators.add(scanlator)
                                     }
-                                    .minimumInteractiveComponentSize()
-                                    .clip(MaterialTheme.shapes.small)
-                                    .fillMaxWidth()
-                                    .padding(horizontal = MaterialTheme.padding.small),
-                            ) {
-                                Icon(
-                                    imageVector = if (isExcluded) {
-                                        Icons.Rounded.DisabledByDefault
-                                    } else {
-                                        Icons.Rounded.CheckBoxOutlineBlank
-                                    },
-                                    tint = if (isExcluded) {
-                                        MaterialTheme.colorScheme.primary
-                                    } else {
-                                        LocalContentColor.current
-                                    },
-                                    contentDescription = null,
-                                )
-                                Text(
-                                    text = scanlator,
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    modifier = Modifier.padding(start = 24.dp),
-                                )
-                            }
+                                }
+                                .minimumInteractiveComponentSize()
+                                .clip(MaterialTheme.shapes.small)
+                                .fillMaxWidth()
+                                .padding(horizontal = MaterialTheme.padding.small),
+                        ) {
+                            Icon(
+                                imageVector = if (isExcluded) {
+                                    Icons.Rounded.DisabledByDefault
+                                } else {
+                                    Icons.Rounded.CheckBoxOutlineBlank
+                                },
+                                tint = if (isExcluded) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    LocalContentColor.current
+                                },
+                                contentDescription = null,
+                            )
+                            Text(
+                                text = scanlator,
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.padding(start = 24.dp),
+                            )
                         }
                     }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -609,10 +609,12 @@ class MangaRestorer(
         if (excludedScanlators.isEmpty()) return
         val existingExcludedScanlators = handler.awaitList {
             excluded_scanlatorsQueries.getExcludedScanlatorsByMangaId(manga.id)
-        }
-        val toInsert = excludedScanlators.filter { it !in existingExcludedScanlators }
+            // KMK -->
+        }.toSet()
+        val toInsert = excludedScanlators.toSet().subtract(existingExcludedScanlators)
         if (toInsert.isNotEmpty()) {
-            handler.await {
+            handler.await(inTransaction = true) {
+                // KMK <--
                 toInsert.forEach {
                     excluded_scanlatorsQueries.insert(manga.id, it)
                 }

--- a/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
@@ -25,10 +25,6 @@ object MangaMapper {
         chapterFlags: Long,
         coverLastModified: Long,
         dateAdded: Long,
-        // SY -->
-        @Suppress("UNUSED_PARAMETER")
-        filteredScanlators: String?,
-        // SY <--
         updateStrategy: UpdateStrategy,
         calculateInterval: Long,
         lastModifiedAt: Long,
@@ -85,9 +81,6 @@ object MangaMapper {
         chapterFlags: Long,
         coverLastModified: Long,
         dateAdded: Long,
-        // SY -->
-        filteredScanlators: String?,
-        // SY <--
         updateStrategy: UpdateStrategy,
         calculateInterval: Long,
         lastModifiedAt: Long,
@@ -125,9 +118,6 @@ object MangaMapper {
             chapterFlags,
             coverLastModified,
             dateAdded,
-            // SY -->
-            filteredScanlators,
-            // SY <--
             updateStrategy,
             calculateInterval,
             lastModifiedAt,
@@ -168,9 +158,6 @@ object MangaMapper {
         chapterFlags: Long,
         coverLastModified: Long,
         dateAdded: Long,
-        // SY -->
-        filteredScanlators: String?,
-        // SY <--
         updateStrategy: UpdateStrategy,
         calculateInterval: Long,
         lastModifiedAt: Long,
@@ -199,9 +186,6 @@ object MangaMapper {
             chapterFlags,
             coverLastModified,
             dateAdded,
-            // SY -->
-            filteredScanlators,
-            // SY <--
             updateStrategy,
             calculateInterval,
             lastModifiedAt,

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -22,7 +22,6 @@ CREATE TABLE mangas(
     chapter_flags INTEGER NOT NULL,
     cover_last_modified INTEGER NOT NULL,
     date_added INTEGER NOT NULL,
-    filtered_scanlators TEXT,
     update_strategy INTEGER AS UpdateStrategy NOT NULL DEFAULT 0,
     calculate_interval INTEGER DEFAULT 0 NOT NULL,
     last_modified_at INTEGER NOT NULL DEFAULT 0,

--- a/data/src/main/sqldelight/tachiyomi/migrations/41.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/41.sqm
@@ -1,0 +1,3 @@
+-- Remove filtered_scanlators column
+ALTER TABLE mangas
+DROP COLUMN filtered_scanlators;

--- a/domain/src/main/java/tachiyomi/domain/manga/model/MangaUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/MangaUpdate.kt
@@ -25,9 +25,6 @@ data class MangaUpdate(
     val initialized: Boolean? = null,
     val version: Long? = null,
     val notes: String? = null,
-    // SY -->
-    val filteredScanlators: List<String>? = null,
-    // SY <--
 )
 
 fun Manga.toMangaUpdate(): MangaUpdate {


### PR DESCRIPTION
Eliminate the filtered_scanlators field from the codebase as it is no longer utilized, while also improving code quality and structure.