### PR TITLE
fix(webtoon-scale): Improve webtoon scale type handling & listener

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -121,14 +121,11 @@ class WebtoonConfig(
                 { pinchToZoomChangedListener?.invoke(it) },
             )
 
-        readerPreferences.webtoonScaleType().changes()
-            .drop(1)
-            .distinctUntilChanged()
-            .onEach {
-                webtoonScaleType = it
-                imagePropertyChangedListener?.invoke()
-            }
-            .launchIn(scope)
+        readerPreferences.webtoonScaleType()
+            .register(
+                { webtoonScaleType = it },
+                { webtoonScaleTypeChangedListener?.invoke(it) },
+            )
         // KMK <--
 
         readerPreferences.readerTheme().changes()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -121,11 +121,14 @@ class WebtoonConfig(
                 { pinchToZoomChangedListener?.invoke(it) },
             )
 
-        readerPreferences.webtoonScaleType()
-            .register(
-                { webtoonScaleType = it },
-                { webtoonScaleTypeChangedListener?.invoke(it) },
-            )
+        readerPreferences.webtoonScaleType().changes()
+            .drop(1)
+            .distinctUntilChanged()
+            .onEach {
+                webtoonScaleType = it
+                imagePropertyChangedListener?.invoke()
+            }
+            .launchIn(scope)
         // KMK <--
 
         readerPreferences.readerTheme().changes()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -207,11 +207,18 @@ class WebtoonViewer(
                 if (recycler.width > 0 && recycler.originalHeight > 0) {
                     applyScale()
                 } else {
+                    var retryCount = 0
+                    val maxRetries = 20
                     recycler.viewTreeObserver.addOnGlobalLayoutListener(object : android.view.ViewTreeObserver.OnGlobalLayoutListener {
                         override fun onGlobalLayout() {
                             if (recycler.width > 0 && recycler.originalHeight > 0) {
                                 recycler.viewTreeObserver.removeOnGlobalLayoutListener(this)
                                 applyScale()
+                            } else {
+                                retryCount++
+                                if (retryCount >= maxRetries) {
+                                    recycler.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                                }
                             }
                         }
                     })

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -6,10 +6,10 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
-import android.view.ViewTreeObserver
 import android.view.animation.LinearInterpolator
 import androidx.annotation.ColorInt
 import androidx.core.app.ActivityCompat
+import androidx.core.view.doOnLayout
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
@@ -208,33 +208,7 @@ class WebtoonViewer(
                 if (recycler.width > 0 && recycler.originalHeight > 0) {
                     applyScale()
                 } else {
-                    val listener = object : ViewTreeObserver.OnGlobalLayoutListener {
-                        private var retryCount = 0
-                        private val maxRetries = 20
-
-                        override fun onGlobalLayout() {
-                            val dimensionsReady = recycler.width > 0 && recycler.originalHeight > 0
-                            if (dimensionsReady) {
-                                applyScale()
-                            } else {
-                                retryCount++
-                            }
-
-                            if (dimensionsReady || retryCount >= maxRetries) {
-                                recycler.viewTreeObserver.removeOnGlobalLayoutListener(this)
-                            }
-                        }
-                    }
-                    recycler.viewTreeObserver.addOnGlobalLayoutListener(listener)
-
-                    // Add listener to be removed when scope is destroyed
-                    scope.coroutineContext[kotlinx.coroutines.Job]?.invokeOnCompletion {
-                        recycler.post {
-                            if (recycler.viewTreeObserver.isAlive) {
-                                recycler.viewTreeObserver.removeOnGlobalLayoutListener(listener)
-                            }
-                        }
-                    }
+                    recycler.doOnLayout { applyScale() }
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -21,7 +21,6 @@ import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.viewer.Viewer
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion
-import exh.util.nullIfZero
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import tachiyomi.core.common.util.system.logcat
@@ -182,14 +181,14 @@ class WebtoonViewer(
             if (!isContinuous && !readerPreferences.longStripGapSmartScale().get()) return@f
 
             recycler.post {
+                // Call `scaleTo` after the view is loaded and visible
+                val currentWidth = recycler.width.takeIf { it > 0 } ?: return@post
+                val currentHeight = recycler.originalHeight.takeIf { it > 0 } ?: return@post
+
                 if (scaleType == ReaderPreferences.WebtoonScaleType.FIT) {
                     recycler.scaleTo(1f)
                     return@post
                 }
-
-                // Call `scaleTo` after the view is loaded and visible
-                val currentWidth = recycler.width.takeIf { it > 0 } ?: activity.window.decorView.width.nullIfZero() ?: return@post
-                val currentHeight = recycler.originalHeight.takeIf { it > 0 } ?: activity.window.decorView.height.nullIfZero() ?: return@post
 
                 val desiredRatio = scaleType.ratio
                 val screenRatio = currentWidth.toFloat() / currentHeight
@@ -300,6 +299,10 @@ class WebtoonViewer(
             val pages = chapters.currChapter.pages ?: return
             moveToPage(pages[min(chapters.currChapter.requestedPage, pages.lastIndex)])
             recycler.isVisible = true
+
+            // KMK -->
+            config.webtoonScaleTypeChangedListener?.invoke(config.webtoonScaleType)
+            // KMK <--
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -228,7 +228,11 @@ class WebtoonViewer(
 
                     // Add listener to be removed when scope is destroyed
                     scope.coroutineContext[kotlinx.coroutines.Job]?.invokeOnCompletion {
-                        recycler.post { recycler.viewTreeObserver.removeOnGlobalLayoutListener(listener) }
+                        recycler.post {
+                            if (recycler.viewTreeObserver.isAlive) {
+                                recycler.viewTreeObserver.removeOnGlobalLayoutListener(listener)
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -213,14 +213,15 @@ class WebtoonViewer(
                         private val maxRetries = 20
 
                         override fun onGlobalLayout() {
-                            if (recycler.width > 0 && recycler.originalHeight > 0) {
-                                recycler.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                            val dimensionsReady = recycler.width > 0 && recycler.originalHeight > 0
+                            if (dimensionsReady) {
                                 applyScale()
                             } else {
                                 retryCount++
-                                if (retryCount >= maxRetries) {
-                                    recycler.viewTreeObserver.removeOnGlobalLayoutListener(this)
-                                }
+                            }
+
+                            if (dimensionsReady || retryCount >= maxRetries) {
+                                recycler.viewTreeObserver.removeOnGlobalLayoutListener(this)
                             }
                         }
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -182,15 +182,14 @@ class WebtoonViewer(
             if (!isContinuous && !readerPreferences.longStripGapSmartScale().get()) return@f
 
             recycler.post {
-                // Call `scaleTo` after the view is loaded and visible
-                val applyScale: () -> Unit = applyScale@{
+                recycler.doOnLayout doOnLayout@{
                     val currentWidth = recycler.width
                     val currentHeight = recycler.originalHeight
-                    if (currentWidth <= 0 || currentHeight <= 0) return@applyScale
+                    if (currentWidth <= 0 || currentHeight <= 0) return@doOnLayout
 
                     if (scaleType == ReaderPreferences.WebtoonScaleType.FIT) {
                         recycler.scaleTo(1f)
-                        return@applyScale
+                        return@doOnLayout
                     }
 
                     val desiredRatio = scaleType.ratio
@@ -203,12 +202,6 @@ class WebtoonViewer(
                     } else {
                         recycler.scaleTo(1f)
                     }
-                }
-
-                if (recycler.width > 0 && recycler.originalHeight > 0) {
-                    applyScale()
-                } else {
-                    recycler.doOnLayout { applyScale() }
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -6,6 +6,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewTreeObserver
 import android.view.animation.LinearInterpolator
 import androidx.annotation.ColorInt
 import androidx.core.app.ActivityCompat
@@ -209,7 +210,7 @@ class WebtoonViewer(
                 } else {
                     var retryCount = 0
                     val maxRetries = 20
-                    recycler.viewTreeObserver.addOnGlobalLayoutListener(object : android.view.ViewTreeObserver.OnGlobalLayoutListener {
+                    val globalLayoutListener = object : ViewTreeObserver.OnGlobalLayoutListener {
                         override fun onGlobalLayout() {
                             if (recycler.width > 0 && recycler.originalHeight > 0) {
                                 recycler.viewTreeObserver.removeOnGlobalLayoutListener(this)
@@ -221,7 +222,8 @@ class WebtoonViewer(
                                 }
                             }
                         }
-                    })
+                    }
+                    recycler.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
                 }
             }
         }


### PR DESCRIPTION
Enhance the handling of webtoon scale types and streamline listener invocation. Introduce a retry mechanism to ensure proper scaling when dimensions are not immediately available.

## Summary by Sourcery

Improve webtoon scale type handling by leveraging doOnLayout for retrying scaling when dimensions become available, and clean up related logic and annotations.

Bug Fixes:
- Ensure webtoon scaling logic waits for valid view dimensions to avoid erroneous scale operations

Enhancements:
- Replace recycler.post with doOnLayout listener to streamline and retry scale handling
- Remove nullIfZero fallbacks and simplify dimension retrieval for scaling
- Annotate seedColor property with @param:ColorInt for consistency