### PR TITLE
Delegate Suwayomi tracker authentication to extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 ### Changed
+- Delegate Suwayomi tracker authentication to extension ([@cpiber](https://github.com/cpiber)) ([#2476](https://github.com/mihonapp/mihon/pull/2476))
+
+### Fixes
+- Fix height of description not being calculated correctly if images are present ([@Secozzi](https://github.com/Secozzi)) ([#2382](https://github.com/mihonapp/mihon/pull/2382))
+- Fix migration progress not updating after manual search ([@Secozzi](https://github.com/Secozzi)) ([#2484](https://github.com/mihonapp/mihon/pull/2484))
+- Fix category migration flag being ignored due to incorrect check against chapter flag ([@Secozzi](https://github.com/Secozzi)) ([#2484](https://github.com/mihonapp/mihon/pull/2484))
+
+## [v0.19.1] - 2025-08-07
+### Changed
 - LocalSource now reads ComicInfo.xml file for chapter (if available) to display chapter title, number and scanlator ([@raxod502](https://github.com/radian-software)) ([#2332](https://github.com/mihonapp/mihon/pull/2332))
 
 ### Removed
@@ -395,7 +404,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Branding to Mihon ([@AntsyLich](https://github.com/AntsyLich))
 - Minimum supported Android version to 8 ([@AntsyLich](https://github.com/AntsyLich)) ([`dfb3091`](https://github.com/mihonapp/mihon/commit/dfb3091e380dda3e9bfb64bf5c9a685cf3a03d0e))
 
-[unreleased]: https://github.com/mihonapp/mihon/compare/v0.19.0...main
+[unreleased]: https://github.com/mihonapp/mihon/compare/v0.19.1...main
+[v0.19.1]: https://github.com/mihonapp/mihon/compare/v0.19.0...v0.19.1
 [v0.19.0]: https://github.com/mihonapp/mihon/compare/v0.18.0...v0.19.0
 [v0.18.0]: https://github.com/mihonapp/mihon/compare/v0.17.1...v0.18.0
 [v0.17.1]: https://github.com/mihonapp/mihon/compare/v0.17.0...v0.17.1

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/SuwayomiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/SuwayomiApi.kt
@@ -1,50 +1,31 @@
 package eu.kanade.tachiyomi.data.track.suwayomi
 
-import android.app.Application
-import android.content.Context
-import android.content.SharedPreferences
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.PUT
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
+import eu.kanade.tachiyomi.source.online.HttpSource
 import kotlinx.serialization.json.Json
-import okhttp3.Credentials
-import okhttp3.Dns
 import okhttp3.FormBody
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import tachiyomi.core.common.util.lang.withIOContext
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
+import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.injectLazy
 import java.nio.charset.Charset
 import java.security.MessageDigest
 
 class SuwayomiApi(private val trackId: Long) {
 
-    private val network: NetworkHelper by injectLazy()
     private val json: Json by injectLazy()
 
-    private val client: OkHttpClient =
-        network.client.newBuilder()
-            .dns(Dns.SYSTEM) // don't use DNS over HTTPS as it breaks IP addressing
-            .build()
-
-    private fun headersBuilder(): Headers.Builder = Headers.Builder().apply {
-        if (basePassword.isNotEmpty() && baseLogin.isNotEmpty()) {
-            val credentials = Credentials.basic(baseLogin, basePassword)
-            add("Authorization", credentials)
-        }
-    }
-
-    private val headers: Headers by lazy { headersBuilder().build() }
-
-    private val baseUrl by lazy { getPrefBaseUrl() }
-    private val baseLogin by lazy { getPrefBaseLogin() }
-    private val basePassword by lazy { getPrefBasePassword() }
+    private val sourceManager: SourceManager by injectLazy()
+    private val source: HttpSource by lazy { sourceManager.get(sourceId) as HttpSource }
+    private val client: OkHttpClient by lazy { source.client }
+    private val headers: Headers by lazy { source.headers }
+    private val baseUrl: String by lazy { source.baseUrl.trimEnd('/') }
 
     suspend fun getTrackSearch(trackUrl: String): TrackSearch = withIOContext {
         val url = try {
@@ -105,19 +86,4 @@ class SuwayomiApi(private val trackId: Long) {
         val bytes = MessageDigest.getInstance("MD5").digest(key.toByteArray())
         (0..7).map { bytes[it].toLong() and 0xff shl 8 * (7 - it) }.reduce(Long::or) and Long.MAX_VALUE
     }
-
-    private val preferences: SharedPreferences by lazy {
-        Injekt.get<Application>().getSharedPreferences("source_$sourceId", Context.MODE_PRIVATE)
-    }
-
-    private fun getPrefBaseUrl(): String = preferences.getString(ADDRESS_TITLE, ADDRESS_DEFAULT)!!
-    private fun getPrefBaseLogin(): String = preferences.getString(LOGIN_TITLE, LOGIN_DEFAULT)!!
-    private fun getPrefBasePassword(): String = preferences.getString(PASSWORD_TITLE, PASSWORD_DEFAULT)!!
 }
-
-private const val ADDRESS_TITLE = "Server URL Address"
-private const val ADDRESS_DEFAULT = ""
-private const val LOGIN_TITLE = "Login (Basic Auth)"
-private const val LOGIN_DEFAULT = ""
-private const val PASSWORD_TITLE = "Password (Basic Auth)"
-private const val PASSWORD_DEFAULT = ""


### PR DESCRIPTION
## Summary by Sourcery

Delegate Suwayomi tracker authentication and configuration to the HTTP source extension by leveraging its client, headers, and base URL instead of manual preference-based setup

Enhancements:
- Switch SuwayomiApi to use the extension’s HttpSource for HTTP client, headers, and base URL
- Remove manual credential handling and preferences in favor of extension-managed authentication

Documentation:
- Add changelog entry for Suwayomi authentication delegation to extension