### PR TITLE
fix(merged-reader): Fix chapter list's download badge in Reader

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -428,20 +428,23 @@ class ReaderViewModel @JvmOverloads constructor(
 
     // SY -->
     fun getChapters(): List<ReaderChapterItem> {
-        return manga?.let { manga ->
-            val currentChapter = getCurrentChapter()
-            val mangaList = state.value.mergedManga?.takeIf { it.isNotEmpty() } ?: mapOf(manga.id to manga)
+        // KMK -->
+        val manga = manga ?: return emptyList()
+        val mangaList = state.value.mergedManga?.takeIf { it.isNotEmpty() } ?: mapOf(manga.id to manga)
+        // KMK <--
 
-            chapterList.map {
-                ReaderChapterItem(
-                    chapter = it.chapter.toDomainChapter()!!,
-                    manga = mangaList[it.chapter.manga_id] ?: manga,
-                    isCurrent = it.chapter.id == currentChapter?.chapter?.id,
-                    dateFormat = UiPreferences.dateFormat(uiPreferences.dateFormat().get()),
-                )
-            }
+        val currentChapter = getCurrentChapter()
+
+        return chapterList.map {
+            ReaderChapterItem(
+                chapter = it.chapter.toDomainChapter()!!,
+                // KMK -->
+                manga = mangaList[it.chapter.manga_id] ?: manga,
+                // KMK <--
+                isCurrent = it.chapter.id == currentChapter?.chapter?.id,
+                dateFormat = UiPreferences.dateFormat(uiPreferences.dateFormat().get()),
+            )
         }
-            ?: emptyList()
     }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -428,16 +428,20 @@ class ReaderViewModel @JvmOverloads constructor(
 
     // SY -->
     fun getChapters(): List<ReaderChapterItem> {
-        val currentChapter = getCurrentChapter()
+        return manga?.let { manga ->
+            val currentChapter = getCurrentChapter()
+            val mangaList = state.value.mergedManga?.takeIf { it.isNotEmpty() } ?: mapOf(manga.id to manga)
 
-        return chapterList.map {
-            ReaderChapterItem(
-                chapter = it.chapter.toDomainChapter()!!,
-                manga = manga!!,
-                isCurrent = it.chapter.id == currentChapter?.chapter?.id,
-                dateFormat = UiPreferences.dateFormat(uiPreferences.dateFormat().get()),
-            )
+            chapterList.map {
+                ReaderChapterItem(
+                    chapter = it.chapter.toDomainChapter()!!,
+                    manga = mangaList[it.chapter.manga_id] ?: manga,
+                    isCurrent = it.chapter.id == currentChapter?.chapter?.id,
+                    dateFormat = UiPreferences.dateFormat(uiPreferences.dateFormat().get()),
+                )
+            }
         }
+            ?: emptyList()
     }
     // SY <--
 


### PR DESCRIPTION
Improve the handling of the chapter list to ensure the correct manga is associated with each chapter, enhancing the download badge functionality.

## Summary by Sourcery

Fix association of manga with chapters in merged reader to ensure download badges display correctly

Bug Fixes:
- Correctly map each chapter to its source manga when handling merged manga lists in the reader

Enhancements:
- Return an empty chapter list when no manga is available to prevent null pointer issues