### PR TITLE
fix(migrate-dialog): Fix Migrate Manga dialog won't show the second time (#1409)

### DIFF
--- a/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
@@ -159,6 +159,7 @@ private class MigrateDialogScreenModel(
                 target = target,
                 applicableFlags = applicableFlags,
                 selectedFlags = selectedFlags,
+                isMigrated = false,
             )
         }
     }
@@ -180,8 +181,14 @@ private class MigrateDialogScreenModel(
         // sourcePreference.migrationFlags().set(state.selectedFlags)
         // KMK <--
         mutableState.update { it.copy(isMigrating = true) }
-        migrateManga(current, target, replace, /* KMK --> */ state.selectedFlags /* KMK <-- */)
-        mutableState.update { it.copy(isMigrating = false, isMigrated = true) }
+        try {
+            migrateManga(current, target, replace, /* KMK --> */ state.selectedFlags /* KMK <-- */)
+            mutableState.update { it.copy(isMigrating = false, isMigrated = true) }
+            // KMK -->
+        } catch (_: Throwable) {
+            mutableState.update { it.copy(isMigrating = false, isMigrated = false) }
+            // KMK <--
+        }
     }
 
     data class State(


### PR DESCRIPTION
Also handle the case migrate-dialog keeps loading forever in case of exception

## Summary by Sourcery

Handle migrate manga dialog migration state more robustly to prevent the dialog from remaining in a loading state or failing to reopen.

Bug Fixes:
- Ensure the migrate manga dialog initializes with a non-migrated state when opened.
- Reset migration state correctly on migration failure so the dialog does not stay stuck loading and can be shown again.