### PR TITLE
fix(library-search): Search by SourceName (LANG)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -30,6 +30,7 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.track.TrackStatus
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.source.Source
+import eu.kanade.tachiyomi.source.getNameForMangaInfo
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.source.online.all.MergedSource
@@ -1207,7 +1208,9 @@ class LibraryScreenModel(
                             (manga.author?.contains(query, true) == true) ||
                             (manga.artist?.contains(query, true) == true) ||
                             (manga.description?.contains(query, true) == true) ||
-                            (source?.name?.contains(query, true) == true || (source?.lang != null && "${source.name} (${source.lang})".contains(query, true))) ||
+                            // KMK -->
+                            (source?.getNameForMangaInfo()?.contains(query, true) == true) ||
+                            // KMK <--
                             (sourceIdString != null && sourceIdString == query) ||
                             (
                                 loggedInTrackServices.isNotEmpty() &&
@@ -1240,7 +1243,9 @@ class LibraryScreenModel(
                                     (manga.author?.contains(query, true) != true) &&
                                     (manga.artist?.contains(query, true) != true) &&
                                     (manga.description?.contains(query, true) != true) &&
-                                    (source?.name?.contains(query, true) != true || (source?.lang == null || !"${source.name} (${source.lang})".contains(query, true))) &&
+                                    // KMK -->
+                                    (source?.getNameForMangaInfo()?.contains(query, true) == true) &&
+                                    // KMK <--
                                     (sourceIdString != null && sourceIdString != query) &&
                                     (
                                         loggedInTrackServices.isEmpty() ||

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -1244,7 +1244,7 @@ class LibraryScreenModel(
                                     (manga.artist?.contains(query, true) != true) &&
                                     (manga.description?.contains(query, true) != true) &&
                                     // KMK -->
-                                    (source?.getNameForMangaInfo()?.contains(query, true) == true) &&
+                                    (source?.getNameForMangaInfo()?.contains(query, true) != true) &&
                                     // KMK <--
                                     (sourceIdString != null && sourceIdString != query) &&
                                     (

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -1207,7 +1207,7 @@ class LibraryScreenModel(
                             (manga.author?.contains(query, true) == true) ||
                             (manga.artist?.contains(query, true) == true) ||
                             (manga.description?.contains(query, true) == true) ||
-                            (source?.name?.contains(query, true) == true) ||
+                            (source?.name?.contains(query, true) == true || (source?.lang != null && "${source.name} (${source.lang})".contains(query, true))) ||
                             (sourceIdString != null && sourceIdString == query) ||
                             (
                                 loggedInTrackServices.isNotEmpty() &&
@@ -1240,7 +1240,7 @@ class LibraryScreenModel(
                                     (manga.author?.contains(query, true) != true) &&
                                     (manga.artist?.contains(query, true) != true) &&
                                     (manga.description?.contains(query, true) != true) &&
-                                    (source?.name?.contains(query, true) != true) &&
+                                    (source?.name?.contains(query, true) != true || (source?.lang == null || !"${source.name} (${source.lang})".contains(query, true))) &&
                                     (sourceIdString != null && sourceIdString != query) &&
                                     (
                                         loggedInTrackServices.isEmpty() ||


### PR DESCRIPTION
closes #1106 
The exclusion method isn't working quite yet. Would appreciate some help.
In this code, when searching for -MangaDex (EN), it'll exclude everything from mangadex instead of only excluding english entries
The inclusion method works. When searching for MangaDex (EN), it'll  exclude everything else
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Extend library search to match source names with appended language codes and refine exclusion rules to only filter out entries with the specified language.

New Features:
- Enable search by source name including language code (e.g., 'MangaDex (EN)')

Bug Fixes:
- Fix exclusion filter so '-SourceName (LANG)' excludes only entries of that language, not all from the source