### PR TITLE
fix(download): Apply filtering when fetching chapters for download

### DIFF
--- a/domain/src/main/java/mihon/domain/chapter/interactor/FilterChaptersForDownload.kt
+++ b/domain/src/main/java/mihon/domain/chapter/interactor/FilterChaptersForDownload.kt
@@ -43,9 +43,9 @@ class FilterChaptersForDownload(
 
         // SY -->
         val existingChapters = if (manga.source == MERGED_SOURCE_ID) {
-            getMergedChaptersByMangaId.await(manga.id)
+            getMergedChaptersByMangaId.await(manga.id, /* KMK --> */ applyFilter = true /* KMK <-- */)
         } else {
-            getChaptersByMangaId.await(manga.id)
+            getChaptersByMangaId.await(manga.id, /* KMK --> */ applyFilter = true /* KMK <-- */)
         }
 
         val readChapterNumbers = existingChapters


### PR DESCRIPTION
Implement filtering logic to ensure only relevant chapters are fetched during the download process.

## Summary by Sourcery

Bug Fixes:
- Pass applyFilter=true to getMergedChaptersByMangaId.await and getChaptersByMangaId.await to filter fetched chapters