### PR TITLE
Replace `compose-stable-marker` with `compose-runtime-annotation`

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     api(libs.sqldelight.android.paging)
 
-    compileOnly(libs.compose.stablemarker)
+    compileOnly(compose.runtime.annotation)
 
     testImplementation(libs.bundles.test)
     testImplementation(kotlinx.coroutines.test)

--- a/gradle/compose.versions.toml
+++ b/gradle/compose.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-compose-bom = "2025.07.00"
+compose-bom = "2025.09.00"
 
 [libraries]
 activity = "androidx.activity:activity-compose:1.10.1"

--- a/gradle/compose.versions.toml
+++ b/gradle/compose.versions.toml
@@ -8,6 +8,7 @@ foundation = { module = "androidx.compose.foundation:foundation" }
 animation = { module = "androidx.compose.animation:animation" }
 animation-graphics = { module = "androidx.compose.animation:animation-graphics" }
 runtime = { module = "androidx.compose.runtime:runtime" }
+runtime-annotation = { module = "androidx.compose.runtime:runtime-annotation" }
 ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 ui-util = { module = "androidx.compose.ui:ui-util" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,6 @@ insetter = "dev.chrisbanes.insetter:insetter:0.6.1"
 compose-materialmotion = "io.github.fornewid:material-motion-compose-core:2.0.1"
 compose-webview = "io.github.kevinnzou:compose-webview:0.33.6"
 compose-grid = "io.woong.compose.grid:grid:1.2.2"
-compose-stablemarker = "com.github.skydoves:compose-stable-marker:1.0.7"
 reorderable = { module = "sh.calvin.reorderable:reorderable", version = "2.5.1" }
 palette-ktx = "androidx.palette:palette-ktx:1.0.0"
 materialKolor = "com.materialkolor:material-kolor:2.1.1"


### PR DESCRIPTION
Correct the Mihon name to Komikku in strings, revert the targetSdk bump, and replace `compose-stable-marker` with `compose-runtime-annotation` in the dependencies.

## Summary by Sourcery

Replace the deprecated Compose stable-marker dependency with the new runtime-annotation library and update version catalogs accordingly

Enhancements:
- Swap compose-stable-marker for compose-runtime-annotation in the domain build configuration
- Add runtime-annotation entry to gradle/compose.versions.toml
- Remove obsolete compose-stablemarker entry from gradle/libs.versions.toml