### PR TITLE
Fix long strip reader not scrolling on consecutive taps

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
@@ -36,7 +36,7 @@ class WebtoonRecyclerView @JvmOverloads constructor(
     private var lastVisibleItemPosition = 0
     private var currentScale = DEFAULT_RATE
 
-    private var isScrolling = false
+    private var isManuallyScrolling = false
     private var hasTappedWhileScrolling = false
 
     var zoomOutDisabled = false
@@ -74,7 +74,7 @@ class WebtoonRecyclerView @JvmOverloads constructor(
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(e: MotionEvent): Boolean {
         if (e.actionMasked == MotionEvent.ACTION_DOWN) {
-            hasTappedWhileScrolling = isScrolling
+            hasTappedWhileScrolling = isManuallyScrolling
         }
         detector.onTouchEvent(e)
         return super.onTouchEvent(e)
@@ -95,7 +95,9 @@ class WebtoonRecyclerView @JvmOverloads constructor(
         val totalItemCount = layoutManager?.itemCount ?: 0
         atLastPosition = visibleItemCount > 0 && lastVisibleItemPosition == totalItemCount - 1
         atFirstPosition = firstVisibleItemPosition == 0
-        isScrolling = state != SCROLL_STATE_IDLE
+        if (state == SCROLL_STATE_IDLE) {
+            isManuallyScrolling = false
+        }
     }
 
     private fun getPositionX(positionX: Float): Float {
@@ -333,6 +335,7 @@ class WebtoonRecyclerView @JvmOverloads constructor(
 
                         if (startScroll) {
                             isZoomDragging = true
+                            isManuallyScrolling = true
                         }
                     }
 


### PR DESCRIPTION
Enhance error handling, improve user experience in WebView, and fix various bugs related to downloads and reader functionality. Update translations and migrate to the GraphQL API for the Suwayomi tracker. Ensure all changes have been tested and reviewed.

## Summary by Sourcery

Bug Fixes:
- Correct detection of manual scrolling state in the webtoon recycler view so consecutive taps properly trigger scrolling in long strip reading.