### PR TITLE
refactor(color-scheme): Remove manual contrast level handling

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -1,8 +1,6 @@
 package eu.kanade.presentation.theme
 
-import android.app.UiModeManager
 import android.content.Context
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
@@ -11,8 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.getSystemService
-import com.materialkolor.Contrast
 import com.materialkolor.DynamicMaterialTheme
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.AppTheme
@@ -55,6 +51,8 @@ fun TachiyomiTheme(
     )
 }
 
+// KMK -->
+/** Theme based on Cover */
 @Composable
 fun TachiyomiTheme(
     seedColor: Color?,
@@ -63,10 +61,11 @@ fun TachiyomiTheme(
     typography: Typography = MaterialTheme.typography,
     content: @Composable () -> Unit,
 ) {
-    val uiPreferences = Injekt.get<UiPreferences>()
-    val context = LocalContext.current
-    val isAmoled = amoled ?: uiPreferences.themeDarkAmoled().get()
-    if (seedColor != null) {
+    if (seedColor == null) {
+        TachiyomiTheme(appTheme, amoled, content)
+    } else {
+        val uiPreferences = Injekt.get<UiPreferences>()
+        val isAmoled = amoled ?: uiPreferences.themeDarkAmoled().get()
         DynamicMaterialTheme(
             seedColor = seedColor,
             isAmoled = isAmoled,
@@ -74,20 +73,10 @@ fun TachiyomiTheme(
             typography = typography,
             animate = true,
             content = content,
-            contrastLevel = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                context.getSystemService<UiModeManager>()?.contrast?.toDouble() ?: Contrast.Default.value
-            } else {
-                Contrast.Default.value
-            },
-        )
-    } else {
-        BaseTachiyomiTheme(
-            appTheme = appTheme ?: uiPreferences.appTheme().get(),
-            isAmoled = isAmoled,
-            content = content,
         )
     }
 }
+// KMK <--
 
 @Composable
 fun TachiyomiPreviewTheme(
@@ -131,8 +120,7 @@ private fun getThemeColorScheme(
         AppTheme.CUSTOM -> {
             val uiPreferences = Injekt.get<UiPreferences>()
             CustomColorScheme(
-                context = context,
-                seed = uiPreferences.colorTheme().get(),
+                seed = Color(uiPreferences.colorTheme().get()),
                 style = uiPreferences.customThemeStyle().get(),
             )
         }

--- a/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
@@ -1,7 +1,5 @@
 package eu.kanade.presentation.theme.colorscheme
 
-import android.app.UiModeManager
-import android.content.Context
 import android.content.res.ColorStateList
 import android.os.Build
 import android.widget.EditText
@@ -11,55 +9,29 @@ import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
-import androidx.core.content.getSystemService
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
-import com.materialkolor.Contrast
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamicColorScheme
 
 internal class CustomColorScheme(
-    context: Context,
-    seed: Int,
+    seed: Color,
     style: PaletteStyle,
 ) : BaseColorScheme() {
-    private val custom = CustomCompatColorScheme(context, seed, style)
+    override val lightScheme = generateColorSchemeFromSeed(seed = seed, style = style, dark = false)
+    override val darkScheme = generateColorSchemeFromSeed(seed = seed, style = style, dark = true)
 
-    override val darkScheme
-        get() = custom.darkScheme
-
-    override val lightScheme
-        get() = custom.lightScheme
-}
-
-private class CustomCompatColorScheme(
-    context: Context,
-    seed: Int,
-    style: PaletteStyle,
-) : BaseColorScheme() {
-    override val lightScheme = dynamicColorScheme(
-        seedColor = Color(seed),
-        isDark = false,
-        isAmoled = false,
-        style = style,
-        contrastLevel = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            context.getSystemService<UiModeManager>()?.contrast?.toDouble() ?: Contrast.Default.value
-        } else {
-            Contrast.Default.value
-        },
-    )
-    override val darkScheme = dynamicColorScheme(
-        seedColor = Color(seed),
-        isDark = true,
-        isAmoled = false,
-        style = style,
-        contrastLevel = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            context.getSystemService<UiModeManager>()?.contrast?.toDouble() ?: Contrast.Default.value
-        } else {
-            Contrast.Default.value
-        },
-    )
+    companion object {
+        fun generateColorSchemeFromSeed(seed: Color, style: PaletteStyle, dark: Boolean): ColorScheme {
+            return dynamicColorScheme(
+                seedColor = seed,
+                isDark = dark,
+                isAmoled = false,
+                style = style,
+            )
+        }
+    }
 }
 
 class AndroidViewColorScheme(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.ui.reader
 
 import android.Manifest
 import android.annotation.SuppressLint
-import android.app.UiModeManager
 import android.app.assist.AssistContent
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -59,7 +58,6 @@ import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
 import com.google.android.material.elevation.SurfaceColors
 import com.google.android.material.transition.platform.MaterialContainerTransform
 import com.hippo.unifile.UniFile
-import com.materialkolor.Contrast
 import com.materialkolor.dynamicColorScheme
 import dev.chrisbanes.insetter.applyInsetter
 import eu.kanade.core.util.ifSourcesLoaded
@@ -769,11 +767,6 @@ class ReaderActivity : BaseActivity() {
                 isDark = isNightMode(),
                 isAmoled = themeDarkAmoled,
                 style = themeCoverBasedStyle,
-                contrastLevel = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                    getSystemService<UiModeManager>()?.contrast?.toDouble() ?: Contrast.Default.value
-                } else {
-                    Contrast.Default.value
-                },
             )
         }
         // KMK <--


### PR DESCRIPTION
Implement materialKolor for a more compatible color scheme and simplify color scheme generation by removing manual contrast level handling. Ensure the new implementation supports both dark and AMOLED themes effectively. Conduct thorough testing across all base themes and tablet modes.

## Summary by Sourcery

Refine app theming to rely on materialKolor-based dynamic schemes while simplifying color generation and AMOLED handling.

Enhancements:
- Replace custom Material dynamic color implementation with materialKolor DynamicScheme/toColorScheme for Monet-based themes.
- Simplify custom and cover-based color scheme generation by removing manual contrast-level handling and redundant compatibility wrappers.
- Adjust base theme handling so AMOLED surface overrides are skipped for Monet themes while preserving overrides for other themes.

Build:
- Update materialKolor dependency to version 5.0.0-alpha04 and consolidate its declaration in the shared libs catalog.