### PR TITLE
Fix pre-1970 upload date display in chapter list

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/components/DateText.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/DateText.kt
@@ -22,7 +22,7 @@ fun relativeDateText(
             Instant.ofEpochMilli(dateEpochMillis),
             ZoneId.systemDefault(),
         )
-            .takeIf { dateEpochMillis > 0L },
+            .takeIf { dateEpochMillis != 0L },
     )
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix incorrect omission or handling of chapter dates when the timestamp is zero milliseconds since the epoch.