### PR TITLE
feat(library): Show language when grouping by source

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/category/CategoryExtensions.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/CategoryExtensions.kt
@@ -6,16 +6,19 @@ import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.category.model.Category
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.source.local.LocalSource
 
 val Category.visualName: String
     @Composable
     get() = when {
+        id == LocalSource.ID && name == stringResource(MR.strings.local_source) -> stringResource(MR.strings.local_source)
         isSystemCategory -> stringResource(MR.strings.label_default)
         else -> name
     }
 
 fun Category.visualName(context: Context): String =
     when {
+        id == LocalSource.ID && name == context.stringResource(MR.strings.local_source) -> context.stringResource(MR.strings.local_source)
         isSystemCategory -> context.stringResource(MR.strings.label_default)
         else -> name
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -30,6 +30,7 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.track.TrackStatus
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.getNameForMangaInfo
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.source.online.all.MergedSource
@@ -120,7 +121,6 @@ import tachiyomi.domain.track.interactor.GetTracksPerManga
 import tachiyomi.domain.track.model.Track
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.sy.SYMR
-import tachiyomi.presentation.core.icons.FlagEmoji
 import tachiyomi.source.local.LocalSource
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
@@ -1480,20 +1480,22 @@ class LibraryScreenModel(
                 sources.associate {
                     val category = Category(
                         id = it.id,
-                        name = if (it.id == LocalSource.ID) {
-                            context.stringResource(MR.strings.local_source)
-                        } else {
-                            // KMK -->
-                            // FIXME: This useLangIcon should be moved out ouf LibraryItem & subscribe to changes() directly from preferences
-                            val useLangIcon = groupCache[it.id]?.let { it.firstOrNull()?.let { itemId -> this.firstOrNull { it.id == itemId } } }?.useLangIcon == true
-                            val langText = if (useLangIcon) FlagEmoji.getEmojiLangFlag(it.lang) else it.lang.uppercase()
-                            // KMK <--
-                            it.name.ifBlank { it.id.toString() }.let { sourceName ->
-                                // KMK -->
-                                "$sourceName ($langText)"
-                                // KMK <--
-                            }
-                        },
+                        // TODO: Probably add condition for useLangIcon to `getNameForMangaInfo` too
+                        name = it.getNameForMangaInfo(),
+//                        if (it.id == LocalSource.ID) {
+//                            context.stringResource(MR.strings.local_source)
+//                        } else {
+//                            // KMK -->
+//                            // FIXME: This useLangIcon should be moved out ouf LibraryItem & subscribe to changes() directly from preferences
+//                            val useLangIcon = groupCache[it.id]?.let { it.firstOrNull()?.let { itemId -> this.firstOrNull { it.id == itemId } } }?.useLangIcon == true
+//                            val langText = if (useLangIcon) FlagEmoji.getEmojiLangFlag(it.lang) else it.lang.uppercase()
+//                            // KMK <--
+//                            it.name.ifBlank { it.id.toString() }.let { sourceName ->
+//                                // KMK -->
+//                                "$sourceName ($langText)"
+//                                // KMK <--
+//                            }
+//                        },
                         order = sources.indexOf(it).toLong(),
                         flags = 0,
                         // KMK -->


### PR DESCRIPTION
closes #474 
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Group library entries by source and language, and display language indicators alongside source names in category titles

New Features:
- Show language indicator (flag emoji or uppercase code) when grouping library by source

Enhancements:
- Change grouping logic to use source-language pairs and update category IDs, names, and ordering accordingly
- Import FlagEmoji to support language icons in category titles
- Use preferences.context for stringResource lookup in category names