### PR TITLE
Cleanup BaseOAuthLoginActivity and TrackLoginActivity 

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/BaseOAuthLoginActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/BaseOAuthLoginActivity.kt
@@ -14,7 +14,7 @@ abstract class BaseOAuthLoginActivity : BaseActivity() {
 
     internal val trackerManager: TrackerManager by injectLazy()
 
-    abstract fun handleResult(data: Uri?)
+    abstract fun handleResult(uri: Uri)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,7 +23,12 @@ abstract class BaseOAuthLoginActivity : BaseActivity() {
             LoadingScreen()
         }
 
-        handleResult(intent.data)
+        val data = intent.data
+        if (data == null) {
+            returnToSettings()
+        } else {
+            handleResult(data)
+        }
     }
 
     internal fun returnToSettings() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/GoogleDriveLoginActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/GoogleDriveLoginActivity.kt
@@ -12,9 +12,9 @@ import uy.kohesive.injekt.api.get
 
 class GoogleDriveLoginActivity : BaseOAuthLoginActivity() {
     private val googleDriveService = Injekt.get<GoogleDriveService>()
-    override fun handleResult(data: Uri?) {
-        val code = data?.getQueryParameter("code")
-        val error = data?.getQueryParameter("error")
+    override fun handleResult(uri: Uri) {
+        val code = uri.getQueryParameter("code")
+        val error = uri.getQueryParameter("error")
         if (code != null) {
             lifecycleScope.launchIO {
                 googleDriveService.handleAuthorizationCode(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/TrackLoginActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/TrackLoginActivity.kt
@@ -2,69 +2,67 @@ package eu.kanade.tachiyomi.ui.setting.track
 
 import android.net.Uri
 import androidx.lifecycle.lifecycleScope
-import tachiyomi.core.common.util.lang.launchIO
+import kotlinx.coroutines.launch
 
 class TrackLoginActivity : BaseOAuthLoginActivity() {
 
-    override fun handleResult(data: Uri?) {
-        when (data?.host) {
-            "anilist-auth" -> handleAnilist(data)
-            "bangumi-auth" -> handleBangumi(data)
-            "myanimelist-auth" -> handleMyAnimeList(data)
-            "shikimori-auth" -> handleShikimori(data)
+    override fun handleResult(uri: Uri) {
+        val data = when {
+            !uri.encodedQuery.isNullOrBlank() -> uri.encodedQuery
+            !uri.encodedFragment.isNullOrBlank() -> uri.encodedFragment
+            else -> null
+        }
+            ?.split("&")
+            ?.filter { it.isNotBlank() }
+            ?.associate {
+                val parts = it.split("=", limit = 2).map<String, String>(Uri::decode)
+                parts[0] to parts.getOrNull(1)
+            }
+            .orEmpty()
+
+        lifecycleScope.launch {
+            try {
+                when (uri.host) {
+                    "anilist-auth" -> handleAniList(data["access_token"])
+                    "bangumi-auth" -> handleBangumi(data["code"])
+                    "myanimelist-auth" -> handleMyAnimeList(data["code"])
+                    "shikimori-auth" -> handleShikimori(data["code"])
+                }
+            } finally {
+                returnToSettings()
+            }
         }
     }
 
-    private fun handleAnilist(data: Uri) {
-        val regex = "(?:access_token=)(.*?)(?:&)".toRegex()
-        val matchResult = regex.find(data.fragment.toString())
-        if (matchResult?.groups?.get(1) != null) {
-            lifecycleScope.launchIO {
-                trackerManager.aniList.login(matchResult.groups[1]!!.value)
-                returnToSettings()
-            }
+    private suspend fun handleAniList(accessToken: String?) {
+        if (accessToken != null) {
+            trackerManager.aniList.login(accessToken)
         } else {
             trackerManager.aniList.logout()
-            returnToSettings()
         }
     }
 
-    private fun handleBangumi(data: Uri) {
-        val code = data.getQueryParameter("code")
+    private suspend fun handleBangumi(code: String?) {
         if (code != null) {
-            lifecycleScope.launchIO {
-                trackerManager.bangumi.login(code)
-                returnToSettings()
-            }
+            trackerManager.bangumi.login(code)
         } else {
             trackerManager.bangumi.logout()
-            returnToSettings()
         }
     }
 
-    private fun handleMyAnimeList(data: Uri) {
-        val code = data.getQueryParameter("code")
+    private suspend fun handleMyAnimeList(code: String?) {
         if (code != null) {
-            lifecycleScope.launchIO {
-                trackerManager.myAnimeList.login(code)
-                returnToSettings()
-            }
+            trackerManager.myAnimeList.login(code)
         } else {
             trackerManager.myAnimeList.logout()
-            returnToSettings()
         }
     }
 
-    private fun handleShikimori(data: Uri) {
-        val code = data.getQueryParameter("code")
+    private suspend fun handleShikimori(code: String?) {
         if (code != null) {
-            lifecycleScope.launchIO {
-                trackerManager.shikimori.login(code)
-                returnToSettings()
-            }
+            trackerManager.shikimori.login(code)
         } else {
             trackerManager.shikimori.logout()
-            returnToSettings()
         }
     }
 }

--- a/app/src/main/java/exh/md/MangaDexLoginActivity.kt
+++ b/app/src/main/java/exh/md/MangaDexLoginActivity.kt
@@ -12,8 +12,8 @@ import uy.kohesive.injekt.api.get
 
 class MangaDexLoginActivity : BaseOAuthLoginActivity() {
 
-    override fun handleResult(data: Uri?) {
-        val code = data?.getQueryParameter("code")
+    override fun handleResult(uri: Uri) {
+        val code = uri.getQueryParameter("code")
         if (code != null) {
             lifecycleScope.launchIO {
                 Injekt.get<SourceManager>().isInitialized.first { it }


### PR DESCRIPTION
## Summary by Sourcery

Simplify and harden OAuth login handling across tracking and backup services by centralizing URI parsing and result handling in BaseOAuthLoginActivity.

Bug Fixes:
- Ensure OAuth login activities safely handle missing or malformed intent data by returning to settings when no URI is provided.
- Fix AniList OAuth token extraction by correctly reading access tokens from either query or fragment parameters instead of relying on a fragile regex.

Enhancements:
- Unify the BaseOAuthLoginActivity handleResult API to require a non-null Uri and adjust callers accordingly.
- Refactor TrackLoginActivity to centralize OAuth parameter parsing and streamline per-service login/logout logic within a single coroutine scope.
- Make Google Drive and MangaDex login activities use the updated non-null Uri handling for OAuth callbacks.