### PR TITLE
chore: Merge `hentaiSourceIds`

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/MigrateSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/MigrateSourceScreen.kt
@@ -41,8 +41,7 @@ import eu.kanade.presentation.components.SOURCE_SEARCH_BOX_HEIGHT
 import eu.kanade.presentation.util.animateItemFastScroll
 import eu.kanade.tachiyomi.ui.browse.migration.sources.MigrateSourceScreenModel
 import eu.kanade.tachiyomi.util.system.copyToClipboard
-import exh.source.EHENTAI_EXT_SOURCES
-import exh.source.EXHENTAI_EXT_SOURCES
+import exh.source.hentaiSourceIds
 import kotlinx.collections.immutable.ImmutableList
 import tachiyomi.domain.UnsortedPreferences
 import tachiyomi.domain.source.model.Source
@@ -196,7 +195,7 @@ private fun MigrateSourceList(
                             !filterObsoleteSource ||
                                 (
                                     it.first.installedExtension?.isObsolete != false &&
-                                        (!isHentaiEnabled || it.first.id !in (EHENTAI_EXT_SOURCES.keys + EXHENTAI_EXT_SOURCES.keys))
+                                        (!isHentaiEnabled || it.first.id !in hentaiSourceIds)
                                     )
                         },
                     // KMK <--

--- a/domain/src/main/java/exh/source/DomainSourceHelpers.kt
+++ b/domain/src/main/java/exh/source/DomainSourceHelpers.kt
@@ -28,13 +28,13 @@ fun isMetadataSource(source: Long) = source in 6900..6999 ||
     metadataDelegatedSourceIds.binarySearch(source) >= 0
 
 // KMK -->
-fun Source.isEhBasedSource() = this is EhBasedSource && id in EHENTAI_EXT_SOURCES || id in EXHENTAI_EXT_SOURCES
+fun Source.isEhBasedSource() = this is EhBasedSource && id in hentaiSourceIds
 // KMK <--
 
 fun Source.isMdBasedSource() = id in mangaDexSourceIds
 
 // KMK -->
-fun Manga.isEhBasedManga() = source in EHENTAI_EXT_SOURCES || source in EXHENTAI_EXT_SOURCES
+fun Manga.isEhBasedManga() = source in hentaiSourceIds
 // KMK <--
 
 fun Source.getMainSource(): Source = if (this is EnhancedHttpSource) {

--- a/source-api/src/commonMain/kotlin/exh/source/SourceIds.kt
+++ b/source-api/src/commonMain/kotlin/exh/source/SourceIds.kt
@@ -71,6 +71,8 @@ val EXHENTAI_EXT_SOURCES = mapOf(
     EXH_SOURCE_ID to "all", // E-Hentai (Multi)
 )
 
+val hentaiSourceIds = EHENTAI_EXT_SOURCES.keys + EXHENTAI_EXT_SOURCES.keys
+
 val COMICK_IDS = setOf(
     982606170401027267, // all
     2971557565147974499, // en


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Introduce a combined hentaiSourceIds collection for EHentai and ExHentai sources and replace scattered usages of individual maps with the unified set.