### PR TITLE
fix(merged-chapters) Fix chapter's webview

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -831,8 +831,8 @@ class ReaderViewModel @JvmOverloads constructor(
     fun getChapterUrl(): String? {
         val sChapter = getCurrentChapter()?.chapter ?: return null
         val source = if (manga?.source == MERGED_SOURCE_ID) {
-            state.value.mergedManga?.get(sChapter.manga_id)?.source?.let { source ->
-                sourceManager.getOrStub(source) as? HttpSource
+            state.value.mergedManga?.get(sChapter.manga_id)?.source?.let { sourceId ->
+                sourceManager.getOrStub(sourceId) as? HttpSource
             }
         } else {
             getSource()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -830,14 +830,12 @@ class ReaderViewModel @JvmOverloads constructor(
 
     fun getChapterUrl(): String? {
         val sChapter = getCurrentChapter()?.chapter ?: return null
-        val source = manga?.let {
-            if (it.source == MERGED_SOURCE_ID) {
-                state.value.mergedManga?.get(sChapter.manga_id)?.source?.let { source ->
-                    sourceManager.getOrStub(source) as? HttpSource
-                }
-            } else {
-                getSource()
+        val source = if (manga?.source == MERGED_SOURCE_ID) {
+            state.value.mergedManga?.get(sChapter.manga_id)?.source?.let { source ->
+                sourceManager.getOrStub(source) as? HttpSource
             }
+        } else {
+            getSource()
         } ?: return null
 
         return try {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -830,7 +830,15 @@ class ReaderViewModel @JvmOverloads constructor(
 
     fun getChapterUrl(): String? {
         val sChapter = getCurrentChapter()?.chapter ?: return null
-        val source = getSource() ?: return null
+        val source = manga?.let {
+            if (it.source == MERGED_SOURCE_ID) {
+                state.value.mergedManga?.get(sChapter.manga_id)?.source?.let { source ->
+                    sourceManager.getOrStub(source) as? HttpSource
+                }
+            } else {
+                getSource()
+            }
+        } ?: return null
 
         return try {
             source.getChapterUrl(sChapter)


### PR DESCRIPTION
Improve the retrieval of chapter URLs in the webview by handling merged sources correctly. This change ensures that the appropriate source is used based on the manga's source ID.

Close #1095

## Summary by Sourcery

Bug Fixes:
- Correct chapter URL retrieval for merged sources in the reader webview by fetching the original HTTP source from the mergedManga mapping