### PR TITLE
Handle reader cutout setting with Insets to support Android 15+

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -146,7 +146,7 @@ object SettingsReaderScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_fullscreen),
                 ),
                 Preference.PreferenceItem.SwitchPreference(
-                    preference = readerPreferences.cutoutShort(),
+                    preference = readerPreferences.drawUnderCutout(),
                     title = stringResource(MR.strings.pref_cutout_short),
                     enabled = LocalView.current.hasDisplayCutout() && fullscreen,
                 ),

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -1,11 +1,11 @@
 package eu.kanade.presentation.reader.settings
 
+import androidx.activity.compose.LocalActivity
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalView
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
 import eu.kanade.tachiyomi.util.system.hasDisplayCutout
@@ -87,10 +87,10 @@ internal fun GeneralPage(screenModel: ReaderSettingsScreenModel) {
     )
 
     val isFullscreen by screenModel.preferences.fullscreen().collectAsState()
-    if (LocalView.current.hasDisplayCutout() && isFullscreen) {
+    if (LocalActivity.current?.hasDisplayCutout() == true && isFullscreen) {
         CheckboxItem(
             label = stringResource(MR.strings.pref_cutout_short),
-            pref = screenModel.preferences.cutoutShort(),
+            pref = screenModel.preferences.drawUnderCutout(),
         )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -39,7 +39,7 @@ class ReaderPreferences(
 
     fun fullscreen() = preferenceStore.getBoolean("fullscreen", true)
 
-    fun cutoutShort() = preferenceStore.getBoolean("cutout_short", true)
+    fun drawUnderCutout() = preferenceStore.getBoolean("cutout_short", true)
 
     fun keepScreenOn() = preferenceStore.getBoolean("pref_keep_screen_on_key", false)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/DisplayExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/DisplayExtensions.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.util.system
 
+import android.app.Activity
 import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
@@ -57,11 +58,19 @@ fun Context.isNightMode(): Boolean {
 /**
  * Checks whether if the device has a display cutout (i.e. notch, camera cutout, etc.).
  *
- * Only relevant from Android 9 to Android 14.
+ * Only works on Android 9+.
+ */
+fun Activity.hasDisplayCutout(): Boolean {
+    return window.decorView.hasDisplayCutout()
+}
+
+/**
+ * Checks whether if the device has a display cutout (i.e. notch, camera cutout, etc.).
+ *
+ * Only works on Android 9+.
  */
 fun View.hasDisplayCutout(): Boolean {
-    return Build.VERSION.SDK_INT in Build.VERSION_CODES.P..Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
-        rootWindowInsets?.displayCutout != null
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && rootWindowInsets?.displayCutout != null
 }
 
 /**


### PR DESCRIPTION
Implement support for the reader cutout setting to accommodate Android 15+ and resolve extra padding issues that occur after user interactions. Ensure the reader preferences are updated accordingly. Test across various themes and tablet modes for consistency.

## Summary by Sourcery

Adjust reader fullscreen and cutout handling to use window insets-based padding and a new draw-under-cutout preference for Android 15+ compatibility.

New Features:
- Add a draw-under-cutout reader preference that controls whether content extends into the display cutout area when in fullscreen mode.

Bug Fixes:
- Resolve extra padding issues in the reader by deriving padding from updated window insets, including display cutouts, instead of fixed fullscreen logic.

Enhancements:
- Simplify edge-to-edge configuration in the reader activity by relying on default system bar styling.
- Refine grayscale and inverted color preference handling by combining their flows for cleaner updates.
- Unify display cutout detection across activities and views and relax its Android version constraints.