### PR TITLE
fix(merged-entries): Fix deletion of chapters and data folders in merged entries

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -444,10 +444,10 @@ class MangaScreenModel(
                 )
             }
             val chapters = if (manga.source == MERGED_SOURCE_ID) {
-                    getMergedChaptersByMangaId.await(mangaId, applyFilter = true)
-                } else {
-                    getMangaAndChapters.awaitChapters(mangaId, applyFilter = true)
-                }
+                getMergedChaptersByMangaId.await(mangaId, applyFilter = true)
+            } else {
+                getMangaAndChapters.awaitChapters(mangaId, applyFilter = true)
+            }
                 .toChapterListItems(manga, mergedData)
             val meta = getFlatMetadata.await(mangaId)
             // SY <--
@@ -1588,7 +1588,7 @@ class MangaScreenModel(
                                     // Refresh chapters state for Local source
                                     fetchChaptersFromSource()
                                 }
-                        }
+                            }
                     } else {
                         downloadManager.deleteManga(
                             manga = state.manga,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1541,7 +1541,7 @@ class MangaScreenModel(
                             // KMK <--
                         )
                         // KMK -->
-                        if (source?.isLocal() == true) {
+                        if (state.source.isLocal()) {
                             // Refresh chapters state for Local source
                             fetchChaptersFromSource()
                         }
@@ -1593,7 +1593,7 @@ class MangaScreenModel(
                             source = state.source,
                             removeQueued = true,
                         )
-                        if (source?.isLocal() == true) {
+                        if (state.source.isLocal()) {
                             // Refresh chapters state for Local source
                             fetchChaptersFromSource()
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1514,6 +1514,7 @@ class MangaScreenModel(
         screenModelScope.launchNonCancellable {
             try {
                 successState?.let { state ->
+                    // KMK --?
                     if (state.source.id == MERGED_SOURCE_ID) {
                         chapters.groupBy { it.mangaId }.forEach { map ->
                             val manga = state.mergedData?.manga?.get(map.key) ?: return@forEach
@@ -1522,18 +1523,15 @@ class MangaScreenModel(
                                 map.value,
                                 manga,
                                 source,
-                                // KMK -->
                                 ignoreCategoryExclusion = true,
-                                // KMK <--
                             )
-                            // KMK -->
                             if (source.isLocal()) {
                                 // Refresh chapters state for Local source
                                 fetchChaptersFromSource()
                             }
-                            // KMK <--
                         }
                     } else {
+                        // KMK <--
                         downloadManager.deleteChapters(
                             chapters,
                             state.manga,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -196,8 +196,7 @@ class ReaderViewModel @JvmOverloads constructor(
         val (chapters, mangaMap) = runBlocking {
             if (manga.source == MERGED_SOURCE_ID) {
                 getMergedChaptersByMangaId.await(manga.id, applyFilter = true) to
-                    getMergedMangaById.await(manga.id)
-                        .associateBy { it.id }
+                    state.value.mergedManga
             } else {
                 getChaptersByMangaId.await(manga.id, applyFilter = true) to null
             }
@@ -367,7 +366,7 @@ class ReaderViewModel @JvmOverloads constructor(
                             getMergedMangaById.await(manga.id)
                         }.associateBy { it.id }
                     } else {
-                        emptyMap()
+                        null
                     }
                     val relativeTime = uiPreferences.relativeTime().get()
                     val autoScrollFreq = readerPreferences.autoscrollInterval().get()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -34,7 +34,7 @@ class ChapterLoader(
     private val sourceManager: SourceManager,
     private val readerPrefs: ReaderPreferences,
     private val mergedReferences: List<MergedMangaReference>,
-    private val mergedManga: Map<Long, Manga>,
+    private val mergedManga: Map<Long, Manga>?,
     // SY <--
 ) {
 
@@ -109,7 +109,7 @@ class ChapterLoader(
                 } ?: error("Merge reference null")
                 val source = sourceManager.get(mangaReference.mangaSourceId)
                     ?: error("Source ${mangaReference.mangaSourceId} was null")
-                val manga = mergedManga[chapter.chapter.manga_id] ?: error("Manga for merged chapter was null")
+                val manga = mergedManga?.get(chapter.chapter.manga_id) ?: error("Manga for merged chapter was null")
                 val isMergedMangaDownloaded = downloadManager.isChapterDownloaded(
                     chapterName = chapter.chapter.name,
                     chapterScanlator = chapter.chapter.scanlator,


### PR DESCRIPTION
Ensure proper handling of chapter and manga deletions for merged sources, improving the refresh logic for local sources. Adjustments made to manage merged manga references more effectively.

Close #839
Close #868

## Summary by Sourcery

Fix deletion logic for chapters and manga in merged entries by processing each underlying source individually and refreshing local sources, and streamline mergedManga handling in the reader and chapter loader.

Bug Fixes:
- Delete chapters of merged entries by grouping them per underlying manga and source, ignoring category exclusions, and refreshing local sources
- Delete manga of merged entries per underlying source with queued removals and local source refresh

Enhancements:
- Use state.value.mergedManga in ReaderViewModel to avoid redundant database calls for merged sources
- Make mergedManga map nullable in ChapterLoader and update null checks accordingly
- Unify chapter retrieval logic in MangaScreenModel for merged and non-merged sources