### PR TITLE
(chore): Don't wrap an intent-chooser inside another intent-chooser

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.ui.manga
 
 import android.Manifest
 import android.content.Context
-import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.BackHandler
@@ -693,12 +692,7 @@ class MangaScreen(
         try {
             getMangaUrl(manga_, source_)?.let { url ->
                 val intent = url.toUri().toShareIntent(context, type = "text/plain")
-                context.startActivity(
-                    Intent.createChooser(
-                        intent,
-                        context.stringResource(MR.strings.action_share),
-                    ),
-                )
+                context.startActivity(intent)
             }
         } catch (e: Exception) {
             context.toast(e.message)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -1032,7 +1032,7 @@ class ReaderActivity : BaseActivity() {
     private fun shareChapter() {
         assistUrl?.let {
             val intent = it.toUri().toShareIntent(this, type = "text/plain")
-            startActivity(Intent.createChooser(intent, stringResource(MR.strings.action_share)))
+            startActivity(intent)
         }
     }
 
@@ -1238,7 +1238,7 @@ class ReaderActivity : BaseActivity() {
                 stringResource(MR.strings.share_page_info, manga.title, chapter.name, page.number)
             },
         )
-        startActivity(Intent.createChooser(intent, stringResource(MR.strings.action_share)))
+        startActivity(intent)
     }
 
     private fun onCopyImageResult(uri: Uri) {


### PR DESCRIPTION
Remove unnecessary wrapping of share intents in an intent chooser for a more straightforward sharing experience.

## Summary by Sourcery

Enhancements:
- Launch share intents for manga URLs, chapters, and pages directly without nesting them inside an extra chooser dialog.