### PR TITLE
feat(reader-paged): Add options to disable zoom in or double tap to zoom for paged-reader

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -256,6 +256,10 @@ object SettingsReaderScreen : SearchableSettings {
         val dualPageSplit by dualPageSplitPref.collectAsState()
         val rotateToFit by rotateToFitPref.collectAsState()
 
+        // KMK -->
+        val pagedDisableZoomIn by readerPreferences.pagedDisableZoomIn().collectAsState()
+        // KMK <--
+
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pager_viewer),
             preferenceItems = persistentListOf(
@@ -311,6 +315,17 @@ object SettingsReaderScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_landscape_zoom),
                     enabled = imageScaleType == 1,
                 ),
+                // KMK -->
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.pagedDisableZoomIn(),
+                    title = stringResource(KMR.strings.pref_paged_disable_zoom_in),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = readerPreferences.pagedDoubleTapZoomEnabled(),
+                    title = stringResource(MR.strings.pref_double_tap_zoom),
+                    enabled = !pagedDisableZoomIn,
+                ),
+                // KMK <--
                 Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.navigateToPan(),
                     title = stringResource(MR.strings.pref_navigate_pan),

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ColorFilterPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ColorFilterPage.kt
@@ -1,6 +1,5 @@
 package eu.kanade.presentation.reader.settings
 
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -21,7 +20,7 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 
 @Composable
-internal fun ColumnScope.ColorFilterPage(screenModel: ReaderSettingsScreenModel) {
+internal fun ColorFilterPage(screenModel: ReaderSettingsScreenModel) {
     val customBrightness by screenModel.preferences.customBrightness().collectAsState()
     CheckboxItem(
         label = stringResource(MR.strings.pref_custom_brightness),

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -1,6 +1,5 @@
 package eu.kanade.presentation.reader.settings
 
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -30,9 +29,8 @@ private val flashColors = listOf(
     MR.strings.pref_flash_style_white_black to ReaderPreferences.FlashColor.WHITE_BLACK,
 )
 
-@Suppress("UnusedReceiverParameter")
 @Composable
-internal fun ColumnScope.GeneralPage(screenModel: ReaderSettingsScreenModel) {
+internal fun GeneralPage(screenModel: ReaderSettingsScreenModel) {
     val readerTheme by screenModel.preferences.readerTheme().collectAsState()
 
     val flashPageState by screenModel.preferences.flashOnPageChange().collectAsState()

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/ReadingModePage.kt
@@ -1,6 +1,5 @@
 package eu.kanade.presentation.reader.settings
 
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -27,7 +26,7 @@ import tachiyomi.presentation.core.util.collectAsState
 import java.text.NumberFormat
 
 @Composable
-internal fun ColumnScope.ReadingModePage(screenModel: ReaderSettingsScreenModel) {
+internal fun ReadingModePage(screenModel: ReaderSettingsScreenModel) {
     HeadingItem(MR.strings.pref_category_for_this_series)
     val manga by screenModel.mangaFlow.collectAsState()
 
@@ -65,7 +64,7 @@ internal fun ColumnScope.ReadingModePage(screenModel: ReaderSettingsScreenModel)
 }
 
 @Composable
-private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenModel) {
+private fun PagerViewerSettings(screenModel: ReaderSettingsScreenModel) {
     HeadingItem(MR.strings.pager_viewer)
 
     val navigationModePager by screenModel.preferences.navigationModePager().collectAsState()
@@ -171,6 +170,20 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
         pref = screenModel.preferences.invertDoublePages(),
     )
 
+    // KMK -->
+    CheckboxItem(
+        label = stringResource(KMR.strings.pref_paged_disable_zoom_in),
+        pref = screenModel.preferences.pagedDisableZoomIn(),
+    )
+    val pagedDisableZoomIn by screenModel.preferences.pagedDisableZoomIn().collectAsState()
+    if (!pagedDisableZoomIn) {
+        CheckboxItem(
+            label = stringResource(MR.strings.pref_double_tap_zoom),
+            pref = screenModel.preferences.pagedDoubleTapZoomEnabled(),
+        )
+    }
+    // KMK <--
+
     val centerMarginType by screenModel.preferences.centerMarginType().collectAsState()
     SettingsChipRow(SYMR.strings.pref_center_margin) {
         ReaderPreferences.CenterMarginTypes.mapIndexed { index, it ->
@@ -185,7 +198,7 @@ private fun ColumnScope.PagerViewerSettings(screenModel: ReaderSettingsScreenMod
 }
 
 @Composable
-private fun ColumnScope.WebtoonViewerSettings(screenModel: ReaderSettingsScreenModel) {
+private fun WebtoonViewerSettings(screenModel: ReaderSettingsScreenModel) {
     val numberFormat = remember { NumberFormat.getPercentInstance() }
 
     HeadingItem(MR.strings.webtoon_viewer)
@@ -279,7 +292,7 @@ private fun ColumnScope.WebtoonViewerSettings(screenModel: ReaderSettingsScreenM
 
 // SY -->
 @Composable
-private fun ColumnScope.WebtoonWithGapsViewerSettings(screenModel: ReaderSettingsScreenModel) {
+private fun WebtoonWithGapsViewerSettings(screenModel: ReaderSettingsScreenModel) {
     HeadingItem(MR.strings.vertical_plus_viewer)
 
     CheckboxItem(
@@ -290,7 +303,7 @@ private fun ColumnScope.WebtoonWithGapsViewerSettings(screenModel: ReaderSetting
 // SY <--
 
 @Composable
-private fun ColumnScope.TapZonesItems(
+private fun TapZonesItems(
     selected: Int,
     onSelect: (Int) -> Unit,
     invertMode: ReaderPreferences.TappingInvertMode,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -54,6 +54,8 @@ class ReaderPreferences(
     fun webtoonDoubleTapZoomEnabled() = preferenceStore.getBoolean("pref_enable_double_tap_zoom_webtoon", true)
 
     // KMK -->
+    fun pagedDoubleTapZoomEnabled() = preferenceStore.getBoolean("pref_enable_double_tap_zoom_paged", true)
+
     fun webtoonPinchToZoomEnabled() = preferenceStore.getBoolean("pref_enable_pinch_to_zoom_webtoon", true)
     // KMK <--
 
@@ -86,6 +88,10 @@ class ReaderPreferences(
     fun skipDupe() = preferenceStore.getBoolean("skip_dupe", false)
 
     fun webtoonDisableZoomOut() = preferenceStore.getBoolean("webtoon_disable_zoom_out", false)
+
+    // KMK -->
+    fun pagedDisableZoomIn() = preferenceStore.getBoolean("paged_disable_zoom_in", false)
+    // KMK <--
 
     // endregion
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -292,7 +292,17 @@ open class ReaderPageImageView @JvmOverloads constructor(
     private fun SubsamplingScaleImageView.setupZoom(config: Config?) {
         // 5x zoom
         maxScale = scale * MAX_ZOOM_SCALE
-        setDoubleTapZoomScale(scale * 2)
+        // KMK -->
+        if (config?.disableZoomIn == true) {
+            isZoomEnabled = false
+        } else {
+            if (config?.doubleTapZoom == false) {
+                setDoubleTapZoomScale(scale)
+            } else {
+                // KMK <--
+                setDoubleTapZoomScale(scale * 2)
+            }
+        }
 
         when (config?.zoomStartPosition) {
             ZoomStartPosition.LEFT -> setScaleAndCenter(scale, PointF(0F, 0F))
@@ -453,6 +463,10 @@ open class ReaderPageImageView @JvmOverloads constructor(
         val cropBorders: Boolean = false,
         val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
         val landscapeZoom: Boolean = false,
+        // KMK -->
+        val disableZoomIn: Boolean = false,
+        val doubleTapZoom: Boolean = true,
+        // KMK <--
     )
 
     enum class ZoomStartPosition {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerConfig.kt
@@ -49,6 +49,14 @@ class PagerConfig(
     var landscapeZoom = false
         private set
 
+    // KMK -->
+    var disableZoomIn = false
+        private set
+
+    var doubleTapZoom = true
+        private set
+    // KMK <--
+
     // SY -->
     var usePageTransitions = false
 
@@ -71,7 +79,6 @@ class PagerConfig(
     var pageCanvasColor = Color.WHITE
 
     var centerMarginType = CenterMarginType.NONE
-
     // SY <--
 
     init {
@@ -116,6 +123,7 @@ class PagerConfig(
             .drop(1)
             .onEach { navigationModeChangedListener?.invoke() }
             .launchIn(scope)
+
         // KMK -->
         readerPreferences.smallerTapZone().changes()
             .drop(1)
@@ -146,6 +154,19 @@ class PagerConfig(
                 { dualPageRotateToFitInvert = it },
                 { imagePropertyChangedListener?.invoke() },
             )
+
+        // KMK -->
+        readerPreferences.pagedDisableZoomIn()
+            .register(
+                { disableZoomIn = it },
+                { imagePropertyChangedListener?.invoke() },
+            )
+        readerPreferences.pagedDoubleTapZoomEnabled()
+            .register(
+                { doubleTapZoom = it },
+                { imagePropertyChangedListener?.invoke() },
+            )
+        // KMK <--
 
         // SY -->
         readerPreferences.pageTransitionsPager()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -216,6 +216,10 @@ class PagerPageHolder(
                         cropBorders = viewer.config.imageCropBorders,
                         zoomStartPosition = viewer.config.imageZoomType,
                         landscapeZoom = viewer.config.landscapeZoom,
+                        // KMK -->
+                        disableZoomIn = viewer.config.disableZoomIn,
+                        doubleTapZoom = viewer.config.doubleTapZoom,
+                        // KMK <--
                     ),
                 )
                 if (!isAnimated) {

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -26,6 +26,7 @@
     <string name="pref_viewer_nav_smaller_tap_zone">Smaller tap zones</string>
     <string name="error_opening_folder">Failed to open folder</string>
     <string name="pref_pinch_to_zoom">Pinch to zoom</string>
+    <string name="pref_paged_disable_zoom_in">Disable zoom in</string>
 
     <!-- Preferences -->
       <!-- Appearance section -->


### PR DESCRIPTION
Introduce settings to disable zooming and double tap zoom functionality in the paged reader, enhancing user control over the reading experience.

Close #517
Close #564

## Summary by Sourcery

Introduce settings to disable pinch and double-tap zoom in the paged reader and update the viewer components to respect these new preferences.

New Features:
- Add "Disable zoom in" and "Double tap zoom" switch preferences to the paged reader settings with the latter hidden when zoom is disabled
- Expose disableZoomIn and doubleTapZoom in PagerConfig and apply them in ReaderPageImageView to control zoom and double-tap zoom behavior

Enhancements:
- Remove unnecessary ColumnScope receivers from reader settings composables