### PR TITLE
Add option to customize concurrent downloads, increase page concurrency

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -39,6 +39,8 @@ object SettingsDownloadScreen : SearchableSettings {
         val allCategories by getCategories.subscribe().collectAsState(initial = emptyList())
 
         val downloadPreferences = remember { Injekt.get<DownloadPreferences>() }
+        val parallelSourceLimit by downloadPreferences.parallelSourceLimit().collectAsState()
+        val parallelPageLimit by downloadPreferences.parallelPageLimit().collectAsState()
         return listOf(
             Preference.PreferenceItem.SwitchPreference(
                 preference = downloadPreferences.downloadOnlyOverWifi(),
@@ -52,6 +54,19 @@ object SettingsDownloadScreen : SearchableSettings {
                 preference = downloadPreferences.splitTallImages(),
                 title = stringResource(MR.strings.split_tall_images),
                 subtitle = stringResource(MR.strings.split_tall_images_summary),
+            ),
+            Preference.PreferenceItem.SliderPreference(
+                value = parallelSourceLimit,
+                valueRange = 1..10,
+                title = stringResource(MR.strings.pref_download_concurrent_sources),
+                onValueChanged = { downloadPreferences.parallelSourceLimit().set(it) },
+            ),
+            Preference.PreferenceItem.SliderPreference(
+                value = parallelPageLimit,
+                valueRange = 1..15,
+                title = stringResource(MR.strings.pref_download_concurrent_pages),
+                subtitle = stringResource(MR.strings.pref_download_concurrent_pages_summary),
+                onValueChanged = { downloadPreferences.parallelPageLimit().set(it) },
             ),
             getDeleteChaptersGroup(
                 downloadPreferences = downloadPreferences,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -202,15 +202,17 @@ class Downloader(
         if (isRunning) return
 
         downloaderJob = scope.launch {
-            val activeDownloadsFlow = queueState.transformLatest { queue ->
+            val activeDownloadsFlow = combine(
+                queueState,
+                downloadPreferences.parallelSourceLimit().changes(),
+            ) { a, b -> a to b }.transformLatest { (queue, parallelCount) ->
                 while (true) {
                     val activeDownloads = queue.asSequence()
                         // Ignore completed downloads, leave them in the queue
                         .filter { it.status.value <= Download.State.DOWNLOADING.value }
                         .groupBy { it.source }
                         .toList()
-                        // Concurrently download from 5 different sources
-                        .take(5)
+                        .take(parallelCount)
                         .map { (_, downloads) -> downloads.first() }
                     emit(activeDownloads)
 
@@ -222,7 +224,8 @@ class Downloader(
                         }.filter { it }
                     activeDownloadsErroredFlow.first()
                 }
-            }.distinctUntilChanged()
+            }
+                .distinctUntilChanged()
 
             // Use supervisorScope to cancel child jobs when the downloader job is cancelled
             supervisorScope {
@@ -390,24 +393,23 @@ class Downloader(
             download.status = Download.State.DOWNLOADING
 
             // Start downloading images, consider we can have downloaded images already
-            // Concurrently do 2 pages at a time
-            pageList.asFlow()
-                .flatMapMerge(concurrency = 2) { page ->
-                    flow {
-                        // Fetch image URL if necessary
-                        if (page.imageUrl.isNullOrEmpty()) {
-                            page.status = Page.State.LoadPage
-                            try {
-                                page.imageUrl = download.source.getImageUrl(page)
-                            } catch (e: Throwable) {
-                                page.status = Page.State.Error(e)
-                            }
+            pageList.asFlow().flatMapMerge(concurrency = downloadPreferences.parallelPageLimit().get()) { page ->
+                flow {
+                    // Fetch image URL if necessary
+                    if (page.imageUrl.isNullOrEmpty()) {
+                        page.status = Page.State.LoadPage
+                        try {
+                            page.imageUrl = download.source.getImageUrl(page)
+                        } catch (e: Throwable) {
+                            page.status = Page.State.Error(e)
                         }
+                    }
 
-                        withIOContext { getOrDownloadImage(page, download, tmpDir, dataSaver) }
-                        emit(page)
-                    }.flowOn(Dispatchers.IO)
+                    withIOContext { getOrDownloadImage(page, download, tmpDir, dataSaver) }
+                    emit(page)
                 }
+                    .flowOn(Dispatchers.IO)
+            }
                 .collect {
                     // Do when page is downloaded.
                     notifier.onProgressChange(download)

--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -37,6 +37,10 @@ class DownloadPreferences(
 
     fun downloadNewUnreadChaptersOnly() = preferenceStore.getBoolean("download_new_unread_chapters_only", false)
 
+    fun parallelSourceLimit() = preferenceStore.getInt("download_parallel_source_limit", 5)
+
+    fun parallelPageLimit() = preferenceStore.getInt("download_parallel_page_limit", 5)
+
     // KMK -->
     fun downloadCacheRenewInterval() = preferenceStore.getInt("download_cache_renew_interval", 1)
     // KMK <--

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -522,6 +522,9 @@
     <string name="save_chapter_as_cbz">Save as CBZ archive</string>
     <string name="split_tall_images">Split tall images</string>
     <string name="split_tall_images_summary">Improves reader performance</string>
+    <string name="pref_download_concurrent_sources">Concurrent source downloads</string>
+    <string name="pref_download_concurrent_pages">Concurrent page downloads</string>
+    <string name="pref_download_concurrent_pages_summary">Pages downloaded simultaneously per source</string>
 
     <!-- Tracking section -->
     <string name="tracking_guide">Tracking guide</string>


### PR DESCRIPTION
Introduce settings to customize the number of concurrent downloads for sources and pages, enhancing user control over download performance. Changes include new preferences in the settings screen and adjustments in the downloader logic to respect these limits. Code has been tested and reviewed for functionality across themes and tablet modes.

## Summary by Sourcery

Add configurable limits for concurrent source and page downloads and wire them into the downloader and settings UI.

New Features:
- Introduce user preferences to control the maximum number of concurrent source downloads.
- Introduce user preferences to control the maximum number of concurrent page downloads per source.

Enhancements:
- Update downloader logic to honor configurable parallel source and page limits instead of fixed values.
- Extend the downloads settings screen with sliders for tuning concurrent source and page downloads.
- Add localized strings for the new concurrent download settings.