### PR TITLE
Add handling for previously unhandled preferences (delegated MD)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mdlist/MdList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mdlist/MdList.kt
@@ -168,11 +168,11 @@ class MdList(id: Long) : BaseTracker(id, "MDList") {
             val manga = mdex.getMangaMetadata(track.toDbTrack())
             TrackMangaMetadata(
                 remoteId = 0,
-                title = manga?.title,
-                thumbnailUrl = manga?.thumbnail_url, // Doesn't load the actual cover because of Refer header
-                description = manga?.description,
-                authors = manga?.author,
-                artists = manga?.artist,
+                title = manga.title,
+                thumbnailUrl = manga.thumbnail_url, // Doesn't load the actual cover because of Refer header
+                description = manga.description,
+                authors = manga.author,
+                artists = manga.artist,
             )
         }
     }

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -704,7 +704,8 @@
     <string name="mangadex_push_favorites_to_mangadex_summary">Syncs any non MdList tracked entries to MangaDex as reading.</string>
     <string name="community_recommendations">Community recommendations</string>
     <string name="similar_titles">Similar titles</string>
-    <string name="alt_titles">Alternative Titles</string>
+    <string name="alt_titles">Alternative titles</string>
+    <string name="final_chapter">Final chapter</string>
 
     <!-- Scanlator filters -->
     <string name="select_scanlators">Scanlator groups to show</string>


### PR DESCRIPTION
* Include romanized titles of the original language in description

* Implement handling for `finalChapterInDesc` preference.

* Handle `preferExtensionLangTitle` preference when fetching manga details.

* Address some warnings, clean up unused code and spotless apply.

Close #836 

## Summary by Sourcery

Handle new MangaDex extension preferences for titles and descriptions and clean up related utilities and metadata usage.

New Features:
- Add support for including alternative titles and final chapter information in manga descriptions based on user preferences.
- Respect a preference to prioritize the extension language title when selecting a manga title from MangaDex metadata.

Bug Fixes:
- Avoid nullable returns for MangaDex metadata retrieval in MdList tracking to ensure consistent access to manga fields.

Enhancements:
- Refine MangaDex title selection and alternative title handling to better use original-language and romanized variants.
- Simplify and modernize MangaDex utility and handler code, including removal of unused helpers and minor API cleanups.
- Update i18n resources for alternative titles and add a new localized string for final chapter labels.