### PR TITLE
fix(manga-screen): Don't show track dialog automatically if manga is not favorited (dialog dismissed)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -477,10 +477,12 @@ class MangaScreen(
 
         val onDismissRequest = {
             screenModel.dismissDialog()
+            // KMK -->
             if (screenModel.autoOpenTrack && screenModel.showTrackDialogAfterCategorySelection) {
                 screenModel.showTrackDialogAfterCategorySelection = false
-                screenModel.showTrackDialog()
+                if (successState.manga.favorite) screenModel.showTrackDialog()
             }
+            // KMK <--
         }
         when (val dialog = successState.dialog) {
             null -> {}


### PR DESCRIPTION
Ensure the track dialog does not open automatically if the manga is not favorited, improving user experience by only showing the dialog for favorited items.

## Summary by Sourcery

Bug Fixes:
- Only auto-show the tracking dialog if the manga is marked as a favorite after dismissing the initial dialog.