### PR TITLE
refactor(merged-settings): Remove unused no-dedupe option

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/merged/EditMergedSettingsHeaderAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/merged/EditMergedSettingsHeaderAdapter.kt
@@ -88,7 +88,7 @@ class EditMergedSettingsHeaderAdapter(
                             0 -> MergedMangaReference.CHAPTER_SORT_PRIORITY
                             1 -> MergedMangaReference.CHAPTER_SORT_MOST_CHAPTERS
                             2 -> MergedMangaReference.CHAPTER_SORT_HIGHEST_CHAPTER_NUMBER
-                            else -> MergedMangaReference.CHAPTER_SORT_NO_DEDUPE
+                            else -> MergedMangaReference.CHAPTER_SORT_NONE
                         },
                     )
                     xLogD(state.mergeReference?.chapterSortMode)
@@ -100,7 +100,7 @@ class EditMergedSettingsHeaderAdapter(
 
                 override fun onNothingSelected(parent: AdapterView<*>?) {
                     state.mergeReference = state.mergeReference?.copy(
-                        chapterSortMode = MergedMangaReference.CHAPTER_SORT_NO_DEDUPE,
+                        chapterSortMode = MergedMangaReference.CHAPTER_SORT_NONE,
                     )
                 }
             }
@@ -169,7 +169,7 @@ class EditMergedSettingsHeaderAdapter(
                 }
                 state.mergeReference = state.mergeReference?.copy(
                     chapterSortMode = when (isChecked) {
-                        true -> MergedMangaReference.CHAPTER_SORT_NO_DEDUPE
+                        true -> MergedMangaReference.CHAPTER_SORT_PRIORITY
                         false -> MergedMangaReference.CHAPTER_SORT_NONE
                     },
                 )

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetMergedChaptersByMangaId.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/GetMergedChaptersByMangaId.kt
@@ -69,7 +69,7 @@ class GetMergedChaptersByMangaId(
         chapterList: List<Chapter>,
     ): List<Chapter> {
         return when (mangaReferences.firstOrNull { it.mangaSourceId == MERGED_SOURCE_ID }?.chapterSortMode) {
-            MergedMangaReference.CHAPTER_SORT_NO_DEDUPE, MergedMangaReference.CHAPTER_SORT_NONE -> chapterList
+            MergedMangaReference.CHAPTER_SORT_NONE -> chapterList
             MergedMangaReference.CHAPTER_SORT_PRIORITY -> dedupeByPriority(mangaReferences, chapterList)
             MergedMangaReference.CHAPTER_SORT_MOST_CHAPTERS -> {
                 findSourceWithMostChapters(chapterList)?.let { mangaId ->

--- a/domain/src/main/java/tachiyomi/domain/manga/model/MergedMangaReference.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/MergedMangaReference.kt
@@ -36,9 +36,8 @@ data class MergedMangaReference(
 ) {
     companion object {
         const val CHAPTER_SORT_NONE = 0
-        const val CHAPTER_SORT_NO_DEDUPE = 1
-        const val CHAPTER_SORT_PRIORITY = 2
-        const val CHAPTER_SORT_MOST_CHAPTERS = 3
-        const val CHAPTER_SORT_HIGHEST_CHAPTER_NUMBER = 4
+        const val CHAPTER_SORT_PRIORITY = 1
+        const val CHAPTER_SORT_MOST_CHAPTERS = 2
+        const val CHAPTER_SORT_HIGHEST_CHAPTER_NUMBER = 3
     }
 }


### PR DESCRIPTION
Close #1165

## Summary by Sourcery

Remove the unused 'no-dedupe' chapter sort mode and update related UI and domain logic to consolidate around CHAPTER_SORT_NONE.

Enhancements:
- Remove the CHAPTER_SORT_NO_DEDUPE constant and shift the remaining chapter sort mode values
- Remove the 'no-dedupe' option from the merged settings UI spinner and checkbox handling
- Simplify GetMergedChaptersByMangaId to treat CHAPTER_SORT_NONE as the only no-dedupe branch