### PR TITLE
Stop tap zones from triggering when scrolling is stopped by tapping

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonFrame.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonFrame.kt
@@ -111,6 +111,7 @@ class WebtoonFrame(context: Context) : FrameLayout(context) {
             velocityX: Float,
             velocityY: Float,
         ): Boolean {
+            recycler?.onManualScroll()
             return recycler?.zoomFling(velocityX.toInt(), velocityY.toInt()) ?: false
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
@@ -56,6 +56,9 @@ class WebtoonRecyclerView @JvmOverloads constructor(
     var tapListener: ((MotionEvent) -> Unit)? = null
     var longTapListener: ((MotionEvent) -> Boolean)? = null
 
+    private var isManuallyScrolling = false
+    private var tapDuringManualScroll = false
+
     override fun onMeasure(widthSpec: Int, heightSpec: Int) {
         halfWidth = MeasureSpec.getSize(widthSpec) / 2
         halfHeight = MeasureSpec.getSize(heightSpec) / 2
@@ -67,6 +70,10 @@ class WebtoonRecyclerView @JvmOverloads constructor(
     }
 
     override fun onTouchEvent(e: MotionEvent): Boolean {
+        if (e.actionMasked == MotionEvent.ACTION_DOWN) {
+            tapDuringManualScroll = isManuallyScrolling
+        }
+
         detector.onTouchEvent(e)
         return super.onTouchEvent(e)
     }
@@ -86,6 +93,10 @@ class WebtoonRecyclerView @JvmOverloads constructor(
         val totalItemCount = layoutManager?.itemCount ?: 0
         atLastPosition = visibleItemCount > 0 && lastVisibleItemPosition == totalItemCount - 1
         atFirstPosition = firstVisibleItemPosition == 0
+
+        if (state == SCROLL_STATE_IDLE) {
+            isManuallyScrolling = false
+        }
     }
 
     private fun getPositionX(positionX: Float): Float {
@@ -224,10 +235,16 @@ class WebtoonRecyclerView @JvmOverloads constructor(
         }
     }
 
+    fun onManualScroll() {
+        isManuallyScrolling = true
+    }
+
     inner class GestureListener : GestureDetectorWithLongTap.Listener() {
 
         override fun onSingleTapConfirmed(ev: MotionEvent): Boolean {
-            tapListener?.invoke(ev)
+            if (!tapDuringManualScroll) {
+                tapListener?.invoke(ev)
+            }
             return false
         }
 


### PR DESCRIPTION
Prevent tap zones from triggering when the user is manually scrolling. This change improves the user experience by avoiding unintended actions during scrolling. The code has been tested and reviewed for functionality across different themes and tablet modes.

## Summary by Sourcery

Bug Fixes:
- Avoid triggering tap actions if a tap occurs while the user is manually scrolling the webtoon reader.