### PR TITLE
fix(manga-cover-dialog): Avoid crash with SubsamplingScaleImageView (SSIV) not fully support Hardware decoder

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaCoverDialog.kt
@@ -214,7 +214,7 @@ fun MangaCoverDialog(
                                 // Because SSIV needs to thoroughly read the image
                                 // KMK -->
                                 val src = (drawable as? BitmapDrawable)?.bitmap
-                                val config = if (src?.config == Bitmap.Config.HARDWARE) Bitmap.Config.ARGB_8888 else src?.config ?: Bitmap.Config.ARGB_8888
+                                val config = src?.config?.takeIf { it != Bitmap.Config.HARDWARE } ?: Bitmap.Config.ARGB_8888
                                 // KMK <--
                                 val copy = src?.copy(config, false)
                                     ?.toDrawable(view.context.resources)


### PR DESCRIPTION
Update the bitmap configuration to ARGB_8888 to prevent crashes when using the SubsamplingScaleImageView with hardware decoding.

The comment mentions that `SubsamplingScaleImageView` (used by `ReaderPageImageView`) needs to thoroughly read the image. `SubsamplingScaleImageView` typically doesn't support hardware bitmaps (`Bitmap.Config.HARDWARE`) because it needs to access pixel data on the CPU to decode regions. Using hardware bitmaps here could lead to an `IllegalStateException` at runtime.

To ensure stability and prevent potential crashes, it's safer to use a software bitmap configuration like `Bitmap.Config.ARGB_8888`.

## Summary by Sourcery

Bug Fixes:
- Avoid crashes in the manga cover dialog by copying bitmaps with a non-HARDWARE configuration, defaulting to ARGB_8888 when necessary.