### PR TITLE
refactor(mass-migration): move migration list feature to `mihon.feature.migration.list`

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/MigrationActionIcon.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/MigrationActionIcon.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigratingManga
+import mihon.feature.migration.list.models.MigratingManga
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.i18n.stringResource

--- a/app/src/main/java/eu/kanade/presentation/browse/components/MigrationItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/MigrationItem.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import eu.kanade.presentation.manga.components.MangaCover
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigratingManga
+import mihon.feature.migration.list.models.MigratingManga
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR

--- a/app/src/main/java/eu/kanade/presentation/browse/components/MigrationItemResult.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/MigrationItemResult.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.manga.components.MangaCover
 import eu.kanade.presentation.util.rememberResourceBitmapPainter
 import eu.kanade.tachiyomi.R
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigratingManga
+import mihon.feature.migration.list.models.MigratingManga
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.sy.SYMR

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreen.kt
@@ -11,8 +11,8 @@ import eu.kanade.presentation.browse.MigrateSearchScreen
 import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationListScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import mihon.feature.migration.list.MigrationListScreen
 
 class MigrateSearchScreen(private val mangaId: Long) : Screen() {
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSourceSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSourceSearchScreen.kt
@@ -24,13 +24,13 @@ import eu.kanade.presentation.components.SearchToolbar
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationListScreen
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.SourceFilterDialog
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewScreen
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.persistentListOf
+import mihon.feature.migration.list.MigrationListScreen
 import mihon.presentation.core.util.collectAsLazyPagingItems
 import tachiyomi.core.common.Constants
 import tachiyomi.domain.manga.model.Manga

--- a/app/src/main/java/exh/smartsearch/SmartLibrarySearchEngine.kt
+++ b/app/src/main/java/exh/smartsearch/SmartLibrarySearchEngine.kt
@@ -1,5 +1,6 @@
 package exh.smartsearch
 
+import mihon.feature.migration.list.search.BaseSmartSearchEngine
 import tachiyomi.domain.library.model.LibraryManga
 
 class SmartLibrarySearchEngine(

--- a/app/src/main/java/exh/ui/smartsearch/SmartSearchScreenModel.kt
+++ b/app/src/main/java/exh/ui/smartsearch/SmartSearchScreenModel.kt
@@ -4,8 +4,8 @@ import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.ui.browse.source.SourcesScreen
-import exh.smartsearch.SmartSourceSearchEngine
 import kotlinx.coroutines.CancellationException
+import mihon.feature.migration.list.search.SmartSourceSearchEngine
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
 import tachiyomi.domain.manga.model.Manga

--- a/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreen.kt
+++ b/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreen.kt
@@ -58,12 +58,12 @@ import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.SOURCE_SEARCH_BOX_HEIGHT
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.source.online.HttpSource
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationListScreen
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationProcedureConfig
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigrationType
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.update
+import mihon.feature.migration.list.MigrationListScreen
+import mihon.feature.migration.list.MigrationProcedureConfig
+import mihon.feature.migration.list.MigrationType
 import sh.calvin.reorderable.ReorderableCollectionItemScope
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.ReorderableLazyListState

--- a/app/src/main/java/mihon/feature/migration/list/MigrationListScreen.kt
+++ b/app/src/main/java/mihon/feature/migration/list/MigrationListScreen.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.browse.migration.advanced.process
+package mihon.feature.migration.list
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
@@ -9,10 +9,6 @@ import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import eu.kanade.presentation.browse.MigrationListScreen
-import eu.kanade.presentation.browse.components.MigrationExitDialog
-import eu.kanade.presentation.browse.components.MigrationMangaDialog
-import eu.kanade.presentation.browse.components.MigrationProgressDialog
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.browse.migration.search.MigrateSearchScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
@@ -22,6 +18,10 @@ import exh.util.underEq
 import kotlinx.collections.immutable.persistentListOf
 import mihon.feature.migration.config.MigrationConfigScreen
 import mihon.feature.migration.config.MigrationConfigScreenSheet
+import mihon.feature.migration.list.components.MigrationExitDialog
+import mihon.feature.migration.list.components.MigrationMangaDialog
+import mihon.feature.migration.list.components.MigrationProgressDialog
+import mihon.feature.migration.list.models.MigratingManga
 import tachiyomi.core.common.i18n.pluralStringResource
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.i18n.sy.SYMR
@@ -95,7 +95,7 @@ class MigrationListScreen(private val config: MigrationProcedureConfig) : Screen
                 }
             }
         }
-        MigrationListScreen(
+        MigrationListScreenContent(
             items = items ?: persistentListOf(),
             migrationDone = migrationDone,
             finishedCount = finishedCount,

--- a/app/src/main/java/mihon/feature/migration/list/MigrationListScreenContent.kt
+++ b/app/src/main/java/mihon/feature/migration/list/MigrationListScreenContent.kt
@@ -1,4 +1,4 @@
-package eu.kanade.presentation.browse
+package mihon.feature.migration.list
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -28,9 +28,9 @@ import eu.kanade.presentation.browse.components.MigrationItem
 import eu.kanade.presentation.browse.components.MigrationItemResult
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigratingManga
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import mihon.feature.migration.list.models.MigratingManga
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
@@ -42,7 +42,7 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.plus
 
 @Composable
-fun MigrationListScreen(
+fun MigrationListScreenContent(
     items: ImmutableList<MigratingManga>,
     migrationDone: Boolean,
     finishedCount: Int,

--- a/app/src/main/java/mihon/feature/migration/list/MigrationListScreenModel.kt
+++ b/app/src/main/java/mihon/feature/migration/list/MigrationListScreenModel.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.browse.migration.advanced.process
+package mihon.feature.migration.list
 
 import android.content.Context
 import android.widget.Toast
@@ -11,9 +11,7 @@ import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.getNameForMangaInfo
 import eu.kanade.tachiyomi.source.online.all.EHentai
-import eu.kanade.tachiyomi.ui.browse.migration.advanced.process.MigratingManga.SearchResult
 import eu.kanade.tachiyomi.util.system.toast
-import exh.smartsearch.SmartSourceSearchEngine
 import exh.source.MERGED_SOURCE_ID
 import exh.util.ThrottleManager
 import kotlinx.collections.immutable.ImmutableList
@@ -32,6 +30,9 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import logcat.LogPriority
 import mihon.domain.migration.usecases.MigrateMangaUseCase
+import mihon.feature.migration.list.models.MigratingManga
+import mihon.feature.migration.list.models.MigratingManga.SearchResult
+import mihon.feature.migration.list.search.SmartSourceSearchEngine
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat

--- a/app/src/main/java/mihon/feature/migration/list/MigrationProcedureConfig.kt
+++ b/app/src/main/java/mihon/feature/migration/list/MigrationProcedureConfig.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.browse.migration.advanced.process
+package mihon.feature.migration.list
 
 import java.io.Serializable
 

--- a/app/src/main/java/mihon/feature/migration/list/components/MigrationExitDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/list/components/MigrationExitDialog.kt
@@ -1,4 +1,4 @@
-package eu.kanade.presentation.browse.components
+package mihon.feature.migration.list.components
 
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text

--- a/app/src/main/java/mihon/feature/migration/list/components/MigrationMangaDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/list/components/MigrationMangaDialog.kt
@@ -1,4 +1,4 @@
-package eu.kanade.presentation.browse.components
+package mihon.feature.migration.list.components
 
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text

--- a/app/src/main/java/mihon/feature/migration/list/components/MigrationProgressDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/list/components/MigrationProgressDialog.kt
@@ -1,4 +1,4 @@
-package eu.kanade.presentation.browse.components
+package mihon.feature.migration.list.components
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.material3.AlertDialog

--- a/app/src/main/java/mihon/feature/migration/list/models/MigratingManga.kt
+++ b/app/src/main/java/mihon/feature/migration/list/models/MigratingManga.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.ui.browse.migration.advanced.process
+package mihon.feature.migration.list.models
 
 import android.content.Context
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/mihon/feature/migration/list/search/BaseSmartSearchEngine.kt
+++ b/app/src/main/java/mihon/feature/migration/list/search/BaseSmartSearchEngine.kt
@@ -1,4 +1,4 @@
-package exh.smartsearch
+package mihon.feature.migration.list.search
 
 import info.debatty.java.stringsimilarity.NormalizedLevenshtein
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/mihon/feature/migration/list/search/SmartSourceSearchEngine.kt
+++ b/app/src/main/java/mihon/feature/migration/list/search/SmartSourceSearchEngine.kt
@@ -1,4 +1,4 @@
-package exh.smartsearch
+package mihon.feature.migration.list.search
 
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.model.SManga


### PR DESCRIPTION
- Relocates migration process screens, models, and components from `eu.kanade` and `exh` packages to a unified `mihon.feature.migration.list` package.
- Renames `MigrationListScreen` (presentation) to `MigrationListScreenContent` to avoid naming conflicts with the UI screen.
- Moves `SmartSourceSearchEngine` and `BaseSmartSearchEngine` to `mihon.feature.migration.list.search`.
- Updates all affected imports across the project.

## Summary by Sourcery

Consolidate the migration list feature into the new `mihon.feature.migration.list` module and update all usages accordingly.

Enhancements:
- Move migration list screens, models, dialogs, and related UI components into the `mihon.feature.migration.list` package for better modularization.
- Relocate smart search engines used by migration to `mihon.feature.migration.list.search` and centralize usage.
- Rename the composable migration list presentation function to `MigrationListScreenContent` to avoid naming conflicts and clarify its role.