### PR TITLE
Bump compileSdk to 36

### DIFF
--- a/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
@@ -4,7 +4,7 @@ import org.gradle.api.JavaVersion as GradleJavaVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget as KotlinJvmTarget
 
 object AndroidConfig {
-    const val COMPILE_SDK = 35
+    const val COMPILE_SDK = 36
     const val TARGET_SDK = 34
     const val MIN_SDK = 26
     const val NDK = "27.1.12297006"


### PR DESCRIPTION
Update the compile SDK version to 36

## Summary by Sourcery

Build:
- Update compile SDK version from 35 to 36