### PR TITLE
Add `src:local` search alias for Local Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Display author & artist name in MAL search results ([@MajorTanya](https://github.com/MajorTanya)) ([#2833](https://github.com/mihonapp/mihon/pull/2833))
 - Add filter options to Updates tab ([@MajorTanya](https://github.com/MajorTanya)) ([#2851](https://github.com/mihonapp/mihon/pull/2851))
 - Add `src:` prefix to search the library by source ID ([@MajorTanya](https://github.com/MajorTanya)) ([#2927](https://github.com/mihonapp/mihon/pull/2927))
+  - Add `src:local` as a way to search for Local Source entries ([@MajorTanya](https://github.com/MajorTanya)) ([#2928](https://github.com/mihonapp/mihon/pull/2928))
 
 ### Improved
 - Minimize memory usage by reducing in-memory cover cache size ([@Lolle2000la](https://github.com/Lolle2000la)) ([#2266](https://github.com/mihonapp/mihon/pull/2266))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -6,6 +6,8 @@ import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
+internal const val LOCAL_SOURCE_ID_ALIAS = "local"
+
 data class LibraryItem(
     val libraryManga: LibraryManga,
     val downloadCount: Long = -1,
@@ -32,7 +34,12 @@ data class LibraryItem(
 //        if (constraint.startsWith("id:", true)) {
 //            return id == constraint.substringAfter("id:").toLongOrNull()
 //        } else if (constraint.startsWith("src:", true)) {
-//            return source.id == constraint.substringAfter("src:").toLongOrNull()
+//            val querySource = constraint.substringAfter("src:")
+//            return if (querySource.equals(LOCAL_SOURCE_ID_ALIAS, ignoreCase = true)) {
+//                source.id == LocalSource.ID
+//            } else {
+//                source.id == querySource.toLongOrNull()
+//            }
 //        }
 //        return libraryManga.manga.title.contains(constraint, true) ||
 //            (libraryManga.manga.author?.contains(constraint, true) ?: false) ||

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -1180,7 +1180,12 @@ class LibraryScreenModel(
                 }
                 val sourceId = item.libraryManga.manga.source
                 if (query.startsWith("src:", true)) {
-                    return@filter sourceId == query.substringAfter("src:").toLongOrNull()
+                    val querySource = query.substringAfter("src:")
+                    return@filter if (querySource.equals(LOCAL_SOURCE_ID_ALIAS, ignoreCase = true)) {
+                        sourceId == LocalSource.ID
+                    } else {
+                        sourceId == querySource.toLongOrNull()
+                    }
                 }
                 if (isMetadataSource(sourceId) && mangaWithMetaIds.binarySearch(mangaId) >= 0) {
                     val tags = getSearchTags.await(mangaId)


### PR DESCRIPTION
## Summary by Sourcery

Allow searching library entries from the Local Source using a dedicated search alias.

New Features:
- Support the `src:local` search prefix to filter library items belonging to the Local Source.

Documentation:
- Document the new `src:local` library search alias in the changelog.