### PR TITLE
Improve spoofing of `X-Requested-With` header for newer WebView versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Changed
 - Delegate Suwayomi tracker authentication to extension ([@cpiber](https://github.com/cpiber)) ([#2476](https://github.com/mihonapp/mihon/pull/2476))
 
+### Improved
+- Spoofing of `X-Requested-With` header to support newer WebView versions ([@Guzmazow](https://github.com/Guzmazow)) ([#2491](https://github.com/mihonapp/mihon/pull/2491))
+
 ### Fixes
 - Fix height of description not being calculated correctly if images are present ([@Secozzi](https://github.com/Secozzi)) ([#2382](https://github.com/mihonapp/mihon/pull/2382))
 - Fix migration progress not updating after manual search ([@Secozzi](https://github.com/Secozzi)) ([#2484](https://github.com/mihonapp/mihon/pull/2484))

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -303,9 +303,13 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         try {
             // Override the value passed as X-Requested-With in WebView requests
             val stackTrace = Looper.getMainLooper().thread.stackTrace
+            // KMK -->
+            val chromiumClasses = setOf("org.chromium.base.buildinfo", "org.chromium.base.apkinfo")
+            val chromiumMethods = setOf("getall", "getpackagename", "<init>")
+            // KMK <--
             val isChromiumCall = stackTrace.any { trace ->
-                trace.className.equals("org.chromium.base.BuildInfo", ignoreCase = true) &&
-                    setOf("getAll", "getPackageName", "<init>").any { trace.methodName.equals(it, ignoreCase = true) }
+                trace.className.lowercase() in chromiumClasses &&
+                    trace.methodName.lowercase() in chromiumMethods
             }
 
             if (isChromiumCall) return WebViewUtil.spoofedPackageName(applicationContext)


### PR DESCRIPTION
Enhance the spoofing mechanism of the `X-Requested-With` header to ensure compatibility with the latest WebView versions.

## Summary by Sourcery

Enhance the spoofing mechanism of the X-Requested-With header for newer WebView versions by expanding class/method name checks and using case-insensitive comparisons.

Enhancements:
- Include "org.chromium.base.ApkInfo" in the Chromium class name checks for spoofing.
- Use lowercase comparisons for class and method names to ensure case-insensitivity.

Documentation:
- Add an "Improved" entry in the CHANGELOG for X-Requested-With header spoofing.