### PR TITLE
feat: Add option to disable pinch to zoom in webtoon viewer

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -445,6 +445,10 @@ object SettingsReaderScreen : SearchableSettings {
                     preference = readerPreferences.webtoonDisableZoomOut(),
                     title = stringResource(MR.strings.pref_webtoon_disable_zoom_out),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.webtoonDisablePinchToZoom(),
+                    title = stringResource(MR.strings.pref_webtoon_disable_pinch_to_zoom),
+                ),
                 // SY -->
                 Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.pageTransitionsWebtoon(),

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -269,6 +269,10 @@ private fun ColumnScope.WebtoonViewerSettings(screenModel: ReaderSettingsScreenM
         label = stringResource(MR.strings.pref_webtoon_disable_zoom_out),
         pref = screenModel.preferences.webtoonDisableZoomOut(),
     )
+    CheckboxItem(
+        label = stringResource(MR.strings.pref_webtoon_disable_pinch_to_zoom),
+        pref = screenModel.preferences.webtoonDisablePinchToZoom(),
+    )
 }
 
 // SY -->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -83,6 +83,8 @@ class ReaderPreferences(
 
     fun webtoonDisableZoomOut() = preferenceStore.getBoolean("webtoon_disable_zoom_out", false)
 
+    fun webtoonDisablePinchToZoom() = preferenceStore.getBoolean("webtoon_disable_pinch_to_zoom", false)
+
     // endregion
 
     // region Split two page spread

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -42,6 +42,11 @@ class WebtoonConfig(
 
     var doubleTapZoomChangedListener: ((Boolean) -> Unit)? = null
 
+    var pinchToZoomDisabled = false
+        private set
+
+    var pinchToZoomChangedListener: ((Boolean) -> Unit)? = null
+
     // SY -->
     var usePageTransitions = false
 
@@ -100,6 +105,12 @@ class WebtoonConfig(
             .register(
                 { doubleTapZoom = it },
                 { doubleTapZoomChangedListener?.invoke(it) },
+            )
+
+        readerPreferences.webtoonDisablePinchToZoom()
+            .register(
+                { pinchToZoomDisabled = it },
+                { pinchToZoomChangedListener?.invoke(it) },
             )
 
         readerPreferences.readerTheme().changes()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonFrame.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonFrame.kt
@@ -39,6 +39,12 @@ class WebtoonFrame(context: Context) : FrameLayout(context) {
             recycler?.zoomOutDisabled = value
         }
 
+    var pinchToZoomDisabled = false
+        set(value) {
+            field = value
+            recycler?.pinchToZoomDisabled = value
+        }
+
     /**
      * Recycler view added in this frame.
      */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
@@ -49,6 +49,8 @@ class WebtoonRecyclerView @JvmOverloads constructor(
 
     var doubleTapZoom = true
 
+    var pinchToZoomDisabled = false
+
     var tapListener: ((MotionEvent) -> Unit)? = null
     var longTapListener: ((MotionEvent) -> Boolean)? = null
 
@@ -174,6 +176,8 @@ class WebtoonRecyclerView @JvmOverloads constructor(
     }
 
     fun onScale(scaleFactor: Float) {
+        if (!detector.isQuickScaling && pinchToZoomDisabled) return
+
         currentScale *= scaleFactor
         currentScale = currentScale.coerceIn(
             minRate,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -173,6 +173,10 @@ class WebtoonViewer(
             frame.zoomOutDisabled = it
         }
 
+        config.pinchToZoomChangedListener = {
+            frame.pinchToZoomDisabled = it
+        }
+
         config.navigationModeChangedListener = {
             val showOnStart = config.navigationOverlayOnStart || config.forceNavigationOverlay
             activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -495,6 +495,7 @@
     <string name="pref_low">Low</string>
     <string name="pref_lowest">Lowest</string>
     <string name="pref_webtoon_disable_zoom_out">Disable zoom out</string>
+    <string name="pref_webtoon_disable_pinch_to_zoom">Disable pinch to zoom</string>
 
       <!-- Downloads section -->
     <string name="pref_category_delete_chapters">Delete chapters</string>


### PR DESCRIPTION
This introduces a new preference to disable pinch to zoom functionality in the webtoon reader.

When enabled, this setting prevents users from zooming in or out using pinch gestures. This can be useful for users who prefer a fixed zoom level or want to avoid accidental zooming.

The following changes were made:
- Added a new preference `webtoonDisablePinchToZoom` in `ReaderPreferences`.
- Updated `WebtoonConfig` to include the new preference and a listener for changes.
- Updated `WebtoonViewer`, `WebtoonFrame` and `WebtoonRecyclerView` to account for the new preference
- Added a new toggle switch for the preference in the global reader settings (`SettingsReaderScreen.kt`) and a checkbox in the in-reader settings (`ReadingModePage.kt`).
- Added a new string resource `pref_webtoon_disable_pinch_to_zoom`.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
