### PR TITLE
fix(deps): update dependency com.materialkolor:material-kolor to v3

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -68,8 +68,7 @@ fun TachiyomiTheme(
     if (seedColor != null) {
         DynamicMaterialTheme(
             seedColor = seedColor,
-            useDarkTheme = isSystemInDarkTheme(),
-            withAmoled = isAmoled,
+            isAmoled = isAmoled,
             style = uiPreferences.themeCoverBasedStyle().get(),
             typography = typography,
             animate = true,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,7 @@ compose-webview = "io.github.kevinnzou:compose-webview:0.33.6"
 compose-grid = "io.woong.compose.grid:grid:1.2.2"
 reorderable = { module = "sh.calvin.reorderable:reorderable", version = "3.0.0" }
 palette-ktx = "androidx.palette:palette-ktx:1.0.0"
-materialKolor = "com.materialkolor:material-kolor:2.1.1"
+materialKolor = "com.materialkolor:material-kolor:3.0.1"
 haze = "dev.chrisbanes.haze:haze:1.6.10"
 
 swipe = "me.saket.swipe:swipe:1.3.0"


### PR DESCRIPTION
## Summary by Sourcery

Update the Material Kolor dependency to v3.0.1 and adjust the DynamicMaterialTheme call to align with the library's updated API.

Enhancements:
- Upgrade the Material Kolor theming library to version 3.0.1
- Adapt the DynamicMaterialTheme invocation to match the updated API parameters

Build:
- Bump com.materialkolor:material-kolor dependency version in libs.versions.toml