### PR TITLE
Use AGP provided NDK and Build Tools version

### DIFF
--- a/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
@@ -7,8 +7,6 @@ object AndroidConfig {
     const val COMPILE_SDK = 36
     const val TARGET_SDK = 34
     const val MIN_SDK = 26
-    const val NDK = "27.1.12297006"
-    const val BUILD_TOOLS = "35.0.1"
 
     // https://youtrack.jetbrains.com/issue/KT-66995/JvmTarget-and-JavaVersion-compatibility-for-easier-JVM-version-setup
     val JavaVersion = GradleJavaVersion.VERSION_17

--- a/buildSrc/src/main/kotlin/mihon/buildlogic/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/mihon/buildlogic/ProjectExtensions.kt
@@ -26,13 +26,9 @@ val Project.libs get() = the<LibrariesForLibs>()
 internal fun Project.configureAndroid(commonExtension: CommonExtension<*, *, *, *, *, *>) {
     commonExtension.apply {
         compileSdk = AndroidConfig.COMPILE_SDK
-        buildToolsVersion = AndroidConfig.BUILD_TOOLS
 
         defaultConfig {
             minSdk = AndroidConfig.MIN_SDK
-            ndk {
-                version = AndroidConfig.NDK
-            }
         }
 
         compileOptions {


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove explicit BUILD_TOOLS and NDK version configuration in favor of AGP-provided defaults.