### PR TITLE
Fix reader tap zones triggering after scrolling was stopped by the user

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.reader.viewer.webtoon
 
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
+import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import android.view.HapticFeedbackConstants
@@ -34,6 +35,10 @@ class WebtoonRecyclerView @JvmOverloads constructor(
     private var firstVisibleItemPosition = 0
     private var lastVisibleItemPosition = 0
     private var currentScale = DEFAULT_RATE
+
+    private var isScrolling = false
+    private var hasTappedWhileScrolling = false
+
     var zoomOutDisabled = false
         set(value) {
             field = value
@@ -66,7 +71,11 @@ class WebtoonRecyclerView @JvmOverloads constructor(
         super.onMeasure(widthSpec, heightSpec)
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(e: MotionEvent): Boolean {
+        if (e.actionMasked == MotionEvent.ACTION_DOWN) {
+            hasTappedWhileScrolling = isScrolling
+        }
         detector.onTouchEvent(e)
         return super.onTouchEvent(e)
     }
@@ -86,6 +95,7 @@ class WebtoonRecyclerView @JvmOverloads constructor(
         val totalItemCount = layoutManager?.itemCount ?: 0
         atLastPosition = visibleItemCount > 0 && lastVisibleItemPosition == totalItemCount - 1
         atFirstPosition = firstVisibleItemPosition == 0
+        isScrolling = state != SCROLL_STATE_IDLE
     }
 
     private fun getPositionX(positionX: Float): Float {
@@ -227,7 +237,9 @@ class WebtoonRecyclerView @JvmOverloads constructor(
     inner class GestureListener : GestureDetectorWithLongTap.Listener() {
 
         override fun onSingleTapConfirmed(ev: MotionEvent): Boolean {
-            tapListener?.invoke(ev)
+            if (!hasTappedWhileScrolling) {
+                tapListener?.invoke(ev)
+            }
             return false
         }
 


### PR DESCRIPTION
Prevent tap zones from being triggered when the user taps while scrolling. This change improves the user experience by ensuring taps are only registered when the user is not actively scrolling. The code has been tested and reviewed for functionality across different themes and tablet modes.

## Summary by Sourcery

Bug Fixes:
- Avoid registering single-tap actions if the user tapped while the list was still scrolling in the webtoon reader.