### PR TITLE
fix(strings): update Mihon name to Komikku strings

### DIFF
--- a/i18n/src/commonMain/moko-resources/cv/strings.xml
+++ b/i18n/src/commonMain/moko-resources/cv/strings.xml
@@ -627,7 +627,7 @@
     <string name="information_empty_repos">Пӗр хушмасен ҫӳпҫи те ҫук.</string>
     <string name="action_add_repo">Хушмасен ҫӳпҫи хуш</string>
     <string name="label_add_repo_input">Хушмасен ҫӳпҫин URL-ӗ</string>
-    <string name="action_add_repo_message">Mihon-а хушма хушмасен ҫӳпҫи хуш. «index.min.json» тенипе вӗҫленекен URL пулмалла.</string>
+    <string name="action_add_repo_message">Komikku-а хушма хушмасен ҫӳпҫи хуш. «index.min.json» тенипе вӗҫленекен URL пулмалла.</string>
     <string name="error_repo_exists">Ку хушмасен ҫӳпҫи унсӑрах пур!</string>
     <string name="action_delete_repo">Хушмасен ҫӳпҫине катерт</string>
     <string name="invalid_repo_name">Хушмасен ҫӳпҫин йӑнӑш URL-ӗ</string>


### PR DESCRIPTION
Replace occurrences of "Mihon" with "Komikku" in the localization strings.

## Summary by Sourcery

Bug Fixes:
- Replace 'Mihon' with 'Komikku' in the cv strings for the action_add_repo_message key