### PR TITLE
Sub-categories have been added, and the UI has undergone major change…

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -74,6 +74,8 @@ class UiPreferences(
     fun usePanoramaCoverMangaInfo() = preferenceStore.getBoolean("use_panorama_cover_manga_info", false)
 
     fun topAlignCover() = preferenceStore.getBoolean("top_align_cover", false)
+
+    fun libraryParentChildLayout() = preferenceStore.getBoolean("pref_library_parent_child_layout", false)
     // KMK <--
 
     fun recommendsInOverflow() = preferenceStore.getBoolean("recommends_in_overflow", false)

--- a/app/src/main/java/eu/kanade/presentation/category/CategoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/CategoryScreen.kt
@@ -11,7 +11,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
 import eu.kanade.presentation.category.components.CategoryFloatingActionButton
@@ -19,6 +22,7 @@ import eu.kanade.presentation.category.components.CategoryListItem
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.tachiyomi.ui.category.CategoryScreenState
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.delay
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import tachiyomi.domain.category.model.Category
@@ -37,6 +41,7 @@ fun CategoryScreen(
     onClickRename: (Category) -> Unit,
     onClickDelete: (Category) -> Unit,
     onChangeOrder: (Category, Int) -> Unit,
+    onChangeParent: (Category, Long?) -> Unit,
     // KMK -->
     onClickHide: (Category) -> Unit,
     // KMK <--
@@ -73,6 +78,7 @@ fun CategoryScreen(
             onClickRename = onClickRename,
             onClickDelete = onClickDelete,
             onChangeOrder = onChangeOrder,
+            onChangeParent = onChangeParent,
             // KMK -->
             onClickHide = onClickHide,
             // KMK <--
@@ -88,21 +94,83 @@ private fun CategoryContent(
     onClickRename: (Category) -> Unit,
     onClickDelete: (Category) -> Unit,
     onChangeOrder: (Category, Int) -> Unit,
+    onChangeParent: (Category, Long?) -> Unit,
     // KMK -->
     onClickHide: (Category) -> Unit,
     // KMK <--
 ) {
-    val categoriesState = remember { categories.toMutableStateList() }
+    val entries = remember(categories) { buildCategoryEntries(categories) }
+    val categoriesState = remember { entries.toMutableStateList() }
+    var needsRebuild by remember { mutableStateOf(false) }
+
     val reorderableState = rememberReorderableLazyListState(lazyListState, paddingValues) { from, to ->
-        val item = categoriesState.removeAt(from.index)
-        categoriesState.add(to.index, item)
-        onChangeOrder(item, to.index)
+        val movedItem = categoriesState.removeAt(from.index)
+        categoriesState.add(to.index, movedItem)
+
+        // If moving a parent category, also move all its children
+        if (movedItem.category.parentId == null && movedItem.depth == 0) {
+            // This is a parent - find all children that should move with it
+            val childrenToMove = mutableListOf<CategoryEntry>()
+
+            // Find all children by checking depth and position
+            // Children are any entries immediately following the parent with greater depth
+            var checkIndex = to.index + 1
+            while (checkIndex < categoriesState.size) {
+                val entry = categoriesState[checkIndex]
+                // Stop when we hit a non-child (same or lower depth)
+                if (entry.depth <= movedItem.depth) {
+                    break
+                }
+                childrenToMove.add(entry)
+                checkIndex++
+            }
+
+            // Remove children from their current positions
+            childrenToMove.forEach { categoriesState.remove(it) }
+
+            // Re-insert children right after parent in the correct order
+            var insertIndex = to.index + 1
+            for (child in childrenToMove) {
+                categoriesState.add(insertIndex, child)
+                insertIndex++
+            }
+            
+            // Mark for rebuild since parent position changed
+            needsRebuild = true
+        } else if (movedItem.category.parentId != null && movedItem.depth > 0) {
+            // This is a child being dragged - check if it's being moved to a new parent
+            val newParentId = findParentAtPosition(categoriesState, to.index)
+            val oldParentId = movedItem.category.parentId
+            
+            // If parent changed, update it
+            if (newParentId != oldParentId) {
+                val updatedCategory = movedItem.category.copy(parentId = newParentId)
+                movedItem.category = updatedCategory
+                onChangeParent(updatedCategory, newParentId)
+            }
+        }
+
+        // Recalculate order indices for all affected categories
+        categoriesState.forEachIndexed { index, entry ->
+            onChangeOrder(entry.category, index)
+        }
     }
 
-    LaunchedEffect(categories) {
-        if (!reorderableState.isAnyItemDragging) {
+    LaunchedEffect(entries) {
+        // Update the list when categories from database change
+        categoriesState.clear()
+        categoriesState.addAll(entries)
+        needsRebuild = false
+    }
+    
+    LaunchedEffect(needsRebuild) {
+        if (needsRebuild) {
+            // Small delay to allow database update, then rebuild
+            kotlinx.coroutines.delay(50)
+            val rebuiltEntries = buildCategoryEntries(categoriesState.map { it.category })
             categoriesState.clear()
-            categoriesState.addAll(categories)
+            categoriesState.addAll(rebuiltEntries)
+            needsRebuild = false
         }
     }
 
@@ -116,16 +184,25 @@ private fun CategoryContent(
     ) {
         items(
             items = categoriesState,
-            key = { category -> category.key },
-        ) { category ->
-            ReorderableItem(reorderableState, category.key) {
+            key = { entry -> entry.category.key },
+        ) { entry ->
+            ReorderableItem(reorderableState, entry.category.key) {
+                val parentCategory = if (entry.category.parentId != null) {
+                    categories.firstOrNull { it.id == entry.category.parentId }
+                } else {
+                    null
+                }
+
                 CategoryListItem(
                     modifier = Modifier.animateItem(),
-                    category = category,
-                    onRename = { onClickRename(category) },
-                    onDelete = { onClickDelete(category) },
+                    category = entry.category,
+                    indentLevel = entry.depth,
+                    isParent = entry.depth == 0,
+                    parentCategory = parentCategory,
+                    onRename = { onClickRename(entry.category) },
+                    onDelete = { onClickDelete(entry.category) },
                     // KMK -->
-                    onHide = { onClickHide(category) },
+                    onHide = { onClickHide(entry.category) },
                     // KMK <--
                 )
             }
@@ -134,3 +211,53 @@ private fun CategoryContent(
 }
 
 private val Category.key inline get() = "category-$id"
+
+private data class CategoryEntry(
+    var category: Category,
+    val depth: Int,
+)
+
+private fun findParentAtPosition(entries: List<CategoryEntry>, position: Int): Long? {
+    if (position <= 0) return null
+    
+    // Look backward to find the nearest parent (depth == 0)
+    for (i in position - 1 downTo 0) {
+        if (entries[i].depth == 0) {
+            return entries[i].category.id
+        }
+    }
+    return null
+}
+
+private fun buildCategoryEntries(categories: List<Category>): List<CategoryEntry> {
+    if (categories.isEmpty()) return emptyList()
+
+    val byParent = categories.groupBy { it.parentId }
+    val visited = mutableSetOf<Long>()
+    val result = mutableListOf<CategoryEntry>()
+
+    fun traverse(parentId: Long?, depth: Int) {
+        val children = byParent[parentId].orEmpty()
+            .sortedBy { it.order }
+        for (child in children) {
+            if (visited.add(child.id)) {
+                result += CategoryEntry(child, depth)
+                traverse(child.id, depth + 1)
+            }
+        }
+    }
+
+    // First pass: traverse all categories with parentId == null (top-level parents)
+    traverse(null, 0)
+
+    // Second pass: include any orphaned categories that did not get visited
+    categories.filter { it.id !in visited }
+        .sortedBy { it.order }
+        .forEach { orphan ->
+            visited.add(orphan.id)
+            result += CategoryEntry(orphan, 0)
+            traverse(orphan.id, 1)
+        }
+
+    return result
+}

--- a/app/src/main/java/eu/kanade/presentation/category/CategoryUtil.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/CategoryUtil.kt
@@ -1,0 +1,72 @@
+package eu.kanade.presentation.category
+
+import tachiyomi.domain.category.model.Category
+
+/**
+ * Represents a category with its hierarchical depth for display purposes.
+ */
+data class CategoryHierarchyEntry(
+    val category: Category,
+    val depth: Int,
+)
+
+/**
+ * Builds a hierarchical list of categories with their depth levels.
+ * Categories are ordered as parent followed by children, recursively.
+ * Orphaned categories (those with invalid parent references) are included at the end.
+ *
+ * @param categories The list of categories to organize
+ * @return A list of CategoryHierarchyEntry with proper depth values
+ */
+fun buildCategoryHierarchy(categories: List<Category>): List<CategoryHierarchyEntry> {
+    if (categories.isEmpty()) return emptyList()
+
+    val byParent = categories.groupBy { it.parentId }
+    val visited = mutableSetOf<Long>()
+    val result = mutableListOf<CategoryHierarchyEntry>()
+
+    fun traverse(parentId: Long?, depth: Int) {
+        val children = byParent[parentId].orEmpty()
+            .sortedBy { it.order }
+        for (child in children) {
+            if (visited.add(child.id)) {
+                result += CategoryHierarchyEntry(child, depth)
+                traverse(child.id, depth + 1)
+            }
+        }
+    }
+
+    // First pass: traverse all categories with parentId == null (top-level parents)
+    traverse(null, 0)
+
+    // Second pass: include any orphaned categories that did not get visited
+    categories.filter { it.id !in visited }
+        .sortedBy { it.order }
+        .forEach { orphan ->
+            visited.add(orphan.id)
+            result += CategoryHierarchyEntry(orphan, 0)
+            traverse(orphan.id, 1)
+        }
+
+    return result
+}
+
+/**
+ * Finds the parent category at a given position in a hierarchical list.
+ * Looks backward from the position to find the nearest category with depth 0.
+ *
+ * @param entries The hierarchical category list
+ * @param position The position to check
+ * @return The parent category ID, or null if no parent found
+ */
+fun findParentAtPosition(entries: List<CategoryHierarchyEntry>, position: Int): Long? {
+    if (position <= 0) return null
+    
+    // Look backward to find the nearest parent (depth == 0)
+    for (i in position - 1 downTo 0) {
+        if (entries[i].depth == 0) {
+            return entries[i].category.id
+        }
+    }
+    return null
+}

--- a/app/src/main/java/eu/kanade/presentation/category/components/CategoryListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/components/CategoryListItem.kt
@@ -1,13 +1,20 @@
 package eu.kanade.presentation.category.components
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.DragHandle
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material.icons.outlined.VisibilityOff
 import androidx.compose.material3.ElevatedCard
@@ -20,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
 import sh.calvin.reorderable.ReorderableCollectionItemScope
 import tachiyomi.domain.category.model.Category
 import tachiyomi.i18n.MR
@@ -32,48 +40,95 @@ fun ReorderableCollectionItemScope.CategoryListItem(
     category: Category,
     onRename: () -> Unit,
     onDelete: () -> Unit,
-    // KMK -->
     onHide: () -> Unit,
-    // KMK <--
+    indentLevel: Int = 0,
+    isParent: Boolean = false,
+    parentCategory: Category? = null,
     modifier: Modifier = Modifier,
 ) {
-    ElevatedCard(modifier = modifier) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable(onClick = onRename)
-                .padding(vertical = MaterialTheme.padding.small)
-                .padding(
-                    start = MaterialTheme.padding.small,
-                    end = MaterialTheme.padding.medium,
-                ),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.DragHandle,
-                contentDescription = null,
+    if (isParent && indentLevel == 0) {
+        // Parent category - container card layout
+        ParentCategoryContainer(
+            category = category,
+            onRename = onRename,
+            onDelete = onDelete,
+            onHide = onHide,
+            modifier = modifier,
+        )
+    } else {
+        // Child category - compact layout
+        ChildCategoryRow(
+            category = category,
+            onRename = onRename,
+            onDelete = onDelete,
+            onHide = onHide,
+            indentLevel = indentLevel,
+            parentCategory = parentCategory,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun ReorderableCollectionItemScope.ParentCategoryContainer(
+    category: Category,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+    onHide: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ElevatedCard(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+    ) {
+        Column {
+            // Parent header with drag handle
+            Row(
                 modifier = Modifier
-                    .padding(MaterialTheme.padding.medium)
-                    .draggableHandle(),
-            )
-            Text(
-                text = category.name,
-                // KMK -->
-                color = LocalContentColor.current.let { if (category.hidden) it.copy(alpha = 0.6f) else it },
-                textDecoration = TextDecoration.LineThrough.takeIf { category.hidden },
-                // KMK <--
-                modifier = Modifier.weight(1f),
-            )
-            IconButton(onClick = onRename) {
+                    .fillMaxWidth()
+                    .padding(vertical = MaterialTheme.padding.small)
+                    .padding(horizontal = MaterialTheme.padding.medium),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                // Drag handle
                 Icon(
-                    imageVector = Icons.Outlined.Edit,
-                    contentDescription = stringResource(MR.strings.action_rename_category),
+                    imageVector = Icons.Outlined.DragHandle,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(end = MaterialTheme.padding.medium)
+                        .draggableHandle(),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-            }
-            // KMK -->
-            IconButton(
-                onClick = onHide,
-                content = {
+
+                // Folder icon
+                Icon(
+                    imageVector = Icons.Outlined.Folder,
+                    contentDescription = null,
+                    modifier = Modifier.padding(end = MaterialTheme.padding.medium),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+
+                // Category name (not clickable - use edit button)
+                Text(
+                    text = category.name,
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = LocalContentColor.current.let {
+                        if (category.hidden) it.copy(alpha = 0.6f) else it
+                    },
+                    textDecoration = TextDecoration.LineThrough.takeIf { category.hidden },
+                )
+
+                // Action buttons
+                IconButton(onClick = onRename, modifier = Modifier.padding(0.dp)) {
+                    Icon(
+                        imageVector = Icons.Outlined.Edit,
+                        contentDescription = stringResource(MR.strings.action_rename_category),
+                        modifier = Modifier.padding(4.dp),
+                    )
+                }
+                IconButton(onClick = onHide, modifier = Modifier.padding(0.dp)) {
                     Icon(
                         imageVector = if (category.hidden) {
                             Icons.Outlined.Visibility
@@ -81,16 +136,134 @@ fun ReorderableCollectionItemScope.CategoryListItem(
                             Icons.Outlined.VisibilityOff
                         },
                         contentDescription = stringResource(KMR.strings.action_hide),
+                        modifier = Modifier.padding(4.dp),
                     )
-                },
-            )
-            // KMK <--
-            IconButton(onClick = onDelete) {
-                Icon(
-                    imageVector = Icons.Outlined.Delete,
-                    contentDescription = stringResource(MR.strings.action_delete),
-                )
+                }
+                IconButton(onClick = onDelete, modifier = Modifier.padding(0.dp)) {
+                    Icon(
+                        imageVector = Icons.Outlined.Delete,
+                        contentDescription = stringResource(MR.strings.action_delete),
+                        modifier = Modifier.padding(4.dp),
+                    )
+                }
             }
         }
     }
 }
+
+@Composable
+private fun ReorderableCollectionItemScope.ChildCategoryRow(
+    category: Category,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+    onHide: () -> Unit,
+    indentLevel: Int = 0,
+    parentCategory: Category? = null,
+    modifier: Modifier = Modifier,
+) {
+    val startIndent = 8.dp + (indentLevel.coerceAtLeast(0) * 16).dp
+
+    Column(modifier = modifier) {
+        // Child item row
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = startIndent, end = MaterialTheme.padding.small)
+                .padding(vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Drag handle
+            Icon(
+                imageVector = Icons.Outlined.DragHandle,
+                contentDescription = null,
+                modifier = Modifier
+                    .padding(end = 4.dp)
+                    .draggableHandle(),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            // Tree connector line visual
+            Box(
+                modifier = Modifier
+                    .width(2.dp)
+                    .height(24.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                        shape = RoundedCornerShape(1.dp),
+                    )
+                    .padding(end = 8.dp),
+            )
+
+            // Category name with strikethrough if hidden (not clickable - use edit button)
+            Text(
+                text = category.name,
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = MaterialTheme.padding.small),
+                style = MaterialTheme.typography.bodyMedium,
+                color = LocalContentColor.current.let {
+                    if (category.hidden) it.copy(alpha = 0.6f) else it
+                },
+                textDecoration = TextDecoration.LineThrough.takeIf { category.hidden },
+            )
+
+            // Action buttons (compact)
+            IconButton(onClick = onRename, modifier = Modifier.padding(4.dp)) {
+                Icon(
+                    imageVector = Icons.Outlined.Edit,
+                    contentDescription = stringResource(MR.strings.action_rename_category),
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .width(18.dp),
+                )
+            }
+                IconButton(onClick = onHide, modifier = Modifier.padding(4.dp)) {
+                    Icon(
+                        imageVector = if (category.hidden) {
+                            Icons.Outlined.Visibility
+                        } else {
+                            Icons.Outlined.VisibilityOff
+                        },
+                        contentDescription = stringResource(KMR.strings.action_hide),
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .width(18.dp),
+                    )
+                }
+                IconButton(onClick = onDelete, modifier = Modifier.padding(4.dp)) {
+                    Icon(
+                        imageVector = Icons.Outlined.Delete,
+                        contentDescription = stringResource(MR.strings.action_delete),
+                        modifier = Modifier
+                            .padding(4.dp)
+                            .width(18.dp),
+                    )
+                }
+            }
+
+            // Parent info footer
+            if (parentCategory != null) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = startIndent + 10.dp,
+                            end = MaterialTheme.padding.small,
+                            top = 2.dp,
+                            bottom = 8.dp,
+                        )
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                            shape = RoundedCornerShape(4.dp),
+                        )
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = "Parent: ${parentCategory.name}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }

--- a/app/src/main/java/eu/kanade/presentation/category/components/CategoryListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/category/components/CategoryListItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -198,72 +199,56 @@ private fun ReorderableCollectionItemScope.ChildCategoryRow(
             Text(
                 text = category.name,
                 modifier = Modifier
-                    .weight(1f)
-                    .padding(start = MaterialTheme.padding.small),
+                    .padding(start = 8.dp, end = 4.dp),
                 style = MaterialTheme.typography.bodyMedium,
                 color = LocalContentColor.current.let {
                     if (category.hidden) it.copy(alpha = 0.6f) else it
                 },
                 textDecoration = TextDecoration.LineThrough.takeIf { category.hidden },
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
             )
 
+            // Parent info label (inline)
+            if (parentCategory != null) {
+                Text(
+                    text = "Parent: ${parentCategory.name}",
+                    modifier = Modifier.padding(horizontal = 8.dp),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
             // Action buttons (compact)
-            IconButton(onClick = onRename, modifier = Modifier.padding(4.dp)) {
+            IconButton(onClick = onRename, modifier = Modifier.padding(0.dp).size(32.dp)) {
                 Icon(
                     imageVector = Icons.Outlined.Edit,
                     contentDescription = stringResource(MR.strings.action_rename_category),
-                    modifier = Modifier
-                        .padding(4.dp)
-                        .width(18.dp),
+                    modifier = Modifier.size(16.dp),
                 )
             }
-                IconButton(onClick = onHide, modifier = Modifier.padding(4.dp)) {
-                    Icon(
-                        imageVector = if (category.hidden) {
-                            Icons.Outlined.Visibility
-                        } else {
-                            Icons.Outlined.VisibilityOff
-                        },
-                        contentDescription = stringResource(KMR.strings.action_hide),
-                        modifier = Modifier
-                            .padding(4.dp)
-                            .width(18.dp),
-                    )
-                }
-                IconButton(onClick = onDelete, modifier = Modifier.padding(4.dp)) {
-                    Icon(
-                        imageVector = Icons.Outlined.Delete,
-                        contentDescription = stringResource(MR.strings.action_delete),
-                        modifier = Modifier
-                            .padding(4.dp)
-                            .width(18.dp),
-                    )
-                }
+            IconButton(onClick = onHide, modifier = Modifier.padding(0.dp).size(32.dp)) {
+                Icon(
+                    imageVector = if (category.hidden) {
+                        Icons.Outlined.Visibility
+                    } else {
+                        Icons.Outlined.VisibilityOff
+                    },
+                    contentDescription = stringResource(KMR.strings.action_hide),
+                    modifier = Modifier.size(16.dp),
+                )
             }
-
-            // Parent info footer
-            if (parentCategory != null) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            start = startIndent + 10.dp,
-                            end = MaterialTheme.padding.small,
-                            top = 2.dp,
-                            bottom = 8.dp,
-                        )
-                        .background(
-                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
-                            shape = RoundedCornerShape(4.dp),
-                        )
-                        .padding(horizontal = 8.dp, vertical = 4.dp),
-                ) {
-                    Text(
-                        text = "Parent: ${parentCategory.name}",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+            IconButton(onClick = onDelete, modifier = Modifier.padding(0.dp).size(32.dp)) {
+                Icon(
+                    imageVector = Icons.Outlined.Delete,
+                    contentDescription = stringResource(MR.strings.action_delete),
+                    modifier = Modifier.size(16.dp),
+                )
             }
         }
     }
+}

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
@@ -1,42 +1,59 @@
 package eu.kanade.presentation.library.components
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import eu.kanade.core.preference.PreferenceMutableState
+import eu.kanade.presentation.category.visualName
 import eu.kanade.tachiyomi.ui.library.LibraryItem
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import tachiyomi.domain.category.model.Category
+import tachiyomi.i18n.MR
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.presentation.core.components.material.PullRefresh
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
 fun LibraryContent(
     categories: List<Category>,
-    // KMK -->
-    activeCategoryIndex: Int,
-    // KMK <--
     searchQuery: String?,
     selection: Set<Long>,
     contentPadding: PaddingValues,
     currentPage: Int,
     hasActiveFilters: Boolean,
     showPageTabs: Boolean,
+    showParentFilters: Boolean,
     onChangeCurrentPage: (Int) -> Unit,
     onClickManga: (Long) -> Unit,
     onContinueReadingClicked: ((LibraryManga) -> Unit)?,
@@ -49,6 +66,18 @@ fun LibraryContent(
     getColumnsForOrientation: (Boolean) -> PreferenceMutableState<Int>,
     getItemsForCategory: (Category) -> List<LibraryItem>,
 ) {
+    // Build parent list and display list depending on parent selection
+    val parentCategories = remember(categories) { categories.filter { it.parentId == null && !it.isSystemCategory } }
+    var activeParentId by rememberSaveable { mutableStateOf<Long?>(null) }
+
+    val displayCategories = remember(categories, activeParentId, showParentFilters) {
+        if (!showParentFilters || activeParentId == null) categories else {
+            val parent = categories.firstOrNull { it.id == activeParentId }
+            val children = categories.filter { it.parentId == activeParentId }
+            (listOfNotNull(parent) + children).ifEmpty { categories }
+        }
+    }
+
     Column(
         modifier = Modifier.padding(
             top = contentPadding.calculateTopPadding(),
@@ -56,18 +85,30 @@ fun LibraryContent(
             end = contentPadding.calculateEndPadding(LocalLayoutDirection.current),
         ),
     ) {
-        val pagerState = rememberPagerState(currentPage) { categories.size }
+        val pagerState = rememberPagerState(currentPage) { displayCategories.size }
 
         val scope = rememberCoroutineScope()
         var isRefreshing by remember(pagerState.currentPage) { mutableStateOf(false) }
 
-        if (showPageTabs && categories.isNotEmpty() && (categories.size > 1 || !categories.first().isSystemCategory)) {
-            LaunchedEffect(categories) {
-                // KMK -->
+        if (showParentFilters && parentCategories.isNotEmpty()) {
+            ParentChipsRow(
+                parents = parentCategories,
+                activeParentId = activeParentId,
+                onParentChange = { newParent ->
+                    activeParentId = newParent
+                    // Reset pager to first page for new selection
+                    val target = 0
+                    scope.launch { pagerState.scrollToPage(target) }
+                },
+            )
+        }
+
+        if (showPageTabs && displayCategories.isNotEmpty() && (displayCategories.size > 1 || !displayCategories.first().isSystemCategory)) {
+            LaunchedEffect(displayCategories) {
                 val targetPage = when {
-                    categories.isEmpty() -> 0
-                    activeCategoryIndex != pagerState.currentPage -> activeCategoryIndex.coerceAtMost(categories.size - 1)
-                    pagerState.currentPage >= categories.size -> categories.size - 1
+                    displayCategories.isEmpty() -> 0
+                    currentPage != pagerState.currentPage -> currentPage.coerceAtMost(displayCategories.size - 1)
+                    pagerState.currentPage >= displayCategories.size -> displayCategories.size - 1
                     else -> pagerState.currentPage
                 }
                 if (targetPage != pagerState.currentPage) {
@@ -76,7 +117,7 @@ fun LibraryContent(
                 // KMK <--
             }
             LibraryTabs(
-                categories = categories,
+                categories = displayCategories,
                 pagerState = pagerState,
                 getItemCountForCategory = getItemCountForCategory,
                 onTabItemClick = {
@@ -108,7 +149,7 @@ fun LibraryContent(
                 selection = selection,
                 searchQuery = searchQuery,
                 onGlobalSearchClicked = onGlobalSearchClicked,
-                getCategoryForPage = { page -> categories[page] },
+                getCategoryForPage = { page -> displayCategories[page] },
                 getDisplayMode = getDisplayMode,
                 getColumnsForOrientation = getColumnsForOrientation,
                 getItemsForCategory = getItemsForCategory,
@@ -126,6 +167,85 @@ fun LibraryContent(
 
         LaunchedEffect(pagerState.currentPage) {
             onChangeCurrentPage(pagerState.currentPage)
+        }
+    }
+}
+
+@Composable
+private fun ParentChipsRow(
+    parents: List<Category>,
+    activeParentId: Long?,
+    onParentChange: (Long?) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small)
+            .horizontalScroll(rememberScrollState())
+            .wrapContentHeight(),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        FilterChip(
+            selected = activeParentId == null,
+            onClick = { onParentChange(null) },
+            label = { Text(stringResource(MR.strings.all)) },
+        )
+        parents.sortedBy { it.order }.forEach { parent ->
+            FilterChip(
+                selected = activeParentId == parent.id,
+                onClick = { onParentChange(parent.id) },
+                label = { Text(parent.visualName) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ParentCategoryMenu(
+    parents: List<Category>,
+    activeParentId: Long?,
+    onParentChange: (Long?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val sortedParents = remember(parents) { parents.sortedBy { it.order } }
+    val defaultLabel = stringResource(MR.strings.categories)
+    val currentParent = remember(activeParentId, sortedParents) {
+        sortedParents.firstOrNull { it.id == activeParentId }
+    }
+    val currentLabel = if (currentParent != null) currentParent.visualName else defaultLabel
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(MR.strings.categories),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.weight(1f))
+        Box {
+            TextButton(onClick = { expanded = true }) {
+                Text(currentLabel)
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.strings.none)) },
+                    onClick = {
+                        onParentChange(null)
+                        expanded = false
+                    },
+                )
+                sortedParents.forEach { parent ->
+                    DropdownMenuItem(
+                        text = { Text(parent.visualName) },
+                        onClick = {
+                            onParentChange(parent.id)
+                            expanded = false
+                        },
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryToolbar.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AccountTree
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -251,6 +251,11 @@ object SettingsAppearanceScreen : SearchableSettings {
                         true
                     },
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.libraryParentChildLayout(),
+                    title = "Library parent/child layout",
+                    subtitle = "Use parent-sub categories in Library tab",
+                ),
                 Preference.PreferenceItem.ListPreference(
                     preference = uiPreferences.dateFormat(),
                     entries = DateFormats

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupCategory.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupCategory.kt
@@ -11,6 +11,7 @@ class BackupCategory(
     @ProtoNumber(3) var id: Long = 0,
     // @ProtoNumber(3) val updateInterval: Int = 0, 1.x value not used in 0.x
     @ProtoNumber(100) var flags: Long = 0,
+    @ProtoNumber(901) var parentId: Long? = null,
     // KMK -->
     @ProtoNumber(900) var hidden: Boolean = false,
     // KMK <--
@@ -22,6 +23,7 @@ class BackupCategory(
         name = this@BackupCategory.name,
         flags = this@BackupCategory.flags,
         order = this@BackupCategory.order,
+        parentId = this@BackupCategory.parentId,
         // KMK -->
         hidden = this@BackupCategory.hidden,
         // KMK <--
@@ -35,6 +37,7 @@ val backupCategoryMapper = { category: Category ->
         name = category.name,
         order = category.order,
         flags = category.flags,
+        parentId = category.parentId,
         // KMK -->
         hidden = category.hidden,
         // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/CategoriesRestorer.kt
@@ -30,6 +30,7 @@ class CategoriesRestorer(
                             it.name,
                             order,
                             it.flags,
+                            parentId = it.parentId,
                             // KMK -->
                             hidden = if (it.hidden) 1L else 0L,
                             // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreen.kt
@@ -113,12 +113,3 @@ private fun isDescendantOf(candidate: Category, parent: Category, allCategories:
     }
     return false
 }
-
-private fun isDescendantOfCategory(candidate: Category, parent: Category, allCategories: List<Category>): Boolean {
-    var currentParentId = candidate.parentId
-    while (currentParentId != null) {
-        if (currentParentId == parent.id) return true
-        currentParentId = allCategories.firstOrNull { it.id == currentParentId }?.parentId
-    }
-    return false
-}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreen.kt
@@ -17,6 +17,7 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.collectLatest
+import tachiyomi.domain.category.model.Category
 import tachiyomi.presentation.core.screens.LoadingScreen
 
 class CategoryScreen : Screen() {
@@ -42,6 +43,7 @@ class CategoryScreen : Screen() {
             onClickRename = { screenModel.showDialog(CategoryDialog.Rename(it)) },
             onClickDelete = { screenModel.showDialog(CategoryDialog.Delete(it)) },
             onChangeOrder = screenModel::changeOrder,
+            onChangeParent = screenModel::changeParent,
             // KMK -->
             onClickHide = screenModel::hideCategory,
             // KMK <--
@@ -55,14 +57,29 @@ class CategoryScreen : Screen() {
                     onDismissRequest = screenModel::dismissDialog,
                     onCreate = screenModel::createCategory,
                     categories = successState.categories.fastMap { it.name }.toImmutableList(),
+                    parentOptions = successState.categories
+                        .filter { it.parentId == null }
+                        .filterNot { it.isSystemCategory }
+                        .toImmutableList(),
                 )
             }
             is CategoryDialog.Rename -> {
                 CategoryRenameDialog(
                     onDismissRequest = screenModel::dismissDialog,
-                    onRename = { screenModel.renameCategory(dialog.category, it) },
+                    onRename = { newName, parentId -> screenModel.renameCategory(dialog.category, newName, parentId) },
                     categories = successState.categories.fastMap { it.name }.toImmutableList(),
                     category = dialog.category.name,
+                    parentOptions = successState.categories
+                        .filterNot { candidate ->
+                            // Can't be: itself, a system category, a descendant of this category, or a subcategory
+                            candidate.id == dialog.category.id ||
+                            candidate.isSystemCategory ||
+                            candidate.parentId != null ||  // Exclude subcategories (only show parent categories)
+                            isDescendantOf(candidate, dialog.category, successState.categories)
+                        }
+                        .toImmutableList(),
+                    initialParentId = dialog.category.parentId,
+                    categoryHasChildren = hasCategoryChildren(dialog.category, successState.categories),
                 )
             }
             is CategoryDialog.Delete -> {
@@ -82,4 +99,26 @@ class CategoryScreen : Screen() {
             }
         }
     }
+}
+
+private fun hasCategoryChildren(category: Category, allCategories: List<Category>): Boolean {
+    return allCategories.any { it.parentId == category.id }
+}
+
+private fun isDescendantOf(candidate: Category, parent: Category, allCategories: List<Category>): Boolean {
+    var currentParentId = candidate.parentId
+    while (currentParentId != null) {
+        if (currentParentId == parent.id) return true
+        currentParentId = allCategories.firstOrNull { it.id == currentParentId }?.parentId
+    }
+    return false
+}
+
+private fun isDescendantOfCategory(candidate: Category, parent: Category, allCategories: List<Category>): Boolean {
+    var currentParentId = candidate.parentId
+    while (currentParentId != null) {
+        if (currentParentId == parent.id) return true
+        currentParentId = allCategories.firstOrNull { it.id == currentParentId }?.parentId
+    }
+    return false
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/CategoryScreenModel.kt
@@ -51,9 +51,9 @@ class CategoryScreenModel(
         }
     }
 
-    fun createCategory(name: String) {
+    fun createCategory(name: String, parentId: Long?) {
         screenModelScope.launch {
-            when (createCategoryWithName.await(name)) {
+            when (createCategoryWithName.await(name, parentId)) {
                 is CreateCategoryWithName.Result.InternalError -> _events.send(CategoryEvent.InternalError)
                 else -> {}
             }
@@ -89,9 +89,18 @@ class CategoryScreenModel(
         }
     }
 
-    fun renameCategory(category: Category, name: String) {
+    fun renameCategory(category: Category, name: String, parentId: Long?) {
         screenModelScope.launch {
-            when (renameCategory.await(category, name)) {
+            when (renameCategory.await(category, name, parentId)) {
+                is RenameCategory.Result.InternalError -> _events.send(CategoryEvent.InternalError)
+                else -> {}
+            }
+        }
+    }
+
+    fun changeParent(category: Category, newParentId: Long?) {
+        screenModelScope.launch {
+            when (renameCategory.await(category, category.name, newParentId)) {
                 is RenameCategory.Result.InternalError -> _events.send(CategoryEvent.InternalError)
                 else -> {}
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/genre/SortTagScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/genre/SortTagScreen.kt
@@ -47,7 +47,7 @@ class SortTagScreen : Screen() {
             SortTagDialog.Create -> {
                 CategoryCreateDialog(
                     onDismissRequest = screenModel::dismissDialog,
-                    onCreate = { screenModel.createTag(it) },
+                    onCreate = { name, _ -> screenModel.createTag(name) },
                     categories = successState.tags,
                     title = stringResource(SYMR.strings.add_tag),
                     extraMessage = stringResource(SYMR.strings.action_add_tags_message),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/sources/SourceCategoryScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/sources/SourceCategoryScreen.kt
@@ -49,7 +49,7 @@ class SourceCategoryScreen : Screen() {
             SourceCategoryDialog.Create -> {
                 CategoryCreateDialog(
                     onDismissRequest = screenModel::dismissDialog,
-                    onCreate = { screenModel.createCategory(it) },
+                    onCreate = { name, _ -> screenModel.createCategory(name) },
                     // SY -->
                     categories = successState.categories,
                     title = stringResource(MR.strings.action_add_category),
@@ -59,7 +59,7 @@ class SourceCategoryScreen : Screen() {
             is SourceCategoryDialog.Rename -> {
                 CategoryRenameDialog(
                     onDismissRequest = screenModel::dismissDialog,
-                    onRename = { screenModel.renameCategory(dialog.category, it) },
+                    onRename = { newName, _ -> screenModel.renameCategory(dialog.category, newName) },
                     // SY -->
                     categories = successState.categories,
                     category = dialog.category,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -56,6 +56,7 @@ import exh.source.nHentaiSourceIds
 import exh.util.cancellable
 import exh.util.isLewd
 import exh.util.nullIfBlank
+import eu.kanade.domain.ui.UiPreferences
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.PersistentList
@@ -138,6 +139,7 @@ class LibraryScreenModel(
     private val updateManga: UpdateManga = Injekt.get(),
     private val setMangaCategories: SetMangaCategories = Injekt.get(),
     private val preferences: BasePreferences = Injekt.get(),
+    private val uiPreferences: UiPreferences = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
     private val coverCache: CoverCache = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
@@ -291,11 +293,12 @@ class LibraryScreenModel(
                         it.ifEmpty {
                             mapOf(
                                 Category(
-                                    0,
-                                    preferences.context.stringResource(MR.strings.default_category),
-                                    0,
-                                    0,
-                                    false,
+                                    id = 0,
+                                    name = preferences.context.stringResource(MR.strings.default_category),
+                                    order = 0,
+                                    flags = 0,
+                                    parentId = null,
+                                    hidden = false,
                                 ) to emptyList(),
                             )
                         }
@@ -316,13 +319,15 @@ class LibraryScreenModel(
             libraryPreferences.categoryTabs().changes(),
             libraryPreferences.categoryNumberOfItems().changes(),
             libraryPreferences.showContinueReadingButton().changes(),
-        ) { a, b, c -> arrayOf(a, b, c) }
-            .onEach { (showCategoryTabs, showMangaCount, showMangaContinueButton) ->
+            uiPreferences.libraryParentChildLayout().changes(),
+        ) { a, b, c, d -> arrayOf(a, b, c, d) }
+            .onEach { (showCategoryTabs, showMangaCount, showMangaContinueButton, showParentFilters) ->
                 mutableState.update { state ->
                     state.copy(
                         showCategoryTabs = showCategoryTabs,
                         showMangaCount = showMangaCount,
                         showMangaContinueButton = showMangaContinueButton,
+                        showParentFilters = showParentFilters,
                     )
                 }
             }
@@ -598,13 +603,12 @@ class LibraryScreenModel(
             LibraryGroup.UNGROUPED -> {
                 return mapOf(
                     Category(
-                        0,
-                        preferences.context.stringResource(SYMR.strings.ungrouped),
-                        0,
-                        0,
-                        // KMK -->
-                        false,
-                        // KMK <--
+                        id = 0,
+                        name = preferences.context.stringResource(SYMR.strings.ungrouped),
+                        order = 0,
+                        flags = 0,
+                        parentId = null,
+                        hidden = false,
                     ) to
                         map { it.id },
                 )
@@ -1393,12 +1397,9 @@ class LibraryScreenModel(
         val newIndex = mutableState.updateAndGet { state ->
             state.copy(
                 activeCategoryIndex = index,
-                // KMK -->
-                activeCategoryId = state.displayedCategories.getOrNull(index)?.id,
-                // KMK <--
             )
         }
-            .coercedActiveCategoryIndex
+            .activeCategoryIndex
 
         libraryPreferences.lastUsedCategory().set(newIndex)
     }
@@ -1485,6 +1486,7 @@ class LibraryScreenModel(
                         order = trackStatus.ordinal.toLong(),
                         // KMK <--
                         flags = 0,
+                        parentId = null,
                         // KMK -->
                         hidden = false,
                         // KMK <--
@@ -1515,6 +1517,7 @@ class LibraryScreenModel(
                         },
                         order = sourceOrderMap[it.id] ?: Long.MAX_VALUE,
                         flags = 0,
+                        parentId = null,
                         // KMK -->
                         hidden = false,
                         // KMK <--
@@ -1535,6 +1538,7 @@ class LibraryScreenModel(
                         name = context.stringResource(nameRes),
                         order = order,
                         flags = 0,
+                        parentId = null,
                         // KMK -->
                         hidden = false,
                         // KMK <--
@@ -1658,12 +1662,10 @@ class LibraryScreenModel(
         val showCategoryTabs: Boolean = false,
         val showMangaCount: Boolean = false,
         val showMangaContinueButton: Boolean = false,
+        val showParentFilters: Boolean = false,
         val dialog: Dialog? = null,
         val libraryData: LibraryData = LibraryData(),
-        private val activeCategoryIndex: Int = 0,
-        // KMK -->
-        private val activeCategoryId: Long? = null,
-        // KMK <--
+        val activeCategoryIndex: Int = 0,
         private val groupedFavorites: Map<Category, List</* LibraryItem */ Long>> = emptyMap(),
         // SY -->
         val showSyncExh: Boolean = false,
@@ -1676,21 +1678,9 @@ class LibraryScreenModel(
         val excludedCategories: ImmutableSet<Long> = persistentSetOf(),
         // KMK <--
     ) {
-        /**
-         * The grouped tabs which is displayed above the library screen.
-         * They can be actual [Category] or [Source], [Track]...
-         */
-        val displayedCategories: List<Category> = groupedFavorites.keys.toList()
+        val categories = groupedFavorites.keys.toList()
 
-        val coercedActiveCategoryIndex = /* KMK --> */ displayedCategories.indexOfFirst { it.id == activeCategoryId }
-            .takeIf { it != -1 } ?: activeCategoryIndex
-            // KMK <--
-            .coerceIn(
-                minimumValue = 0,
-                maximumValue = displayedCategories.lastIndex.coerceAtLeast(0),
-            )
-
-        val activeCategory: Category? = displayedCategories.getOrNull(coercedActiveCategoryIndex)
+        val activeCategory: Category? = categories.getOrNull(activeCategoryIndex)
 
         val isLibraryEmpty = libraryData.favorites.isEmpty()
 
@@ -1725,7 +1715,7 @@ class LibraryScreenModel(
 
         fun getItemsForCategoryId(categoryId: Long?): List<LibraryItem> {
             if (categoryId == null) return emptyList()
-            val category = displayedCategories.find { it.id == categoryId } ?: return emptyList()
+            val category = categories.find { it.id == categoryId } ?: return emptyList()
             return getItemsForCategory(category)
         }
 
@@ -1742,7 +1732,7 @@ class LibraryScreenModel(
             defaultCategoryTitle: String,
             page: Int,
         ): LibraryToolbarTitle {
-            val category = displayedCategories.getOrNull(page) ?: return LibraryToolbarTitle(defaultTitle)
+            val category = categories.getOrNull(page) ?: return LibraryToolbarTitle(defaultTitle)
             val categoryName = category.let {
                 if (it.isSystemCategory) defaultCategoryTitle else it.name
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -148,7 +148,7 @@ data object LibraryTab : Tab {
                 val title = state.getToolbarTitle(
                     defaultTitle = stringResource(MR.strings.label_library),
                     defaultCategoryTitle = stringResource(MR.strings.label_default),
-                    page = state.coercedActiveCategoryIndex,
+                    page = state.activeCategoryIndex,
                 )
                 LibraryToolbar(
                     hasActiveFilters = state.hasActiveFilters,
@@ -301,16 +301,14 @@ data object LibraryTab : Tab {
                 }
                 else -> {
                     LibraryContent(
-                        categories = state.displayedCategories,
-                        // KMK -->
-                        activeCategoryIndex = state.coercedActiveCategoryIndex,
-                        // KMK <--
+                        categories = state.categories,
                         searchQuery = state.searchQuery,
                         selection = state.selection,
                         contentPadding = contentPadding,
-                        currentPage = state.coercedActiveCategoryIndex,
+                        currentPage = { state.categories.indexOfFirst { it.id == state.activeCategory?.id }.takeIf { it != -1 } ?: 0 }(),
                         hasActiveFilters = state.hasActiveFilters,
                         showPageTabs = state.showCategoryTabs || !state.searchQuery.isNullOrEmpty(),
+                        showParentFilters = state.showParentFilters && state.categories.any { it.parentId == null && !it.isSystemCategory },
                         onChangeCurrentPage = screenModel::updateActiveCategoryIndex,
                         onClickManga = { navigator.push(MangaScreen(it)) },
                         onContinueReadingClicked = { it: LibraryManga ->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -305,7 +305,7 @@ data object LibraryTab : Tab {
                         searchQuery = state.searchQuery,
                         selection = state.selection,
                         contentPadding = contentPadding,
-                        currentPage = { state.categories.indexOfFirst { it.id == state.activeCategory?.id }.takeIf { it != -1 } ?: 0 }(),
+                        currentPage = state.activeCategoryIndex.coerceIn(0, state.categories.lastIndex.coerceAtLeast(0)),
                         hasActiveFilters = state.hasActiveFilters,
                         showPageTabs = state.showCategoryTabs || !state.searchQuery.isNullOrEmpty(),
                         showParentFilters = state.showParentFilters && state.categories.any { it.parentId == null && !it.isSystemCategory },

--- a/app/src/main/java/mihon/core/migration/migrations/MoveSortingModeSettingsMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/MoveSortingModeSettingsMigration.kt
@@ -40,9 +40,11 @@ class MoveSortingModeSettingsMigration : Migration {
                         flags = it.flags and 0b00111100L.inv(),
                         name = null,
                         order = null,
+                        parentId = null,
                         // KMK -->
                         hidden = null,
                         // KMK <--
+
                     )
                 }
         }

--- a/app/src/test/kotlin/Tester.kt
+++ b/app/src/test/kotlin/Tester.kt
@@ -81,6 +81,7 @@ class Tester {
                 name = "a",
                 order = 1,
                 flags = 0,
+                parentId = null,
                 // KMK -->
                 hidden = false,
                 // KMK <--

--- a/data/src/main/java/tachiyomi/data/category/CategoryMapper.kt
+++ b/data/src/main/java/tachiyomi/data/category/CategoryMapper.kt
@@ -8,6 +8,7 @@ object CategoryMapper {
         name: String,
         order: Long,
         flags: Long,
+        parentId: Long?,
         // KMK -->
         hidden: Long,
         // KMK <--
@@ -17,6 +18,7 @@ object CategoryMapper {
             name = name,
             order = order,
             flags = flags,
+            parentId = parentId,
             // KMK -->
             hidden = hidden == 1L,
             // KMK <--

--- a/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/category/CategoryRepositoryImpl.kt
@@ -42,6 +42,7 @@ class CategoryRepositoryImpl(
                 name = category.name,
                 order = category.order,
                 flags = category.flags,
+                parentId = category.parentId,
                 // KMK -->
                 hidden = if (category.hidden) 1L else 0L,
                 // KMK <--
@@ -70,6 +71,7 @@ class CategoryRepositoryImpl(
             name = update.name,
             order = update.order,
             flags = update.flags,
+            parentId = update.parentId,
             // KMK -->
             hidden = update.hidden?.let { if (it) 1L else 0L },
             // KMK <--

--- a/data/src/main/sqldelight/tachiyomi/data/categories.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/categories.sq
@@ -7,13 +7,14 @@ CREATE TABLE categories(
     sort INTEGER NOT NULL,
     flags INTEGER NOT NULL,
     manga_order TEXT AS List<Long> NOT NULL,
+    parent_id INTEGER REFERENCES categories (_id),
     -- KMK -->
     hidden INTEGER NOT NULL DEFAULT 0
     -- KMK <--
 );
 
 -- Insert system category
-INSERT OR IGNORE INTO categories(_id, name, sort, flags, manga_order, hidden) VALUES (0, "", -1, 0, "", 0);
+INSERT OR IGNORE INTO categories(_id, name, sort, flags, manga_order, parent_id, hidden) VALUES (0, "", -1, 0, "", NULL, 0);
 -- Disallow deletion of default category
 CREATE TRIGGER IF NOT EXISTS system_category_delete_trigger BEFORE DELETE
 ON categories
@@ -24,7 +25,7 @@ BEGIN SELECT CASE
 END;
 
 getCategory:
-SELECT _id,name,sort,flags,hidden
+SELECT _id,name,sort,flags,parent_id,hidden
 FROM categories
 WHERE _id = :id
 LIMIT 1;
@@ -35,6 +36,7 @@ _id AS id,
 name,
 sort AS `order`,
 flags,
+parent_id,
 -- KMK -->
 hidden
 -- KMK <--
@@ -47,6 +49,7 @@ C._id AS id,
 C.name,
 C.sort AS `order`,
 C.flags,
+C.parent_id,
 -- KMK -->
 C.hidden
 -- KMK <--
@@ -56,8 +59,8 @@ ON C._id = MC.category_id
 WHERE MC.manga_id = :mangaId;
 
 insert:
-INSERT INTO categories(name, sort, flags, manga_order, hidden)
-VALUES (:name, :order, :flags, "", :hidden);
+INSERT INTO categories(name, sort, flags, manga_order, parent_id, hidden)
+VALUES (:name, :order, :flags, "", :parentId, :hidden);
 
 delete:
 DELETE FROM categories
@@ -68,6 +71,7 @@ UPDATE categories
 SET name = coalesce(:name, name),
     sort = coalesce(:order, sort),
     flags = coalesce(:flags, flags),
+    parent_id = coalesce(:parentId, parent_id),
     -- KMK -->
     hidden = coalesce(:hidden, hidden)
     -- KMK <--

--- a/data/src/main/sqldelight/tachiyomi/migrations/42.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/42.sqm
@@ -1,0 +1,2 @@
+ALTER TABLE categories ADD COLUMN parent_id INTEGER REFERENCES categories(_id);
+CREATE INDEX IF NOT EXISTS categories_parent_id_index ON categories(parent_id);

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/CreateCategoryWithName.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/CreateCategoryWithName.kt
@@ -18,7 +18,7 @@ class CreateCategoryWithName(
             return sort.type.flag or sort.direction.flag
         }
 
-    suspend fun await(name: String): Result = withNonCancellableContext {
+    suspend fun await(name: String, parentId: Long? = null): Result = withNonCancellableContext {
         val categories = categoryRepository.getAll()
         val nextOrder = categories.maxOfOrNull { it.order }?.plus(1) ?: 0
         val newCategory = Category(
@@ -26,6 +26,7 @@ class CreateCategoryWithName(
             name = name,
             order = nextOrder,
             flags = initialFlags,
+            parentId = parentId,
             // KMK -->
             hidden = false,
             // KMK <--

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/RenameCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/RenameCategory.kt
@@ -11,10 +11,11 @@ class RenameCategory(
     private val categoryRepository: CategoryRepository,
 ) {
 
-    suspend fun await(categoryId: Long, name: String) = withNonCancellableContext {
+    suspend fun await(categoryId: Long, name: String, parentId: Long? = null) = withNonCancellableContext {
         val update = CategoryUpdate(
             id = categoryId,
             name = name,
+            parentId = parentId,
         )
 
         try {
@@ -26,7 +27,8 @@ class RenameCategory(
         }
     }
 
-    suspend fun await(category: Category, name: String) = await(category.id, name)
+    suspend fun await(category: Category, name: String, parentId: Long? = category.parentId) =
+        await(category.id, name, parentId)
 
     sealed interface Result {
         data object Success : Result

--- a/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/model/Category.kt
@@ -7,6 +7,7 @@ data class Category(
     val name: String,
     val order: Long,
     val flags: Long,
+    val parentId: Long? = null,
     // KMK -->
     val hidden: Boolean,
     // KMK <--

--- a/domain/src/main/java/tachiyomi/domain/category/model/CategoryUpdate.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/model/CategoryUpdate.kt
@@ -5,6 +5,7 @@ data class CategoryUpdate(
     val name: String? = null,
     val order: Long? = null,
     val flags: Long? = null,
+    val parentId: Long? = null,
     // KMK -->
     val hidden: Boolean? = null,
     // KMK <--

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -163,6 +163,8 @@ class LibraryPreferences(
 
     fun categoryTabs() = preferenceStore.getBoolean("display_category_tabs", true)
 
+    fun subcategoryTabs() = preferenceStore.getBoolean("display_subcategory_tabs", false)
+
     fun categoryNumberOfItems() = preferenceStore.getBoolean("display_number_of_items", false)
 
     fun categorizedDisplaySettings() = preferenceStore.getBoolean("categorized_display", false)


### PR DESCRIPTION
Changes

 - Added Toggle in Setting > Appearance (Library parent/child layout)
 Difference
 Kept Original UI and New UI
 New UI is only adding the Parent/SubCategories in LibraryTab accessible
 
 - Added Sub category Feature to it (Beta)
 - Added SubCategory with Dialog when you adding the manga/manhwa to library 
 
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Introduce hierarchical library categories with optional parent/child layout and update related UI, persistence, and settings.

New Features:
- Allow creating and renaming categories with an optional parent category to form parent/child hierarchies.
- Add an optional parent/child layout for the Library tab, including parent filter chips and hierarchical category paging.
- Include parent category selection in category create/rename dialogs and show parent information in category list items.
- Preserve category parent/child relationships in backups and during restore.

Enhancements:
- Redesign category list items and dialogs to visually represent hierarchy and improve interaction when reordering and managing categories.
- Update library state and toolbar title handling to work with the new hierarchical category model instead of derived displayed categories.