### PR TITLE
feat(theme): Support Dynamic theme for Android 11 and below

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -5,8 +5,6 @@ import com.materialkolor.PaletteStyle
 import eu.kanade.domain.ui.model.AppTheme
 import eu.kanade.domain.ui.model.TabletUiMode
 import eu.kanade.domain.ui.model.ThemeMode
-import eu.kanade.tachiyomi.util.system.DeviceUtil
-import eu.kanade.tachiyomi.util.system.isDynamicColorAvailable
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
 import java.time.format.DateTimeFormatter
@@ -21,11 +19,7 @@ class UiPreferences(
 
     fun appTheme() = preferenceStore.getEnum(
         "pref_app_theme",
-        if (DeviceUtil.isDynamicColorAvailable) {
-            AppTheme.MONET
-        } else {
-            AppTheme.DEFAULT
-        },
+        AppTheme.MONET,
     )
 
     fun themeDarkAmoled() = preferenceStore.getBoolean("pref_theme_dark_amoled_key", false)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidget.kt
@@ -46,8 +46,6 @@ import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.domain.ui.model.AppTheme
 import eu.kanade.presentation.manga.components.MangaCover
 import eu.kanade.presentation.theme.TachiyomiTheme
-import eu.kanade.tachiyomi.util.system.DeviceUtil
-import eu.kanade.tachiyomi.util.system.isDynamicColorAvailable
 import tachiyomi.core.common.preference.InMemoryPreferenceStore
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.padding
@@ -82,7 +80,7 @@ private fun AppThemesList(
     val context = LocalContext.current
     val appThemes = remember {
         AppTheme.entries
-            .filterNot { it.titleRes == null || (it == AppTheme.MONET && !DeviceUtil.isDynamicColorAvailable) }
+            .filterNot { it.titleRes == null }
     }
     LazyRow(
         contentPadding = PaddingValues(horizontal = PrefsHorizontalPadding),

--- a/app/src/main/java/eu/kanade/presentation/theme/colorscheme/MonetColorScheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/colorscheme/MonetColorScheme.kt
@@ -54,7 +54,7 @@ internal class MonetCompatColorScheme(seed: Color) : BaseColorScheme() {
                 seedColor = seed,
                 isDark = dark,
                 specVersion = ColorSpec.SpecVersion.SPEC_2025,
-                style = PaletteStyle.Expressive,
+                style = PaletteStyle.TonalSpot,
             )
                 .toColorScheme(isAmoled = false)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/DeviceUtilExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/DeviceUtilExtensions.kt
@@ -1,8 +1,0 @@
-package eu.kanade.tachiyomi.util.system
-
-import android.os.Build
-import com.google.android.material.color.DynamicColors
-
-val DeviceUtil.isDynamicColorAvailable by lazy {
-    DynamicColors.isDynamicColorAvailable() || (DeviceUtil.isSamsung && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
-}


### PR DESCRIPTION
Implement support for dynamic themes on devices running Android 11 and earlier.

## Summary by Sourcery

Enable Monet dynamic theming as the default app theme and make dynamic theme options available across all supported Android versions.

Enhancements:
- Always default the app theme preference to Monet instead of conditionally based on device dynamic color support.
- Show the Monet app theme option in the theme picker for all devices rather than hiding it when dynamic color is unavailable.
- Adjust the Monet-compatible color scheme to use the TonalSpot palette style instead of Expressive.