### PR TITLE
Add a small increment to chapter number before comparison to fix progress sync issues for Suwayomi

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/SuwayomiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/SuwayomiApi.kt
@@ -115,7 +115,7 @@ class SuwayomiApi(private val trackId: Long) {
                 .data
                 .entry
                 .nodes
-                .mapNotNull { n -> n.id.takeIf { n.chapterNumber <= track.last_chapter_read } }
+                .mapNotNull { n -> n.id.takeIf { n.chapterNumber <= track.last_chapter_read + 0.001 } }
         }
 
         val markQuery = if (deleteDownloadsOnServer) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent Suwayomi progress sync from missing chapters due to floating-point precision issues in chapter number comparison.