### PR TITLE
Fix scrollbar not showing when animator duration scale animation is turned off

### DIFF
--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/VerticalFastScroller.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/VerticalFastScroller.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastLastOrNull
 import androidx.compose.ui.util.fastMaxBy
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.sample
@@ -177,7 +178,8 @@ fun VerticalFastScroller(
                     .collectLatest {
                         if (thumbAllowed()) {
                             alpha.snapTo(1f)
-                            alpha.animateTo(0f, animationSpec = FadeOutAnimationSpec)
+                            delay(ScrollBarVisibilityDurationMillis)
+                            alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
                         } else {
                             alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
                         }
@@ -366,7 +368,8 @@ fun VerticalGridFastScroller(
                     .collectLatest {
                         if (thumbAllowed()) {
                             alpha.snapTo(1f)
-                            alpha.animateTo(0f, animationSpec = FadeOutAnimationSpec)
+                            delay(ScrollBarVisibilityDurationMillis)
+                            alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
                         } else {
                             alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
                         }
@@ -460,10 +463,7 @@ object Scroller {
 private val ThumbLength = 48.dp
 private val ThumbThickness = 12.dp
 private val ThumbShape = RoundedCornerShape(ThumbThickness / 2)
-private val FadeOutAnimationSpec = tween<Float>(
-    durationMillis = ViewConfiguration.getScrollBarFadeDuration(),
-    delayMillis = 2000,
-)
+private val ScrollBarVisibilityDurationMillis = 2000L
 private val ImmediateFadeOutAnimationSpec = tween<Float>(
     durationMillis = ViewConfiguration.getScrollBarFadeDuration(),
 )

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/util/Scrollbar.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/util/Scrollbar.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.fastSumBy
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.sample
@@ -218,7 +219,8 @@ private fun Modifier.drawScrollbar(
             .sample(100)
             .collectLatest {
                 alpha.snapTo(1f)
-                alpha.animateTo(0f, animationSpec = FadeOutAnimationSpec)
+                delay(ScrollBarVisibilityDurationMillis)
+                alpha.animateTo(0f, animationSpec = ImmediateFadeOutAnimationSpec)
             }
     }
 
@@ -241,9 +243,9 @@ private fun Modifier.drawScrollbar(
         }
 }
 
-private val FadeOutAnimationSpec = tween<Float>(
+private val ScrollBarVisibilityDurationMillis = ViewConfiguration.getScrollDefaultDelay().toLong()
+private val ImmediateFadeOutAnimationSpec = tween<Float>(
     durationMillis = ViewConfiguration.getScrollBarFadeDuration(),
-    delayMillis = ViewConfiguration.getScrollDefaultDelay(),
 )
 
 @Preview(widthDp = 400, heightDp = 400, showBackground = true)


### PR DESCRIPTION
Adjust the scrollbar behavior to ensure it remains visible even when the animator duration scale animation is disabled. This change improves user experience by maintaining consistent scrollbar visibility.

## Summary by Sourcery

Ensure scrollbars remain visible for a fixed duration before fading out, even when animator duration scale animations are disabled.

Bug Fixes:
- Fix scrollbars disappearing immediately when system animator duration scale is turned off by decoupling visibility duration from fade-out animation timing.

Enhancements:
- Standardize scrollbar visibility timing using explicit delays and immediate fade-out animations in fast scroller and scrollbar components.