### PR TITLE
Fix title text color in light mode on mass migration list

### DIFF
--- a/app/src/main/java/mihon/feature/migration/list/MigrationListScreenContent.kt
+++ b/app/src/main/java/mihon/feature/migration/list/MigrationListScreenContent.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.DpOffset
@@ -215,10 +214,10 @@ fun MigrationListItem(
                     .background(
                         Brush.verticalGradient(
                             0f to Color.Transparent,
-                            1f to Color(0xAA000000),
+                            1f to MaterialTheme.colorScheme.background,
                         ),
                     )
-                    .fillMaxHeight(0.33f)
+                    .fillMaxHeight(0.4f)
                     .fillMaxWidth()
                     .align(Alignment.BottomCenter),
             )
@@ -229,8 +228,7 @@ fun MigrationListItem(
                 text = manga.title,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 2,
-                style = MaterialTheme.typography.labelMedium
-                    .merge(shadow = Shadow(color = Color.Black, blurRadius = 4f)),
+                style = MaterialTheme.typography.labelMedium,
             )
             BadgeGroup(modifier = Modifier.padding(4.dp)) {
                 Badge(text = "$chapterCount")


### PR DESCRIPTION
## Summary by Sourcery

Adjust migration list item styling to improve title readability across themes.

Bug Fixes:
- Fix migration list title text visibility in light mode by updating the overlay gradient and text style.

Enhancements:
- Increase the height of the bottom gradient overlay on migration list items to provide better contrast for titles.