### PR TITLE
feat: Add WebMAV synchronization service

### DIFF
--- a/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
@@ -18,6 +18,11 @@ class SyncPreferences(
     fun syncInterval() = preferenceStore.getInt("sync_interval", 0)
     fun syncService() = preferenceStore.getInt("sync_service", 0)
 
+    fun webDavUrl() = preferenceStore.getString("webdav_url", "")
+    fun webDavUsername() = preferenceStore.getString("webdav_username", "")
+    fun webDavPassword() = preferenceStore.getString("webdav_password", "")
+    fun webDavFolder() = preferenceStore.getString("webdav_folder", "komikku")
+
     fun googleDriveAccessToken() = preferenceStore.getString(
         Preference.appStateKey("google_drive_access_token"),
         "",

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -559,6 +559,7 @@ object SettingsDataScreen : SearchableSettings {
                             SyncManager.SyncService.NONE.value to stringResource(MR.strings.off),
                             SyncManager.SyncService.SYNCYOMI.value to stringResource(SYMR.strings.syncyomi),
                             SyncManager.SyncService.GOOGLE_DRIVE.value to stringResource(SYMR.strings.google_drive),
+                            SyncManager.SyncService.WebDAV.value to stringResource(SYMR.strings.web_dav),
                         ),
                         title = stringResource(SYMR.strings.pref_sync_service),
                         onValueChanged = { true },
@@ -591,6 +592,7 @@ object SettingsDataScreen : SearchableSettings {
             SyncManager.SyncService.NONE -> emptyList()
             SyncManager.SyncService.SYNCYOMI -> getSelfHostPreferences(syncPreferences)
             SyncManager.SyncService.GOOGLE_DRIVE -> getGoogleDrivePreferences()
+            SyncManager.SyncService.WebDAV -> getWebDavPreferences(syncPreferences)
         }
 
         return if (syncServiceType != SyncManager.SyncService.NONE) {
@@ -762,6 +764,60 @@ object SettingsDataScreen : SearchableSettings {
             },
         )
     }
+
+
+    @Composable
+    private fun getWebDavPreferences(syncPreferences: SyncPreferences): List<Preference> {
+        val scope = rememberCoroutineScope()
+
+        return listOf(
+            Preference.PreferenceItem.EditTextPreference(
+                preference = syncPreferences.webDavUrl(),
+                title = stringResource(SYMR.strings.pref_webdav_url),
+                subtitle = stringResource(SYMR.strings.pref_webdav_url_summ),
+                onValueChanged = { newValue ->
+                    scope.launch {
+                        syncPreferences.webDavUrl().set(newValue.trim())
+                    }
+                    true
+                },
+            ),
+            Preference.PreferenceItem.EditTextPreference(
+                preference = syncPreferences.webDavUsername(),
+                title = stringResource(SYMR.strings.pref_webdav_username),
+                subtitle = stringResource(SYMR.strings.pref_webdav_username_summ),
+                onValueChanged = { newValue ->
+                    scope.launch {
+                        syncPreferences.webDavUsername().set(newValue)
+                    }
+                    true
+                },
+            ),
+            Preference.PreferenceItem.EditTextPreference(
+                preference = syncPreferences.webDavPassword(),
+                title = stringResource(SYMR.strings.pref_webdav_password),
+                subtitle = stringResource(SYMR.strings.pref_webdav_password_summ),
+                onValueChanged = { newValue ->
+                    scope.launch {
+                        syncPreferences.webDavPassword().set(newValue)
+                    }
+                    true
+                },
+            ),
+            Preference.PreferenceItem.EditTextPreference(
+                preference = syncPreferences.webDavFolder(),
+                title = stringResource(SYMR.strings.pref_webdav_folder),
+                subtitle = stringResource(SYMR.strings.pref_webdav_folder_summ),
+                onValueChanged = { newValue ->
+                    scope.launch {
+                        syncPreferences.webDavFolder().set(newValue)
+                    }
+                    true
+                }
+            )
+        )
+    }
+
 
     @Composable
     private fun getSyncNowPref(): Preference.PreferenceGroup {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaRestorer
 import eu.kanade.tachiyomi.data.sync.service.GoogleDriveSyncService
 import eu.kanade.tachiyomi.data.sync.service.SyncData
 import eu.kanade.tachiyomi.data.sync.service.SyncYomiSyncService
+import eu.kanade.tachiyomi.data.sync.service.WebDavSyncService
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.protobuf.ProtoBuf
 import logcat.LogPriority
@@ -55,6 +56,7 @@ class SyncManager(
         NONE(0),
         SYNCYOMI(1),
         GOOGLE_DRIVE(2),
+        WebDAV(3),
         ;
 
         companion object {
@@ -135,6 +137,10 @@ class SyncManager(
 
             SyncService.GOOGLE_DRIVE -> {
                 GoogleDriveSyncService(context, json, syncPreferences)
+            }
+
+            SyncService.WebDAV -> {
+                WebDavSyncService(context, json, syncPreferences, notifier)
             }
 
             else -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/WebDavSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/WebDavSyncService.kt
@@ -1,0 +1,163 @@
+package eu.kanade.tachiyomi.data.sync.service
+
+import android.content.Context
+import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.sync.SyncNotifier
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.PUT
+import eu.kanade.tachiyomi.network.await
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.protobuf.ProtoBuf
+import logcat.LogPriority
+import logcat.logcat
+import okhttp3.Credentials
+import okhttp3.Headers
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.apache.http.HttpStatus
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.concurrent.TimeUnit
+
+class WebDavSyncService(
+    context: Context,
+    json: Json,
+    syncPreferences: SyncPreferences,
+    private val notifier: SyncNotifier,
+    private val protoBuf: ProtoBuf = Injekt.get(),
+) : SyncService(context, json, syncPreferences) {
+
+    private class WebDavException(message: String?) : Exception(message)
+
+    private fun buildWebDavFileUrl(baseUrl: String, folder: String, fileName: String): String {
+        val cleanBase = baseUrl.trimEnd('/')
+        val cleanFolder = folder.trim('/')
+        return if (cleanFolder.isNotEmpty()) {
+            "$cleanBase/$cleanFolder/$fileName"
+        } else {
+            "$cleanBase/$fileName"
+        }
+    }
+
+
+    override suspend fun doSync(syncData: SyncData): Backup? {
+        try {
+            val (remoteData, etag) = pullSyncData()
+
+            val finalSyncData = if (remoteData != null) {
+                assert(etag.isNotEmpty()) { "ETag should never be empty if remote data is not null" }
+                logcat(LogPriority.DEBUG) { "Merging local and remote data with ETag($etag)" }
+                mergeSyncData(syncData, remoteData)
+            } else {
+                logcat(LogPriority.DEBUG) { "No remote data, using local syncData" }
+                syncData
+            }
+
+            pushSyncData(finalSyncData, etag)
+            return finalSyncData.backup
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR) { "WebDAV sync error: ${e.message}" }
+            notifier.showSyncError(e.message)
+            return null
+        }
+    }
+
+    private suspend fun pullSyncData(): Pair<SyncData?, String> {
+        val url = syncPreferences.webDavUrl().get()
+        val folder = syncPreferences.webDavFolder().get()
+        val username = syncPreferences.webDavUsername().get()
+        val password = syncPreferences.webDavPassword().get()
+
+        val credentials = Credentials.basic(username, password)
+        val lastETag = syncPreferences.lastSyncEtag().get()
+
+        val headersBuilder = Headers.Builder().add("Authorization", credentials)
+        if (lastETag.isNotEmpty()) {
+            headersBuilder.add("If-None-Match", lastETag)
+        }
+
+        val requestUrl = buildWebDavFileUrl(url, folder, "backup.proto")
+        val request = GET(requestUrl, headers = headersBuilder.build())
+
+        val client = OkHttpClient()
+        val response = client.newCall(request).await()
+
+        return when (response.code) {
+            HttpStatus.SC_NOT_MODIFIED -> {
+                logcat(LogPriority.INFO) { "Remote file not modified" }
+                Pair(null, lastETag)
+            }
+            HttpStatus.SC_NOT_FOUND -> {
+                logcat(LogPriority.INFO) { "No remote file found" }
+                Pair(null, "")
+            }
+            else -> {
+                if (response.isSuccessful) {
+                    val newETag = response.headers["ETag"] ?: ""
+                    val bytes = response.body.byteStream().use { it.readBytes() }
+                    try {
+                        val backup = protoBuf.decodeFromByteArray(Backup.serializer(), bytes)
+                        Pair(SyncData(backup = backup), newETag)
+                    } catch (e: Exception) {
+                        logcat(LogPriority.ERROR) { "Invalid backup format: ${e.message}" }
+                        Pair(null, "")
+                    }
+                } else {
+                    val body = response.body.string()
+                    throw WebDavException("Failed to download: $body")
+                }
+            }
+        }
+    }
+
+    private suspend fun pushSyncData(syncData: SyncData, eTag: String) {
+        val backup = syncData.backup ?: return
+
+        val url = syncPreferences.webDavUrl().get()
+        val folder = syncPreferences.webDavFolder().get()
+        val username = syncPreferences.webDavUsername().get()
+        val password = syncPreferences.webDavPassword().get()
+        val credentials = Credentials.basic(username, password)
+
+        val timeout = 30L
+        val client = OkHttpClient.Builder()
+            .connectTimeout(timeout, TimeUnit.SECONDS)
+            .readTimeout(timeout, TimeUnit.SECONDS)
+            .writeTimeout(timeout, TimeUnit.SECONDS)
+            .build()
+
+        val byteArray = protoBuf.encodeToByteArray(Backup.serializer(), backup)
+        if (byteArray.isEmpty()) {
+            throw IllegalStateException(context.stringResource(MR.strings.empty_backup_error))
+        }
+
+        val body = byteArray.toRequestBody("application/octet-stream".toMediaType())
+        val headersBuilder = Headers.Builder().add("Authorization", credentials)
+        if (eTag.isNotEmpty()) {
+            headersBuilder.add("If-Match", eTag)
+        }
+
+        val requestUrl = buildWebDavFileUrl(url, folder, "backup.proto")
+        val request = PUT(requestUrl, headers = headersBuilder.build(), body = body)
+
+        val response = client.newCall(request).await()
+
+        if (response.isSuccessful) {
+            val newETag = response.headers["ETag"] ?: ""
+            if (newETag.isNotEmpty()) {
+                syncPreferences.lastSyncEtag().set(newETag)
+            }
+            logcat(LogPriority.INFO) { "WebDAV sync completed" }
+        } else if (response.code == HttpStatus.SC_PRECONDITION_FAILED) {
+            logcat(LogPriority.WARN) { "WebDAV sync conflict (412)" }
+        } else {
+            val bodyStr = response.body.string()
+            throw WebDavException("Upload failed: $bodyStr")
+        }
+    }
+}
+

--- a/i18n-sy/src/commonMain/moko-resources/ar/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/ar/strings.xml
@@ -293,6 +293,15 @@
     <string name="google_drive">جوجل درايف</string>
     <string name="google_drive_sync_data_purged">تمت إزالة بيانات المزامنة من Google Drive</string>
     <string name="google_drive_sync_data_not_found">لم يتم العثور على بيانات مزامنة في Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">رابط خادم WebDAV</string>
+    <string name="pref_webdav_url_summ">أدخل عنوان خادم WebDAV</string>
+    <string name="pref_webdav_username">اسم المستخدم</string>
+    <string name="pref_webdav_username_summ">أدخل اسم مستخدم WebDAV الخاص بك</string>
+    <string name="pref_webdav_password">كلمة المرور</string>
+    <string name="pref_webdav_password_summ">أدخل كلمة مرور WebDAV الخاصة بك</string>
+    <string name="pref_webdav_folder">مجلد فرعي لـ WebDAV</string>
+    <string name="pref_webdav_folder_summ">سيقوم التطبيق بتخزين البيانات في هذا المجلد</string>
     <string name="google_drive_sync_data_purge_error">حدث خطأ أثناء إزالة بيانات المزامنة من Google Drive، حاول تسجيل الدخول مرة أخرى.</string>
     <string name="pref_choose_what_to_sync">اختر ما تريد مزامنته</string>
     <string name="syncyomi">Sync Yomi</string>

--- a/i18n-sy/src/commonMain/moko-resources/as/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/as/strings.xml
@@ -226,6 +226,15 @@
     <string name="pref_sync_automatic_category">স্বয়ংক্ৰিয় সিঙ্কৰণ</string>
     <string name="pref_sync_interval">সিঙ্কৰ ঘনত্ব</string>
     <string name="last_synchronization">শেষ সিঙ্ক: %1$s</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">WebDAV ছাৰ্ভাৰ URL</string>
+    <string name="pref_webdav_url_summ">WebDAV ছাৰ্ভাৰৰ ঠিকনা লিখক</string>
+    <string name="pref_webdav_username">ইউজাৰনেম</string>
+    <string name="pref_webdav_username_summ">আপোনাৰ WebDAV ইউজাৰনেম লিখক</string>
+    <string name="pref_webdav_password">পাছৱৰ্ড</string>
+    <string name="pref_webdav_password_summ">আপোনাৰ WebDAV পাছৱৰ্ড লিখক</string>
+    <string name="pref_webdav_folder">WebDAV সাবফোল্ডাৰ</string>
+    <string name="pref_webdav_folder_summ">অ্যাপ্লিকেশনে ডেটা এই ফোল্ডাৰত সংৰক্ষণ কৰিব</string>
     <string name="google_drive">গুগল ড্ৰাইভ</string>
     <string name="pref_google_drive_sign_in">সাইন ইন কৰক</string>
     <string name="pref_google_drive_purge_sync_data">গুগল ড্ৰাইভৰ পৰা সিঙ্ক তথ্য পৰিস্কাৰ কৰক</string>

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -232,6 +232,15 @@
     <string name="scan_qr_code">Scan a QR code</string>
     <string name="last_synchronization">Last Synchronization: %1$s</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">WebDAV Server URL</string>
+    <string name="pref_webdav_url_summ">Enter the WebDAV server address</string>
+    <string name="pref_webdav_username">Username</string>
+    <string name="pref_webdav_username_summ">Enter your WebDAV account username</string>
+    <string name="pref_webdav_password">Password</string>
+    <string name="pref_webdav_password_summ">Enter your WebDAV account password</string>
+    <string name="pref_webdav_folder">WebDAV data folder</string>
+    <string name="pref_webdav_folder_summ">The application will store the data in this folder</string>
     <string name="pref_google_drive_sign_in">Sign in</string>
     <string name="pref_google_drive_purge_sync_data">Clear Sync Data from Google Drive</string>
     <string name="google_drive_sync_data_purged">Sync data purged from Google Drive</string>

--- a/i18n-sy/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/de/strings.xml
@@ -161,6 +161,15 @@
     <string name="pref_sync_automatic_category">Automatische Synchronisierung</string>
     <string name="pref_sync_interval">Synchronisierungsfrequenz</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">WebDAV Server-URL</string>
+    <string name="pref_webdav_url_summ">Geben Sie die WebDAV-Serveradresse ein</string>
+    <string name="pref_webdav_username">Benutzername</string>
+    <string name="pref_webdav_username_summ">Geben Sie Ihren WebDAV-Benutzernamen ein</string>
+    <string name="pref_webdav_password">Passwort</string>
+    <string name="pref_webdav_password_summ">Geben Sie Ihr WebDAV-Passwort ein</string>
+    <string name="pref_webdav_folder">WebDAV-Unterordner</string>
+    <string name="pref_webdav_folder_summ">Die Anwendung speichert Daten in diesem Ordner</string>
     <string name="pref_purge_confirmation_title">Reinigung bestätigen</string>
     <string name="pref_source_navigation">\'Neuste\'-Taste ersetzen</string>
     <string name="custom_entry_info">Benutzerdefinierte Eintragsinformation</string>

--- a/i18n-sy/src/commonMain/moko-resources/es/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/es/strings.xml
@@ -236,6 +236,15 @@
     <string name="pref_google_drive_sign_in">Iniciar sesión</string>
     <string name="error_deleting_google_drive_lock_file">Error borrando el archivo de bloqueo de Google Drive</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL del servidor WebDAV</string>
+    <string name="pref_webdav_url_summ">Ingrese la dirección del servidor WebDAV</string>
+    <string name="pref_webdav_username">Nombre de usuario</string>
+    <string name="pref_webdav_username_summ">Ingrese su nombre de usuario de WebDAV</string>
+    <string name="pref_webdav_password">Contraseña</string>
+    <string name="pref_webdav_password_summ">Ingrese su contraseña de WebDAV</string>
+    <string name="pref_webdav_folder">Subcarpeta WebDAV</string>
+    <string name="pref_webdav_folder_summ">La aplicación almacenará los datos en esta carpeta</string>
     <string name="pref_purge_confirmation_message">Al eliminar los datos de sincronización, se eliminarán todos los datos sincronizados a Google Drive. ¿Estás seguro de que deseas continuar?</string>
     <string name="pref_purge_confirmation_title">Confirmación de purga</string>
     <string name="sync_on_app_start">Sincronizar al iniciar la aplicación</string>

--- a/i18n-sy/src/commonMain/moko-resources/fil/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/fil/strings.xml
@@ -545,6 +545,15 @@
     <string name="data_saver">Taga-save ng datos</string>
     <string name="syncyomi">SyncYomi</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL ng WebDAV Server</string>
+    <string name="pref_webdav_url_summ">Ilagay ang address ng WebDAV server</string>
+    <string name="pref_webdav_username">Username</string>
+    <string name="pref_webdav_username_summ">Ilagay ang iyong WebDAV username</string>
+    <string name="pref_webdav_password">Password</string>
+    <string name="pref_webdav_password_summ">Ilagay ang iyong WebDAV password</string>
+    <string name="pref_webdav_folder">WebDAV Subfolder</string>
+    <string name="pref_webdav_folder_summ">Ang app ay mag-iimbak ng mga data sa folder na ito</string>
     <string name="aes_256">AES 256</string>
     <string name="favorites_sync_failed_to_add_to_local_error">\'%1$s\' %2$s</string>
     <string name="rating9">Kamangha-mangha</string>

--- a/i18n-sy/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/fr/strings.xml
@@ -462,6 +462,15 @@
     <string name="pref_choose_what_to_sync">Choisir quoi synchroniser</string>
     <string name="last_synchronization">Dernière synchronisation : %1$s</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL du serveur WebDAV</string>
+    <string name="pref_webdav_url_summ">Entrez l'adresse du serveur WebDAV</string>
+    <string name="pref_webdav_username">Nom d'utilisateur</string>
+    <string name="pref_webdav_username_summ">Entrez votre nom d'utilisateur WebDAV</string>
+    <string name="pref_webdav_password">Mot de passe</string>
+    <string name="pref_webdav_password_summ">Entrez votre mot de passe WebDAV</string>
+    <string name="pref_webdav_folder">Sous-dossier WebDAV</string>
+    <string name="pref_webdav_folder_summ">L'application stockera les données dans ce dossier</string>
     <string name="pref_google_drive_sign_in">Connexion</string>
     <string name="google_drive_login_success">Connecté à Google Drive</string>
     <string name="google_drive_login_failed">Impossible de se connecter à Google Drive : %s</string>

--- a/i18n-sy/src/commonMain/moko-resources/in/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/in/strings.xml
@@ -556,6 +556,15 @@
     <string name="syncyomi">SyncYomi</string>
     <string name="last_synchronization">Sinkronisasi Terakhir: %1$s</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL Server WebDAV</string>
+    <string name="pref_webdav_url_summ">Masukkan alamat server WebDAV</string>
+    <string name="pref_webdav_username">Nama Pengguna</string>
+    <string name="pref_webdav_username_summ">Masukkan nama pengguna WebDAV Anda</string>
+    <string name="pref_webdav_password">Kata Sandi</string>
+    <string name="pref_webdav_password_summ">Masukkan kata sandi WebDAV Anda</string>
+    <string name="pref_webdav_folder">Subfolder WebDAV</string>
+    <string name="pref_webdav_folder_summ">Aplikasi akan menyimpan data di folder ini</string>
     <string name="pref_google_drive_sign_in">Masuk</string>
     <string name="google_drive_sync_data_purged">Data sinkronisasi dihapus dari Google Drive</string>
     <string name="google_drive_sync_data_not_found">Tidak ada data sinkronisasi yang ditemukan di Google Drive</string>

--- a/i18n-sy/src/commonMain/moko-resources/it/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/it/strings.xml
@@ -150,6 +150,15 @@
     <string name="pref_choose_what_to_sync">Scegli cosa sincronizzare</string>
     <string name="last_synchronization">Ultima Sincronizzazione: %1$s</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL del server WebDAV</string>
+    <string name="pref_webdav_url_summ">Inserisci l'indirizzo del server WebDAV</string>
+    <string name="pref_webdav_username">Nome utente</string>
+    <string name="pref_webdav_username_summ">Inserisci il tuo nome utente WebDAV</string>
+    <string name="pref_webdav_password">Password</string>
+    <string name="pref_webdav_password_summ">Inserisci la tua password WebDAV</string>
+    <string name="pref_webdav_folder">Sottocartella WebDAV</string>
+    <string name="pref_webdav_folder_summ">L'app salverà i dati in questa cartella</string>
     <string name="aes_256">AES 256</string>
     <string name="aes_128">AES 128</string>
     <string name="reader_preload_amount_4_pages">4 Pagine</string>

--- a/i18n-sy/src/commonMain/moko-resources/ja/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/ja/strings.xml
@@ -209,6 +209,15 @@
     <string name="pref_choose_what_to_sync">同期する項目を選択</string>
     <string name="syncyomi">SyncYomi</string>
     <string name="last_synchronization">最後の同期: %1$s</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">WebDAV サーバー URL</string>
+    <string name="pref_webdav_url_summ">WebDAV サーバーのアドレスを入力してください</string>
+    <string name="pref_webdav_username">ユーザー名</string>
+    <string name="pref_webdav_username_summ">WebDAV のユーザー名を入力してください</string>
+    <string name="pref_webdav_password">パスワード</string>
+    <string name="pref_webdav_password_summ">WebDAV のパスワードを入力してください</string>
+    <string name="pref_webdav_folder">WebDAV サブフォルダー</string>
+    <string name="pref_webdav_folder_summ">アプリはこのフォルダーにデータを保存します</string>
     <string name="google_drive">Google ドライブ</string>
     <string name="pref_google_drive_sign_in">サインイン</string>
     <string name="pref_google_drive_purge_sync_data">Google ドライブから同期データを消去</string>

--- a/i18n-sy/src/commonMain/moko-resources/pt-rBR/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/pt-rBR/strings.xml
@@ -512,6 +512,15 @@
     <string name="pref_choose_what_to_sync">Escolha o que sincronizar</string>
     <string name="syncyomi">SyncYomi</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL do servidor WebDAV</string>
+    <string name="pref_webdav_url_summ">Digite o endereço do servidor WebDAV</string>
+    <string name="pref_webdav_username">Nome de usuário</string>
+    <string name="pref_webdav_username_summ">Digite seu nome de usuário do WebDAV</string>
+    <string name="pref_webdav_password">Senha</string>
+    <string name="pref_webdav_password_summ">Digite sua senha do WebDAV</string>
+    <string name="pref_webdav_folder">Subpasta WebDAV</string>
+    <string name="pref_webdav_folder_summ">O aplicativo armazenará os dados nesta pasta</string>
     <string name="pref_google_drive_sign_in">Login</string>
     <string name="pref_google_drive_purge_sync_data">Limpar dados sincronizados do Google Drive</string>
     <string name="google_drive_sync_data_purged">Sincronizar dados purgados do Google Drive</string>

--- a/i18n-sy/src/commonMain/moko-resources/ru/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/ru/strings.xml
@@ -209,6 +209,15 @@
     <string name="pref_google_drive_purge_sync_data">Очистить данные синхронизации с Google Диска</string>
     <string name="google_drive_sync_data_purged">Данные синхронизации удалены из Google Диска</string>
     <string name="google_drive_sync_data_not_found">Данные синхронизации не найдены в Google Диске</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL сервера WebDAV</string>
+    <string name="pref_webdav_url_summ">Введите адрес сервера WebDAV</string>
+    <string name="pref_webdav_username">Имя пользователя</string>
+    <string name="pref_webdav_username_summ">Введите имя пользователя WebDAV</string>
+    <string name="pref_webdav_password">Пароль</string>
+    <string name="pref_webdav_password_summ">Введите пароль WebDAV</string>
+    <string name="pref_webdav_folder">WebDAV Подкаталог</string>
+    <string name="pref_webdav_folder_summ">Приложение будет сохранять данные в эту папку</string>
     <string name="google_drive_sync_data_purge_error">Ошибка при очистке данных синхронизации с Google Диска, попробуйте войти снова.</string>
     <string name="google_drive_login_success">Выполнен вход в Google Диск</string>
     <string name="google_drive_login_failed">Не удалось войти в Google Диск: %s</string>

--- a/i18n-sy/src/commonMain/moko-resources/ta/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/ta/strings.xml
@@ -278,6 +278,15 @@
     <string name="pref_choose_what_to_sync">ஒத்திசைக்க என்ன என்பதைத் தேர்வுசெய்க</string>
     <string name="syncyomi">சினிசோமி</string>
     <string name="last_synchronization">கடைசி ஒத்திசைவு: %1$s</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">WebDAV சேவை URL</string>
+    <string name="pref_webdav_url_summ">WebDAV சேவை முகவரியை உள்ளிடவும்</string>
+    <string name="pref_webdav_username">பயனர் பெயர்</string>
+    <string name="pref_webdav_username_summ">உங்கள் WebDAV பயனர் பெயரை உள்ளிடவும்</string>
+    <string name="pref_webdav_password">கடவுச்சொல்</string>
+    <string name="pref_webdav_password_summ">உங்கள் WebDAV கடவுச்சொல்லை உள்ளிடவும்</string>
+    <string name="pref_webdav_folder">WebDAV துணை கோப்புறை</string>
+    <string name="pref_webdav_folder_summ">ஆப் இந்த கோப்புறையில் தரவை சேமிக்கும்</string>
     <string name="google_drive">கூகிள் இயக்கி</string>
     <string name="pref_google_drive_sign_in">விடுபதிகை</string>
     <string name="pref_google_drive_purge_sync_data">Google இயக்ககத்திலிருந்து ஒத்திசைவு தரவை அழிக்கவும்</string>

--- a/i18n-sy/src/commonMain/moko-resources/tr/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/tr/strings.xml
@@ -196,6 +196,15 @@
     <string name="syncyomi">SyncYomi</string>
     <string name="last_synchronization">Son eşitleme: %1$s</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">WebDAV Sunucu URL'si</string>
+    <string name="pref_webdav_url_summ">WebDAV sunucu adresini girin</string>
+    <string name="pref_webdav_username">Kullanıcı adı</string>
+    <string name="pref_webdav_username_summ">WebDAV kullanıcı adınızı girin</string>
+    <string name="pref_webdav_password">Şifre</string>
+    <string name="pref_webdav_password_summ">WebDAV şifrenizi girin</string>
+    <string name="pref_webdav_folder">WebDAV Alt Klasörü</string>
+    <string name="pref_webdav_folder_summ">Uygulama verileri bu klasöre kaydedecektir</string>
     <string name="pref_google_drive_sign_in">Giriş yap</string>
     <string name="pref_google_drive_purge_sync_data">Eşitleme verilerini Google Drive\'dan silin</string>
     <string name="google_drive_sync_data_purged">Eşitleme verileri Google Drive\'dan silindi</string>

--- a/i18n-sy/src/commonMain/moko-resources/uk/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/uk/strings.xml
@@ -180,6 +180,15 @@
     <string name="pref_choose_what_to_sync">Виберіть, що синхронізувати</string>
     <string name="google_drive_login_success">Вхід до Google Диску</string>
     <string name="pref_sync_options">Створити сценарії синхронізації</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL сервера WebDAV</string>
+    <string name="pref_webdav_url_summ">Введіть адресу сервера WebDAV</string>
+    <string name="pref_webdav_username">Ім'я користувача</string>
+    <string name="pref_webdav_username_summ">Введіть своє ім'я користувача WebDAV</string>
+    <string name="pref_webdav_password">Пароль</string>
+    <string name="pref_webdav_password_summ">Введіть свій пароль WebDAV</string>
+    <string name="pref_webdav_folder">Підпапка WebDAV</string>
+    <string name="pref_webdav_folder_summ">Додаток зберігатиме дані в цій папці</string>
     <string name="google_drive">Google Диск</string>
     <string name="pref_google_drive_sign_in">Увійти</string>
     <string name="pref_google_drive_purge_sync_data">Очистити дані синхронізації з Google Диска</string>

--- a/i18n-sy/src/commonMain/moko-resources/vi/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/vi/strings.xml
@@ -113,6 +113,15 @@
     <string name="google_drive_not_signed_in">Chưa đăng nhập vào Google Drive</string>
     <string name="error_uploading_sync_data">Đã có lỗi khi tải dữ liệu đồng bộ lên Google Drive</string>
     <string name="google_drive_login_failed">Đăng nhập vào Google Drive thất bại:%s</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">URL máy chủ WebDAV</string>
+    <string name="pref_webdav_url_summ">Nhập địa chỉ của máy chủ WebDAV</string>
+    <string name="pref_webdav_username">Tên người dùng</string>
+    <string name="pref_webdav_username_summ">Nhập tên người dùng WebDAV của bạn</string>
+    <string name="pref_webdav_password">Mật khẩu</string>
+    <string name="pref_webdav_password_summ">Nhập mật khẩu WebDAV của bạn</string>
+    <string name="pref_webdav_folder">Thư mục con WebDAV</string>
+    <string name="pref_webdav_folder_summ">Ứng dụng sẽ lưu dữ liệu vào thư mục này</string>
     <string name="pref_sync_service_category">Đồng bộ</string>
     <string name="last_synchronization">Lần đồng bộ gần nhất:%1$s</string>
     <string name="google_drive_sync_data_not_found">Không tìm thấy dữ liệu đồng bộ trong Google Drive</string>

--- a/i18n-sy/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -596,7 +596,16 @@
     <string name="pref_choose_what_to_sync">选择要同步的内容</string>
     <string name="last_synchronization">最后同步：%1$s</string>
     <string name="google_drive">谷歌云端硬盘</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">WebDAV服务器地址</string>
+    <string name="pref_webdav_url_summ">输入WebDAV服务器地址</string>
+    <string name="pref_webdav_username">WebDAV账号</string>
+    <string name="pref_webdav_username_summ">输入WebDAV账号</string>
+    <string name="pref_webdav_password">WebDAV密码</string>
+    <string name="pref_webdav_password_summ">输入WebDAV密码</string>
     <string name="pref_google_drive_sign_in">登录</string>
+    <string name="pref_webdav_folder">WebDAV子文件夹</string>
+    <string name="pref_webdav_folder_summ">应用会把数据储存至该文件夹中</string>
     <string name="pref_google_drive_purge_sync_data">从谷歌云端硬盘清除同步的数据</string>
     <string name="google_drive_sync_data_purged">同步数据已从谷歌云端硬盘清除</string>
     <string name="google_drive_sync_data_purge_error">从谷歌云端硬盘清除同步的数据失败，请尝试重新登录。</string>

--- a/i18n-sy/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -203,6 +203,15 @@
     <string name="syncyomi">SyncYomi</string>
     <string name="last_synchronization">上次同步時間：%1$s</string>
     <string name="google_drive">Google Drive</string>
+    <string name="web_dav">WebDAV</string>
+    <string name="pref_webdav_url">WebDAV 伺服器 URL</string>
+    <string name="pref_webdav_url_summ">輸入 WebDAV 伺服器地址</string>
+    <string name="pref_webdav_username">使用者名稱</string>
+    <string name="pref_webdav_username_summ">輸入你的 WebDAV 帳號</string>
+    <string name="pref_webdav_password">密碼</string>
+    <string name="pref_webdav_password_summ">輸入你的 WebDAV 密碼</string>
+    <string name="pref_webdav_folder">WebDAV 子資料夾</string>
+    <string name="pref_webdav_folder_summ">應用程式會將資料儲存至此資料夾</string>
     <string name="pref_google_drive_sign_in">登入</string>
     <string name="pref_google_drive_purge_sync_data">從 Google Drive 清除同步資料</string>
     <string name="google_drive_sync_data_purged">已從 Google Drive 清除同步資料</string>


### PR DESCRIPTION
### Summary
This PR introduces a new preference setting that allows users to use **WebDAV** as an option for app sync.

When users select WebDAV as the sync option, the app can save and retrieve synced files from a user-specified WebDAV server.

This is particularly useful for users in mainland China. Due to the Great Firewall (GFW), syncing with Google Drive requires a VPN, which can cause some manga sources to fail Cloudflare's bot verification. This change allows syncing without a VPN and avoids Cloudflare verification issues.

### Changes
- Added **WebDAV section** in sync settings.
  - Configurable fields: Server URL, Username, Password, and Subfolder.
  - Added descriptive summaries for each preference.
- Implemented `WebDavSyncService` to handle uploading and downloading backups via WebDAV.
  - Stores backups in a configurable subfolder on the WebDAV server.
- Added **string resources** for WebDAV preferences in multiple languages.

### Notes
- Users must set the WebDAV folder correctly; otherwise, sync will fail.
- Tested against `dav.jianguoyun.com` and similar WebDAV services.