### PR TITLE
fix(discord): Fix service crash

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordRPCService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/connections/discord/DiscordRPCService.kt
@@ -178,12 +178,14 @@ class DiscordRPCService : Service() {
         fun start(context: Context, connectionsManager: ConnectionsManager = Injekt.get()) {
             handler.removeCallbacksAndMessages(null)
             val token = connectionsPreferences.connectionsToken(connectionsManager.discord).get()
-            if (rpc == null && connectionsPreferences.enableDiscordRPC().get() && token.isNotBlank()) {
-                since = System.currentTimeMillis()
-                context.startForegroundService(Intent(context, DiscordRPCService::class.java))
-            } else if (token.isBlank()) {
-                Timber.tag(TAG).w("Discord RPC not started due to missing token")
-                connectionsPreferences.enableDiscordRPC().set(false)
+            if (connectionsPreferences.enableDiscordRPC().get()) {
+                if (token.isBlank()) {
+                    Timber.tag(TAG).w("Discord RPC not started due to missing token")
+                    connectionsPreferences.enableDiscordRPC().set(false)
+                } else if (rpc == null) {
+                    since = System.currentTimeMillis()
+                    context.startForegroundService(Intent(context, DiscordRPCService::class.java))
+                }
             }
         }
 


### PR DESCRIPTION
Address a crash caused by not calling `Service.startForeground` in a timely manner and prevent the Discord RPC from restarting without a valid token.

## Summary by Sourcery

Fix service crashing by entering foreground promptly and prevent Discord RPC from running without a valid token.

Bug Fixes:
- Enter service foreground immediately on start to avoid crashes from missing `startForeground` call
- Stop the service if setting the initial Discord RPC screen fails to prevent uncaught exceptions
- Prevent starting or restarting Discord RPC when no valid token is present and disable the feature in preferences

Enhancements:
- Inject `ConnectionsManager` into static `start` and `restart` methods for token availability checks
- Log warnings when Discord RPC is not started due to a missing token