### PR TITLE
Use ComposeStars from RatingBar library

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceEHentaiList.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastAny
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
-import com.gowtham.ratingbar.RatingBar
+import com.gowtham.ratingbar.ComposeStars
 import com.gowtham.ratingbar.RatingBarStyle
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.presentation.library.components.CommonMangaItemDefaults
@@ -267,14 +267,15 @@ fun BrowseSourceEHentaiListItem(
                     verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
                     horizontalAlignment = Alignment.Start,
                 ) {
-                    RatingBar(
+                    ComposeStars(
                         value = rating,
-                        onValueChange = {},
-                        onRatingChanged = {},
-                        isIndicator = true,
                         numOfStars = 5,
                         size = 18.dp,
+                        spaceBetween = 2.dp,
+                        hideInactiveStars = false,
                         style = RatingBarStyle.Fill(),
+                        painterEmpty = null,
+                        painterFilled = null,
                     )
                     val color = genre?.first?.color
                     // KMK -->


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Standardize EHentai browse item rating display on the ComposeStars component with configured spacing and styling options.