### PR TITLE
Fix reader "Unable to edit key" error

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
 import okhttp3.Response
@@ -148,7 +147,7 @@ class ChapterCache(
     fun isImageInCache(imageUrl: String): Boolean {
         return try {
             diskCache.get(DiskUtil.hashKeyForDisk(imageUrl)).use { it != null }
-        } catch (e: IOException) {
+        } catch (_: IOException) {
             false
         }
     }
@@ -180,7 +179,7 @@ class ChapterCache(
         try {
             // Get editor from md5 key.
             val key = DiskUtil.hashKeyForDisk(imageUrl)
-            editor = diskCache.edit(key) ?: throw IOException("Unable to edit key")
+            editor = diskCache.edit(key) ?: return
 
             // Get OutputStream and write image with Okio.
             response.body.source().saveTo(editor.newOutputStream(0))


### PR DESCRIPTION
This change addresses the "Unable to edit key" error encountered in the ChapterCache class. The error handling has been improved to prevent exceptions from disrupting the flow when editing keys in the disk cache.

Code has been tested and self-reviewed. All base themes and tablet modes have been checked for relevant changes.

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when disk cache keys cannot be edited by safely returning on editor acquisition failure.