### PR TITLE
fix(migration): Add Merged Manga Dedupe Mode Migration and update versioning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,8 +25,8 @@ android {
     defaultConfig {
         applicationId = "app.komikku"
 
-        versionCode = 76
-        versionName = "1.13.4"
+        versionCode = 77
+        versionName = "1.13.5"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getGitSha()}\"")

--- a/app/src/main/java/mihon/core/migration/migrations/MergedMangaDedupeModeMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/MergedMangaDedupeModeMigration.kt
@@ -1,0 +1,35 @@
+package mihon.core.migration.migrations
+
+import mihon.core.migration.Migration
+import mihon.core.migration.MigrationContext
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.data.DatabaseHandler
+import tachiyomi.data.manga.MergedMangaMapper
+import tachiyomi.domain.manga.interactor.UpdateMergedSettings
+import tachiyomi.domain.manga.model.MergeMangaSettingsUpdate
+
+class MergedMangaDedupeModeMigration : Migration {
+    override val version: Float = 77f
+
+    override suspend fun invoke(migrationContext: MigrationContext): Boolean = withIOContext {
+        val handler = migrationContext.get<DatabaseHandler>() ?: return@withIOContext false
+        val updateMergedSettings = migrationContext.get<UpdateMergedSettings>() ?: return@withIOContext false
+
+        // Get merged manga references from db
+        val dbMergedMangaReferences = handler.awaitList {
+            mergedQueries.selectAll(MergedMangaMapper::map)
+        }
+
+        dbMergedMangaReferences.map {
+            MergeMangaSettingsUpdate(
+                id = it.id,
+                chapterSortMode = (it.chapterSortMode - 1).coerceAtLeast(0),
+                isInfoManga = null,
+                getChapterUpdates = null,
+                chapterPriority = null,
+                downloadChapters = null,
+            )
+        }.let { updateMergedSettings.awaitAll(it) }
+        return@withIOContext true
+    }
+}

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -48,6 +48,7 @@ val migrations: List<Migration>
         IntegratedHentaiMigration(),
         SetupAppUpdateMigration(),
         EHentaiMigration(),
+        MergedMangaDedupeModeMigration(),
         // KMK <--
         TrustExtensionRepositoryMigration(),
         CategoryPreferencesCleanupMigration(),


### PR DESCRIPTION
Introduce a migration for deduplicating merged manga settings and update the application version to reflect this change.

## Summary by Sourcery

Add a migration to deduplicate merged manga settings and bump app version to 1.13.5

Bug Fixes:
- Introduce MergedMangaDedupeModeMigration to remove duplicate merged manga entries during migration

Enhancements:
- Register MergedMangaDedupeModeMigration in the migrations list

Build:
- Bump versionCode to 77 and versionName to 1.13.5