### PR TITLE
Migrate Kitsu to use library_id and remote_id properly

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
@@ -102,6 +102,7 @@ class Kitsu(id: Long) : BaseTracker(id, "Kitsu"), DeletableTracker {
         return if (remoteTrack != null) {
             track.copyPersonalFrom(remoteTrack, copyRemotePrivate = false)
             track.remote_id = remoteTrack.remote_id
+            track.library_id = remoteTrack.library_id
 
             if (track.status != COMPLETED) {
                 track.status = if (hasReadChapters) READING else track.status

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
@@ -79,7 +79,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
                     .awaitSuccess()
                     .parseAs<KitsuAddMangaResult>()
                     .let {
-                        track.remote_id = it.data.id
+                        track.library_id = it.data.id
                         track
                     }
             }
@@ -91,7 +91,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
             val data = buildJsonObject {
                 putJsonObject("data") {
                     put("type", "libraryEntries")
-                    put("id", track.remote_id)
+                    put("id", track.library_id)
                     putJsonObject("attributes") {
                         put("status", track.toApiStatus())
                         put("progress", track.last_chapter_read.toInt())
@@ -105,7 +105,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
 
             authClient.newCall(
                 Request.Builder()
-                    .url("${BASE_URL}library-entries/${track.remote_id}")
+                    .url("${BASE_URL}library-entries/${track.library_id}")
                     .headers(
                         headersOf("Content-Type", VND_API_JSON),
                     )
@@ -122,7 +122,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
         withIOContext {
             authClient.newCall(
                 DELETE(
-                    "${BASE_URL}library-entries/${track.remoteId}",
+                    "${BASE_URL}library-entries/${track.libraryId}",
                     headers = headersOf("Content-Type", VND_API_JSON),
                 ),
             )
@@ -195,7 +195,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
     suspend fun getLibManga(track: Track): Track {
         return withIOContext {
             val url = "${BASE_URL}library-entries".toUri().buildUpon()
-                .encodedQuery("filter[id]=${track.remote_id}")
+                .encodedQuery("filter[id]=${track.library_id}")
                 .appendQueryParameter("include", "manga")
                 .build()
             with(json) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuListSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuListSearch.kt
@@ -21,7 +21,8 @@ data class KitsuListSearchResult(
         val manga = included[0].attributes
 
         return TrackSearch.create(TrackerManager.KITSU).apply {
-            remote_id = userData.id
+            remote_id = included[0].id
+            library_id = userData.id
             title = manga.canonicalTitle
             total_chapters = manga.chapterCount ?: 0
             cover_url = manga.posterImage?.original ?: ""

--- a/data/src/main/sqldelight/tachiyomi/migrations/42.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/42.sqm
@@ -1,0 +1,7 @@
+-- Save the current remote_id as library_id, since old Kitsu tracker did not use this correctly
+UPDATE manga_sync SET library_id = remote_id WHERE sync_id = 3;
+
+-- Kitsu and Suwayomi aren't using the remote_id field properly, but for both the ID is present in the URL
+-- This parses a url and gets the ID from the trailing path part, e.g. https://kitsu.app/manga/<id>
+-- Based on https://stackoverflow.com/a/38330814
+UPDATE manga_sync SET remote_id = replace(remote_url, rtrim(remote_url, replace(remote_url, '/', '')), '') WHERE sync_id IN (3, 9);


### PR DESCRIPTION
Update Kitsu tracker to correctly utilize `library_id` and `remote_id`, ensuring proper data structure compliance. This change includes database updates to align existing records with the new implementation. Code has been tested and reviewed for functionality across all relevant themes and tablet modes.

## Summary by Sourcery

Align Kitsu tracking with separate library and remote identifiers and migrate existing data accordingly.

Bug Fixes:
- Correctly store the Kitsu library entry identifier in `library_id` instead of `remote_id` when creating and updating entries.
- Populate both `remote_id` (manga identifier) and `library_id` (library entry identifier) when mapping Kitsu search results and existing tracks.

Chores:
- Add a database migration to support the updated Kitsu tracking identifier usage.