### PR TITLE
fix(deps): update dependency androidx.compose:compose-bom to v2025.09.01

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/AutoCompleteItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/AutoCompleteItem.kt
@@ -190,7 +190,7 @@ fun AutoCompleteTextField(
         if (value.text.length > 2 && filteredValues.isNotEmpty()) {
             ExposedDropdownMenu(
                 modifier = Modifier
-                    .exposedDropdownSize(matchTextFieldWidth = true),
+                    .exposedDropdownSize(matchAnchorWidth = true),
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
             ) {

--- a/gradle/compose.versions.toml
+++ b/gradle/compose.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-compose-bom = "2025.09.00"
+compose-bom = "2025.09.01"
 
 [libraries]
 activity = "androidx.activity:activity-compose:1.10.1"


### PR DESCRIPTION
Correct the Mihon name to Komikku, revert a previous SDK bump, and update the Compose BOM dependency to the latest version. Adjust the dropdown size modifier for better UI consistency.

## Summary by Sourcery

Update the Compose BOM to v2025.09.01 and refine the exposed dropdown size modifier for better UI consistency.

Enhancements:
- Adjust dropdown menu width to match its anchor for consistent UI presentation.

Build:
- Update Compose BOM dependency to version 2025.09.01.