### PR TITLE
fix(notifications): paused notifications not showing

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
@@ -66,6 +66,7 @@ internal class DownloadNotifier(private val context: Context) {
      */
     fun dismissProgress() {
         context.cancelNotification(Notifications.ID_DOWNLOAD_CHAPTER_PROGRESS)
+        // KMK -->
         context.cancelNotification(Notifications.ID_DOWNLOAD_CHAPTER_PAUSED)
     }
 
@@ -74,6 +75,7 @@ internal class DownloadNotifier(private val context: Context) {
      */
     fun dismissPaused() {
         context.cancelNotification(Notifications.ID_DOWNLOAD_CHAPTER_PAUSED)
+        // KMK <--
     }
 
     /**
@@ -155,7 +157,9 @@ internal class DownloadNotifier(private val context: Context) {
                 NotificationReceiver.clearDownloadsPendingBroadcast(context),
             )
 
+            // KMK -->
             show(Notifications.ID_DOWNLOAD_CHAPTER_PAUSED)
+            // KMK <--
         }
 
         // Reset initial values

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -139,7 +139,9 @@ class Downloader(
             return false
         }
 
+        // KMK -->
         notifier.dismissPaused()
+        // KMK <--
 
         val pending = queueState.value.filter { it.status != Download.State.DOWNLOADED }
         pending.forEach { if (it.status != Download.State.QUEUE) it.status = Download.State.QUEUE }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -42,8 +42,9 @@ object Notifications {
     private const val GROUP_DOWNLOADER = "group_downloader"
     const val CHANNEL_DOWNLOADER_PROGRESS = "downloader_progress_channel"
     const val ID_DOWNLOAD_CHAPTER_PROGRESS = -201
-    /** Separate ID required: DownloadJob foreground worker uses ID_DOWNLOAD_CHAPTER_PROGRESS and clears it when stopping. */
+    // KMK -->
     const val ID_DOWNLOAD_CHAPTER_PAUSED = -203
+    // KMK <--
     const val CHANNEL_DOWNLOADER_ERROR = "downloader_error_channel"
     const val ID_DOWNLOAD_CHAPTER_ERROR = -202
 


### PR DESCRIPTION
### Summary

Pausing an ongoing download did not reliably show a paused notification.  
This occurred because the downloader progress notification shared the same notification ID as the foreground `DownloadJob` notification, which Android removes when the worker stops.

As a result, the paused notification could disappear immediately or never appear.

### Fixed Issue

- Paused download notifications not showing consistently

### Changes

- Introduced a separate notification ID dedicated to the paused download state
- When downloads are paused:
  - The progress notification is dismissed
  - A dedicated paused notification is shown, preventing it from being cleared by the foreground worker lifecycle
- Properly dismiss the paused notification when:
  - Downloads resume
  - Downloads complete
  - The download queue is cleared

### Testing

- [x] Paused an active download and verified paused notification appears
- [x] Resumed download and verified paused notification is dismissed
- [x] Completed download clears paused notification correctly
- [x] Cleared download queue removes paused notification
- [x] Checked default theme
- [x] Checked tablet mode

### Images

_Not applicable (no visual changes)_

## Summary by Sourcery

Ensure paused download notifications use a dedicated notification ID and are correctly shown and dismissed during download lifecycle events.

Bug Fixes:
- Prevent paused download notifications from being removed when the foreground download worker stops.
- Clear any existing paused notification when downloads are resumed to avoid stale notifications.

Enhancements:
- Include paused download notifications in the general progress dismissal logic so both progress and paused states are cleaned up together.