### PR TITLE
Add option to skip migration config

### DIFF
--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -78,6 +78,8 @@ class SourcePreferences(
         deserializer = { value: Int -> MigrationFlag.fromBit(value) },
     )
 
+    fun skipMigrationConfig() = preferenceStore.getBoolean(Preference.appStateKey("skip_migration_config"), false)
+
     // KMK -->
     fun globalSearchPinnedState() = preferenceStore.getEnum(
         Preference.appStateKey("global_search_pinned_toggle_state"),
@@ -123,8 +125,6 @@ class SourcePreferences(
     fun smartMigration() = preferenceStore.getBoolean("smart_migrate", false)
 
     fun useSourceWithMost() = preferenceStore.getBoolean("use_source_with_most", false)
-
-    fun skipPreMigration() = preferenceStore.getBoolean(Preference.appStateKey("skip_pre_migration"), false)
 
     fun hideNotFoundMigration() = preferenceStore.getBoolean("hide_not_found_migration", false)
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBrowseScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBrowseScreen.kt
@@ -30,6 +30,7 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 object SettingsBrowseScreen : SearchableSettings {
+    @Suppress("unused")
     private fun readResolve(): Any = SettingsBrowseScreen
 
     @ReadOnlyComposable
@@ -171,16 +172,14 @@ object SettingsBrowseScreen : SearchableSettings {
 
     @Composable
     fun getMigrationCategory(sourcePreferences: SourcePreferences): Preference.PreferenceGroup {
-        val skipPreMigration by sourcePreferences.skipPreMigration().collectAsState()
-        val migrationSources by sourcePreferences.migrationSources().collectAsState()
         return Preference.PreferenceGroup(
-            stringResource(SYMR.strings.migration),
-            enabled = skipPreMigration || migrationSources.isNotEmpty(),
+            stringResource(MR.strings.browseSettingsScreen_migrationCategoryHeader),
+            enabled = sourcePreferences.skipMigrationConfig().isSet(),
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.SwitchPreference(
-                    preference = sourcePreferences.skipPreMigration(),
-                    title = stringResource(SYMR.strings.skip_pre_migration),
-                    subtitle = stringResource(SYMR.strings.pref_skip_pre_migration_summary),
+                    preference = sourcePreferences.skipMigrationConfig(),
+                    title = stringResource(MR.strings.browseSettingsScreen_skipMigrationConfigTitle),
+                    subtitle = stringResource(MR.strings.browseSettingsScreen_skipMigrationConfigSubtitle),
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/advanced/design/MigrationBottomSheetDialog.kt
@@ -144,7 +144,7 @@ class MigrationBottomSheetDialogState(
             }
             sourceGroup.bindToPreference(preferences.useSourceWithMost())
 
-            skipStep.isChecked = preferences.skipPreMigration().get()
+            skipStep.isChecked = preferences.skipMigrationConfig().get()
             hideNotFoundManga.isChecked = preferences.hideNotFoundMigration().get()
             onlyShowUpdates.isChecked = preferences.showOnlyUpdatesMigration().get()
             skipStep.setOnCheckedChangeListener { _, isChecked ->
@@ -157,7 +157,7 @@ class MigrationBottomSheetDialogState(
             }
 
             migrateBtn.setOnClickListener {
-                preferences.skipPreMigration().set(skipStep.isChecked)
+                preferences.skipMigrationConfig().set(skipStep.isChecked)
                 preferences.hideNotFoundMigration().set(hideNotFoundManga.isChecked)
                 preferences.showOnlyUpdatesMigration().set(onlyShowUpdates.isChecked)
                 onStartMigration.value(

--- a/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreenSheet.kt
+++ b/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreenSheet.kt
@@ -1,0 +1,87 @@
+package mihon.feature.migration.config
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.presentation.components.AdaptiveSheet
+import tachiyomi.core.common.preference.toggle
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.Button
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.util.collectAsState
+
+@Composable
+fun MigrationConfigScreenSheet(
+    preferences: SourcePreferences,
+    onDismissRequest: () -> Unit,
+    onStartMigration: () -> Unit,
+) {
+    val skipMigrationConfig by preferences.skipMigrationConfig().collectAsState()
+    AdaptiveSheet(onDismissRequest = onDismissRequest) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                MigrationSheetItem(
+                    title = stringResource(MR.strings.migrationConfigScreen_skipMigrationConfigTitle),
+                    subtitle = stringResource(MR.strings.migrationConfigScreen_skipMigrationConfigSubtitle),
+                    action = {
+                        Switch(
+                            checked = skipMigrationConfig,
+                            onCheckedChange = null,
+                        )
+                    },
+                    onClick = { preferences.skipMigrationConfig().toggle() },
+                )
+            }
+            HorizontalDivider()
+            Button(
+                onClick = onStartMigration,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = MaterialTheme.padding.medium,
+                        vertical = MaterialTheme.padding.small,
+                    ),
+            ) {
+                Text(text = stringResource(MR.strings.migrationConfigScreen_continueButtonText))
+            }
+        }
+    }
+}
+
+@Composable
+private fun MigrationSheetItem(
+    title: String,
+    subtitle: String?,
+    action: @Composable () -> Unit,
+    onClick: () -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text(text = title) },
+        supportingContent = subtitle?.let { { Text(text = subtitle) } },
+        trailingContent = action,
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1015,4 +1015,10 @@
     <string name="migrationConfigScreen.selectEnabledLabel">Select enabled sources</string>
     <string name="migrationConfigScreen.selectPinnedLabel">Select pinned sources</string>
     <string name="migrationConfigScreen.continueButtonText">Continue</string>
+    <string name="migrationConfigScreen.skipMigrationConfigTitle">Skip migration config</string>
+    <string name="migrationConfigScreen.skipMigrationConfigSubtitle">To show this screen again in the future, disable skipping in Settings → Browse</string>
+
+    <string name="browseSettingsScreen.migrationCategoryHeader">Migration</string>
+    <string name="browseSettingsScreen.skipMigrationConfigTitle">Skip migration config</string>
+    <string name="browseSettingsScreen.skipMigrationConfigSubtitle">Use last used sources and preferences for migration</string>
 </resources>


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable option to skip the migration configuration step and reuse previous migration settings, wiring it through the migration flow and settings UI.

New Features:
- Introduce a skip-migration-config preference that allows bypassing the migration configuration screen and using last-used migration settings.
- Add a migration configuration bottom sheet that lets users toggle skipping the config step before starting migration.

Enhancements:
- Streamline the migration flow to respect the skip-migration-config preference and show a loading state while deciding whether to bypass config.
- Update the browse settings migration category to expose the new skip-migration-config option with refreshed labels and strings.