### PR TITLE
chore(settings): Always display `App Language` text in settings

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
@@ -39,6 +38,7 @@ import uy.kohesive.injekt.api.get
 import java.time.LocalDate
 
 object SettingsAppearanceScreen : SearchableSettings {
+    @Suppress("unused")
     private fun readResolve(): Any = SettingsAppearanceScreen
 
     @ReadOnlyComposable
@@ -130,7 +130,6 @@ object SettingsAppearanceScreen : SearchableSettings {
                                     stringResource(KMR.strings.pref_theme_cover_based_style_fidelity)
                                 PaletteStyle.Content ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_content)
-                                else -> it.name
                             }
                         }
                         .toImmutableMap(),
@@ -194,7 +193,6 @@ object SettingsAppearanceScreen : SearchableSettings {
                                     stringResource(KMR.strings.pref_theme_cover_based_style_fidelity)
                                 PaletteStyle.Content ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_content)
-                                else -> it.name
                             }
                         }
                         .toImmutableMap(),
@@ -239,7 +237,7 @@ object SettingsAppearanceScreen : SearchableSettings {
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.TextPreference(
                     title = stringResource(MR.strings.pref_app_language) +
-                        if (currentLanguage !in listOf( "en", "")) " (App Language)" else "",
+                        if (currentLanguage !in listOf("en", "")) " (App Language)" else "",
                     onClick = { navigator.push(AppLanguageScreen()) },
                 ),
                 Preference.PreferenceItem.ListPreference(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -237,7 +237,7 @@ object SettingsAppearanceScreen : SearchableSettings {
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.TextPreference(
                     title = stringResource(MR.strings.pref_app_language) +
-                        if (currentLanguage !in listOf("en", "")) " (App Language)" else "",
+                        if (currentLanguage.isNotEmpty() && !currentLanguage.startsWith("en")) " (App Language)" else "",
                     onClick = { navigator.push(AppLanguageScreen()) },
                 ),
                 Preference.PreferenceItem.ListPreference(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -1,10 +1,12 @@
 package eu.kanade.presentation.more.settings.screen
 
 import android.app.Activity
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
@@ -228,11 +230,16 @@ object SettingsAppearanceScreen : SearchableSettings {
             UiPreferences.dateFormat(dateFormat).format(now)
         }
 
+        val currentLanguage = remember {
+            AppCompatDelegate.getApplicationLocales().get(0)?.toLanguageTag() ?: ""
+        }
+
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_category_display),
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.TextPreference(
-                    title = stringResource(MR.strings.pref_app_language),
+                    title = stringResource(MR.strings.pref_app_language) +
+                        if (currentLanguage !in listOf( "en", "")) " (App Language)" else "",
                     onClick = { navigator.push(AppLanguageScreen()) },
                 ),
                 Preference.PreferenceItem.ListPreference(


### PR DESCRIPTION
Ensure the app language text is consistently shown in the settings, enhancing user awareness of the current language selection.

## Summary by Sourcery

Add logic to detect the current application locale and append “(App Language)” to the app language setting title for better user awareness.

Enhancements:
- Detect the current application language using AppCompatDelegate.getApplicationLocales().
- Append “(App Language)” to the Settings > Appearance app language preference title when the locale is not English.