### PR TITLE
Manhua type support to AutoWebtoonMode

### DIFF
--- a/app/src/main/java/exh/util/MangaType.kt
+++ b/app/src/main/java/exh/util/MangaType.kt
@@ -54,7 +54,7 @@ fun Manga.mangaType(sourceName: String? = Injekt.get<SourceManager>().get(source
  * read types
  */
 fun Manga.defaultReaderType(type: MangaType = mangaType()): Int? {
-    return if (type == MangaType.TYPE_MANHUA || type == MangaType.TYPE_MANHWA || type == MangaType.TYPE_WEBTOON) {
+    return if (type in setOf(MangaType.TYPE_MANHUA, MangaType.TYPE_MANHWA, MangaType.TYPE_WEBTOON)) {
         ReadingMode.WEBTOON.flagValue
     } else {
         null


### PR DESCRIPTION
AutoWebtoon mode only works when entries have tags like `webtoon, manhwa, long strip` but not with `manhua`

| Manhua Type |
| ------- |
| ![221307](https://github.com/user-attachments/assets/91c71ab6-5951-4ef9-820d-ffcf6385cf9d) |


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

New Features:
- Enable AutoWebtoon mode for manhua-tagged entries by including TYPE_MANHUA in the reader type check