### PR TITLE
network: replace extension throttling with global request limiter

### DIFF
--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/GlobalRequestLimiter.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/GlobalRequestLimiter.kt
@@ -1,0 +1,23 @@
+package eu.kanade.tachiyomi.network
+
+import java.util.concurrent.Semaphore
+
+/**
+ * Global request limiter used to cap concurrent network requests.
+ * This intentionally replaces extension-specific throttling behavior.
+ */
+object GlobalRequestLimiter {
+
+    // Conservative default to avoid overwhelming servers
+    private const val MAX_CONCURRENT_REQUESTS = 8
+
+    private val semaphore = Semaphore(MAX_CONCURRENT_REQUESTS, true)
+
+    fun acquire() {
+        semaphore.acquireUninterruptibly()
+    }
+
+    fun release() {
+        semaphore.release()
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a global concurrency limiter for all OkHttp clients and refine large file download retry handling.

Enhancements:
- Add a shared GlobalRequestLimiter using a semaphore to cap concurrent network requests across all clients.
- Wire the global request limiter into the shared OkHttp client builder used by regular and Cloudflare clients.
- Improve large file download logic to better handle partial content, file resets, and exponential backoff with jitter.