### PR TITLE
Switch to MaterialExpressiveTheme

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,6 +168,7 @@ kotlin {
             "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
             "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi",
             "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+            "-opt-in=androidx.compose.material3.ExperimentalMaterial3ExpressiveApi",
             "-opt-in=androidx.compose.ui.ExperimentalComposeUiApi",
             "-opt-in=coil3.annotation.ExperimentalCoilApi",
             "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",

--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -33,11 +33,11 @@ class UiPreferences(
     // KMK -->
     fun colorTheme() = preferenceStore.getInt("pref_color_theme", 0xFFDF0090.toInt())
 
-    fun customThemeStyle() = preferenceStore.getEnum("pref_custom_theme_style_key", PaletteStyle.Fidelity)
+    fun customThemeStyle() = preferenceStore.getEnum("pref_custom_theme_style_key", PaletteStyle.Expressive)
 
     fun themeCoverBased() = preferenceStore.getBoolean("pref_theme_cover_based_key", true)
 
-    fun themeCoverBasedStyle() = preferenceStore.getEnum("pref_theme_cover_based_style_key", PaletteStyle.Vibrant)
+    fun themeCoverBasedStyle() = preferenceStore.getEnum("pref_theme_cover_based_style_key", PaletteStyle.Expressive)
 
     fun preloadLibraryColor() = preferenceStore.getBoolean("pref_preload_library_color_key", true)
     // KMK <--

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -112,14 +112,14 @@ object SettingsAppearanceScreen : SearchableSettings {
                     entries = PaletteStyle.entries
                         .associateWith {
                             when (it) {
+                                PaletteStyle.Expressive ->
+                                    stringResource(KMR.strings.pref_theme_cover_based_style_expressive)
                                 PaletteStyle.TonalSpot ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_tonalspot)
                                 PaletteStyle.Neutral ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_neutral)
                                 PaletteStyle.Vibrant ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_vibrant)
-                                PaletteStyle.Expressive ->
-                                    stringResource(KMR.strings.pref_theme_cover_based_style_expressive)
                                 PaletteStyle.Rainbow ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_rainbow)
                                 PaletteStyle.FruitSalad ->
@@ -175,14 +175,14 @@ object SettingsAppearanceScreen : SearchableSettings {
                     entries = PaletteStyle.entries
                         .associateWith {
                             when (it) {
+                                PaletteStyle.Expressive ->
+                                    stringResource(KMR.strings.pref_theme_cover_based_style_expressive)
                                 PaletteStyle.TonalSpot ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_tonalspot)
                                 PaletteStyle.Neutral ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_neutral)
                                 PaletteStyle.Vibrant ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_vibrant)
-                                PaletteStyle.Expressive ->
-                                    stringResource(KMR.strings.pref_theme_cover_based_style_expressive)
                                 PaletteStyle.Rainbow ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_rainbow)
                                 PaletteStyle.FruitSalad ->

--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -3,13 +3,14 @@ package eu.kanade.presentation.theme
 import android.content.Context
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialExpressiveTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import com.materialkolor.DynamicMaterialTheme
+import com.materialkolor.DynamicMaterialExpressiveTheme
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.AppTheme
 import eu.kanade.presentation.theme.colorscheme.BaseColorScheme
@@ -66,7 +67,7 @@ fun TachiyomiTheme(
     } else {
         val uiPreferences = Injekt.get<UiPreferences>()
         val isAmoled = amoled ?: uiPreferences.themeDarkAmoled().get()
-        DynamicMaterialTheme(
+        DynamicMaterialExpressiveTheme(
             seedColor = seedColor,
             isAmoled = isAmoled,
             style = uiPreferences.themeCoverBasedStyle().get(),
@@ -93,7 +94,7 @@ private fun BaseTachiyomiTheme(
 ) {
     val context = LocalContext.current
     val isDark = isSystemInDarkTheme()
-    MaterialTheme(
+    MaterialExpressiveTheme(
         colorScheme = remember(appTheme, isDark, isAmoled) {
             getThemeColorScheme(
                 context = context,

--- a/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomColorScheme.kt
@@ -14,6 +14,7 @@ import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.materialkolor.PaletteStyle
 import com.materialkolor.dynamicColorScheme
+import com.materialkolor.dynamiccolor.ColorSpec
 
 internal class CustomColorScheme(
     seed: Color,
@@ -29,6 +30,7 @@ internal class CustomColorScheme(
                 isDark = dark,
                 isAmoled = false,
                 style = style,
+                specVersion = ColorSpec.SpecVersion.SPEC_2025,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/theme/colorscheme/MonetColorScheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/colorscheme/MonetColorScheme.kt
@@ -8,6 +8,8 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.ui.graphics.Color
+import com.materialkolor.PaletteStyle
+import com.materialkolor.dynamiccolor.ColorSpec
 import com.materialkolor.ktx.DynamicScheme
 import com.materialkolor.toColorScheme
 
@@ -48,7 +50,12 @@ internal class MonetCompatColorScheme(seed: Color) : BaseColorScheme() {
 
     companion object {
         fun generateColorSchemeFromSeed(seed: Color, dark: Boolean): ColorScheme {
-            return DynamicScheme(seedColor = seed, isDark = dark)
+            return DynamicScheme(
+                seedColor = seed,
+                isDark = dark,
+                specVersion = ColorSpec.SpecVersion.SPEC_2025,
+                style = PaletteStyle.Expressive,
+            )
                 .toColorScheme(isAmoled = false)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -59,6 +59,7 @@ import com.google.android.material.elevation.SurfaceColors
 import com.google.android.material.transition.platform.MaterialContainerTransform
 import com.hippo.unifile.UniFile
 import com.materialkolor.dynamicColorScheme
+import com.materialkolor.dynamiccolor.ColorSpec
 import dev.chrisbanes.insetter.applyInsetter
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.domain.base.BasePreferences
@@ -767,6 +768,7 @@ class ReaderActivity : BaseActivity() {
                 isDark = isNightMode(),
                 isAmoled = themeDarkAmoled,
                 style = themeCoverBasedStyle,
+                specVersion = ColorSpec.SpecVersion.SPEC_2025,
             )
         }
         // KMK <--


### PR DESCRIPTION
Update the theme to use `MaterialExpressiveTheme` and adjust related preferences and styles accordingly. Ensure compatibility with existing color schemes and settings. Test across all base themes and tablet modes for consistency.

## Summary by Sourcery

Switch the app’s theming system to use Material Expressive themes and update color generation to the latest MaterialKolor spec.

New Features:
- Adopt MaterialExpressiveTheme and DynamicMaterialExpressiveTheme as the base app theme for both static and dynamic color modes.

Enhancements:
- Update dynamic color scheme generation to use the 2025 ColorSpec with the Expressive palette style for Monet and custom color schemes.
- Change default custom and cover-based theme styles to PaletteStyle.Expressive in UI preferences.
- Ensure appearance settings correctly expose the Expressive palette style option in cover-based theme preferences.
- Opt in to the ExperimentalMaterial3ExpressiveApi in the Gradle configuration.
- Align the reader activity’s dynamic color scheme with the new 2025 ColorSpec and expressive palette configuration.