### PR TITLE
fix(recommends): Handle crash due to null manga case in RecommendsScreenModel

### DIFF
--- a/app/src/main/java/exh/recs/RecommendsScreenModel.kt
+++ b/app/src/main/java/exh/recs/RecommendsScreenModel.kt
@@ -50,7 +50,7 @@ open class RecommendsScreenModel(
         ioCoroutineScope.launch {
             val recommendationSources = when (args) {
                 is RecommendsScreen.Args.SingleSourceManga -> {
-                    val manga = getManga.await(args.mangaId)!!
+                    val manga = getManga.await(args.mangaId) ?: return@launch
                     mutableState.update { it.copy(title = manga.title) }
 
                     RecommendationPagingSource.createSources(


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Gracefully handle null manga results in the recommendations screen model instead of force-unwrapping.