### PR TITLE
Update markdown to 0.37.0

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MarkdownRender.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MarkdownRender.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
@@ -102,13 +101,9 @@ private fun getMarkdownColors(): MarkdownColors {
     val codeBackground = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f)
     return DefaultMarkdownColors(
         text = MaterialTheme.colorScheme.onSurface,
-        codeText = Color.Unspecified,
-        inlineCodeText = Color.Unspecified,
-        linkText = Color.Unspecified,
         codeBackground = codeBackground,
         inlineCodeBackground = codeBackground,
         dividerColor = MaterialTheme.colorScheme.outlineVariant,
-        tableText = Color.Unspecified,
         tableBackground = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f),
     )
 }
@@ -139,7 +134,6 @@ private fun getMarkdownTypography(): MarkdownTypography {
         ordered = MaterialTheme.typography.bodyMedium,
         bullet = MaterialTheme.typography.bodyMedium,
         list = MaterialTheme.typography.bodyMedium,
-        link = link,
         textLink = TextLinkStyles(style = link.toSpanStyle()),
         table = MaterialTheme.typography.bodyMedium,
     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ voyager = "1.1.0-beta03"
 spotless = "7.2.1"
 ktlint-core = "1.5.0"
 firebase-bom = "33.16.0"
-markdown = "0.35.0"
+markdown = "0.37.0"
 junit = "5.13.4"
 
 [libraries]


### PR DESCRIPTION
Upgrade the markdown library to improve functionality and performance. Adjustments made to related color and typography settings to align with the new version.

## Summary by Sourcery

Upgrade markdown library to v0.37.0 and update MarkdownRender to remove now-unnecessary custom color and typography overrides

Enhancements:
- Remove explicit color and typography overrides for code, inline code, links, and tables in MarkdownRender

Build:
- Bump markdown library version to 0.37.0 in libs.versions.toml