### PR TITLE
chore(pr_label): Update permissions and label conditions for pull requests

### DIFF
--- a/.github/workflows/pr_label.yml
+++ b/.github/workflows/pr_label.yml
@@ -5,7 +5,9 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
+  contents: read
+  pull-requests: write
+  issues: write
 
 jobs:
   label_pr:
@@ -18,9 +20,9 @@ jobs:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
 
-            if (prAuthor === 'weblate') {
-              const labels = ['Translations'];
-              await github.issues.addLabels({
+            if (prAuthor === 'cuong-tran') {
+              const labels = ['translations'];
+              await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,

--- a/.github/workflows/pr_label.yml
+++ b/.github/workflows/pr_label.yml
@@ -20,7 +20,7 @@ jobs:
           script: |
             const prAuthor = context.payload.pull_request.user.login;
 
-            if (prAuthor === 'cuong-tran') {
+            if (prAuthor === 'weblate') {
               const labels = ['translations'];
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,


### PR DESCRIPTION
Revise permissions for pull request labeling and adjust conditions for applying labels based on the author.

## Summary by Sourcery

Revise the pr_label GitHub Actions workflow to adjust permissions and label conditions based on the PR author

CI:
- Adjust workflow permissions to contents:read and add pull-requests:write and issues:write
- Update author check to 'cuong-tran', lowercase label to 'translations', and switch to github.rest.issues.addLabels API