### PR TITLE
Fix no sources while migrating alongside UI and code cleanup

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/process/MigrationListScreen.kt
@@ -21,7 +21,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import exh.util.overEq
 import exh.util.underEq
 import kotlinx.collections.immutable.persistentListOf
-import mihon.feature.migration.MigrateMangaConfigScreen
+import mihon.feature.migration.config.MigrationConfigScreen
 import tachiyomi.core.common.i18n.pluralStringResource
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.i18n.sy.SYMR
@@ -76,7 +76,7 @@ class MigrationListScreen(private val config: MigrationProcedureConfig) : Screen
                             val newStack = navigator.items.filter {
                                 it !is MangaScreen &&
                                     it !is MigrationListScreen &&
-                                    it !is MigrateMangaConfigScreen
+                                    it !is MigrationConfigScreen
                             } + MangaScreen(mangaId)
                             navigator replaceAll newStack.first()
                             navigator.push(newStack.drop(1))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreen.kt
@@ -13,7 +13,7 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.flow.collectLatest
-import mihon.feature.migration.MigrateMangaConfigScreen
+import mihon.feature.migration.config.MigrationConfigScreen
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.screens.LoadingScreen
 
@@ -38,14 +38,14 @@ data class MigrateMangaScreen(
             navigateUp = navigator::pop,
             title = state.source?.name ?: "???",
             state = state,
-            onClickItem = { navigator.push(MigrateMangaConfigScreen(listOf(it.id))) },
+            onClickItem = { navigator.push(MigrationConfigScreen(listOf(it.id))) },
             onClickCover = { navigator.push(MangaScreen(it.id)) },
             // KMK -->
             onMultiMigrateClicked = {
                 if (state.selectionMode) {
-                    navigator.push(MigrateMangaConfigScreen(state.selected.map { it.manga.id }))
+                    navigator.push(MigrationConfigScreen(state.selected.map { it.manga.id }))
                 } else {
-                    navigator.push(MigrateMangaConfigScreen(state.titles.map { it.manga.id }))
+                    navigator.push(MigrationConfigScreen(state.titles.map { it.manga.id }))
                 }
             },
             onSelectAll = screenModel::toggleAllSelection,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -66,7 +66,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import mihon.feature.migration.MigrateMangaConfigScreen
+import mihon.feature.migration.config.MigrationConfigScreen
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.category.model.Category
@@ -210,7 +210,7 @@ data object LibraryTab : Tab {
                             .map { it.id }
                         screenModel.clearSelection()
                         if (selectedMangaIds.isNotEmpty()) {
-                            navigator.push(MigrateMangaConfigScreen(selectedMangaIds))
+                            navigator.push(MigrationConfigScreen(selectedMangaIds))
                         } else {
                             context.toast(SYMR.strings.no_valid_entry)
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -9,7 +9,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.libraryUpdateError.LibraryUpdateErrorScreen
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
-import mihon.feature.migration.MigrateMangaConfigScreen
+import mihon.feature.migration.config.MigrationConfigScreen
 
 class LibraryUpdateErrorScreen : Screen() {
 
@@ -22,11 +22,11 @@ class LibraryUpdateErrorScreen : Screen() {
         LibraryUpdateErrorScreen(
             state = state,
             onClick = { item ->
-                navigator.push(MigrateMangaConfigScreen(listOf(item.error.mangaId)))
+                navigator.push(MigrationConfigScreen(listOf(item.error.mangaId)))
             },
             onClickCover = { item -> navigator.push(MangaScreen(item.error.mangaId)) },
             onMultiMigrateClicked = {
-                navigator.push(MigrateMangaConfigScreen(state.selected.map { it.error.mangaId }))
+                navigator.push(MigrationConfigScreen(state.selected.map { it.error.mangaId }))
             },
             onSelectAll = screenModel::toggleAllSelection,
             onInvertSelection = screenModel::invertSelection,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -103,7 +103,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import logcat.LogPriority
-import mihon.feature.migration.MigrateMangaConfigScreen
+import mihon.feature.migration.config.MigrationConfigScreen
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.launchUI
@@ -366,7 +366,7 @@ class MangaScreen(
                 successState.manga.favorite
             },
             onMigrateClicked = {
-                navigator.push(MigrateMangaConfigScreen(listOf(successState.manga.id)))
+                navigator.push(MigrationConfigScreen(listOf(successState.manga.id)))
             }.takeIf { successState.manga.favorite },
             // SY -->
             previewsRowCount = successState.previewsRowCount,

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/LocaleHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/LocaleHelper.kt
@@ -53,6 +53,16 @@ object LocaleHelper {
         return Locale.forLanguageTag(normalizedLang).displayName
     }
 
+    fun getShortDisplayName(lang: String?): String {
+        return when (lang) {
+            null -> ""
+            "es-419" -> "es-la"
+            "zh-CN" -> "zh-hans"
+            "zh-TW" -> "zh-hant"
+            else -> lang
+        }
+    }
+
     /**
      * Returns display name of a string language code.
      *


### PR DESCRIPTION
## Summary by Sourcery

Rename and relocate the migration configuration screen while fixing migration source persistence and improving language display for sources.

New Features:
- Add a dedicated saveSources function to persist selected migration sources explicitly from the UI.
- Display concise, normalized language codes for migration sources using a new LocaleHelper.getShortDisplayName helper.

Bug Fixes:
- Ensure selected migration sources are saved when continuing the migration flow, preventing migrations from running with no configured sources.

Enhancements:
- Refine MigrationSource to expose simplified id and name accessors and precomputed short language fields for cleaner UI usage.
- Simplify list item visuals by removing disabled alpha styling tied to selection state in the migration source list.

Chores:
- Move the migration config screen into a dedicated config package, renaming it to MigrationConfigScreen and updating all navigation references.
- Simplify state updates for migration sources by using MutableStateFlow.update instead of updateAndGet and centralizing source persistence logic.