### PR TITLE
Revert part of "Switch to MaterialExpressiveTheme"

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -33,11 +33,11 @@ class UiPreferences(
     // KMK -->
     fun colorTheme() = preferenceStore.getInt("pref_color_theme", 0xFFDF0090.toInt())
 
-    fun customThemeStyle() = preferenceStore.getEnum("pref_custom_theme_style_key", PaletteStyle.Expressive)
+    fun customThemeStyle() = preferenceStore.getEnum("pref_custom_theme_style_key", PaletteStyle.Fidelity)
 
     fun themeCoverBased() = preferenceStore.getBoolean("pref_theme_cover_based_key", true)
 
-    fun themeCoverBasedStyle() = preferenceStore.getEnum("pref_theme_cover_based_style_key", PaletteStyle.Expressive)
+    fun themeCoverBasedStyle() = preferenceStore.getEnum("pref_theme_cover_based_style_key", PaletteStyle.Vibrant)
 
     fun preloadLibraryColor() = preferenceStore.getBoolean("pref_preload_library_color_key", true)
     // KMK <--

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -112,14 +112,14 @@ object SettingsAppearanceScreen : SearchableSettings {
                     entries = PaletteStyle.entries
                         .associateWith {
                             when (it) {
-                                PaletteStyle.Expressive ->
-                                    stringResource(KMR.strings.pref_theme_cover_based_style_expressive)
                                 PaletteStyle.TonalSpot ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_tonalspot)
                                 PaletteStyle.Neutral ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_neutral)
                                 PaletteStyle.Vibrant ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_vibrant)
+                                PaletteStyle.Expressive ->
+                                    stringResource(KMR.strings.pref_theme_cover_based_style_expressive)
                                 PaletteStyle.Rainbow ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_rainbow)
                                 PaletteStyle.FruitSalad ->
@@ -175,14 +175,14 @@ object SettingsAppearanceScreen : SearchableSettings {
                     entries = PaletteStyle.entries
                         .associateWith {
                             when (it) {
-                                PaletteStyle.Expressive ->
-                                    stringResource(KMR.strings.pref_theme_cover_based_style_expressive)
                                 PaletteStyle.TonalSpot ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_tonalspot)
                                 PaletteStyle.Neutral ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_neutral)
                                 PaletteStyle.Vibrant ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_vibrant)
+                                PaletteStyle.Expressive ->
+                                    stringResource(KMR.strings.pref_theme_cover_based_style_expressive)
                                 PaletteStyle.Rainbow ->
                                     stringResource(KMR.strings.pref_theme_cover_based_style_rainbow)
                                 PaletteStyle.FruitSalad ->


### PR DESCRIPTION
## Summary by Sourcery

Adjust theme preference defaults and palette style ordering for cover-based theme settings.

Bug Fixes:
- Restore intended default values for custom theme style and cover-based theme style preferences.

Enhancements:
- Reorder palette style entries so the Expressive option appears after Vibrant in cover-based theme style choices.