### PR TITLE
fix(ehentai-browse): Fix eHentai tag's text color

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
@@ -43,6 +43,7 @@ import exh.metadata.metadata.EHentaiSearchMetadata
 import exh.metadata.metadata.RaisedSearchMetadata
 import exh.util.SourceTagsUtil
 import exh.util.SourceTagsUtil.GenreColor
+import exh.util.SourceTagsUtil.genreTextColor
 import exh.util.floor
 import kotlinx.coroutines.flow.StateFlow
 import tachiyomi.core.common.i18n.pluralStringResource
@@ -276,6 +277,9 @@ fun BrowseSourceEHentaiListItem(
                         style = RatingBarStyle.Fill(),
                     )
                     val color = genre?.first?.color
+                    // KMK -->
+                    val textColor = genre?.first?.let(::genreTextColor)?.let(::Color) ?: Color.Unspecified
+                    // KMK <--
                     val res = genre?.second
                     Card(
                         colors = if (color != null) {
@@ -290,6 +294,9 @@ fun BrowseSourceEHentaiListItem(
                             } else {
                                 metadata.genre.orEmpty()
                             },
+                            // KMK -->
+                            color = textColor,
+                            // KMK <--
                             modifier = Modifier.padding(vertical = 4.dp, horizontal = 8.dp),
                             maxLines = 1,
                             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/exh/util/SourceTagsUtil.kt
+++ b/app/src/main/java/exh/util/SourceTagsUtil.kt
@@ -1,5 +1,6 @@
 package exh.util
 
+import android.graphics.Color
 import androidx.annotation.ColorInt
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -113,16 +114,16 @@ object SourceTagsUtil {
 
     @ColorInt fun genreTextColor(genre: GenreColor): Int {
         return when (genre) {
-            GenreColor.DOUJINSHI_COLOR -> "#000000".toColorInt()
-            GenreColor.MANGA_COLOR -> "#000000".toColorInt()
-            GenreColor.ARTIST_CG_COLOR -> "#000000".toColorInt()
-            GenreColor.GAME_CG_COLOR -> "#000000".toColorInt()
-            GenreColor.WESTERN_COLOR -> "#000000".toColorInt()
-            GenreColor.NON_H_COLOR -> "#000000".toColorInt()
-            GenreColor.IMAGE_SET_COLOR -> "#FFFFFF".toColorInt()
-            GenreColor.COSPLAY_COLOR -> "#FFFFFF".toColorInt()
-            GenreColor.ASIAN_PORN_COLOR -> "#000000".toColorInt()
-            GenreColor.MISC_COLOR -> "#000000".toColorInt()
+            GenreColor.DOUJINSHI_COLOR -> Color.BLACK
+            GenreColor.MANGA_COLOR -> Color.BLACK
+            GenreColor.ARTIST_CG_COLOR -> Color.BLACK
+            GenreColor.GAME_CG_COLOR -> Color.BLACK
+            GenreColor.WESTERN_COLOR -> Color.BLACK
+            GenreColor.NON_H_COLOR -> Color.BLACK
+            GenreColor.IMAGE_SET_COLOR -> Color.WHITE
+            GenreColor.COSPLAY_COLOR -> Color.WHITE
+            GenreColor.ASIAN_PORN_COLOR -> Color.BLACK
+            GenreColor.MISC_COLOR -> Color.BLACK
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Improve eHentai browse tag readability and modernize color handling for genre tags.

Bug Fixes:
- Ensure eHentai genre tag text uses contrasting colors for better visibility across themes.

Enhancements:
- Replace hardcoded hex string text colors with typed Color constants for genre tag rendering.