### PR TITLE
Revert targetSdk to 34

### DIFF
--- a/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget as KotlinJvmTarget
 
 object AndroidConfig {
     const val COMPILE_SDK = 35
-    const val TARGET_SDK = 35
+    const val TARGET_SDK = 34
     const val MIN_SDK = 26
     const val NDK = "27.1.12297006"
     const val BUILD_TOOLS = "35.0.1"


### PR DESCRIPTION
Restore the targetSdk version to 34, reverting the previous change that bumped it to 35.

## Summary by Sourcery

Build:
- Restore TARGET_SDK constant in AndroidConfig to 34