### PR TITLE
feat(navigation): Allow clearing search when Back on Extensions Screen

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsTab.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.browse.extension
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined._18UpRating
 import androidx.compose.material3.AlertDialog
@@ -66,6 +67,9 @@ fun extensionsTab(
             ),
         ),
         content = { contentPadding, _ ->
+            BackHandler(enabled = state.searchQuery != null) {
+                extensionsScreenModel.search(null)
+            }
             ExtensionScreen(
                 state = state,
                 contentPadding = contentPadding,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/feed/FeedTab.kt
@@ -58,13 +58,6 @@ fun Screen.feedTab(
 
     val haptic = LocalHapticFeedback.current
 
-    BackHandler(enabled = bulkFavoriteState.selectionMode || showingFeedOrderScreen.value) {
-        when {
-            bulkFavoriteState.selectionMode -> bulkFavoriteScreenModel.backHandler()
-            showingFeedOrderScreen.value -> showingFeedOrderScreen.value = false
-        }
-    }
-
     LaunchedEffect(bulkFavoriteState.selectionMode) {
         HomeScreen.showBottomNav(!bulkFavoriteState.selectionMode)
     }
@@ -122,6 +115,12 @@ fun Screen.feedTab(
         },
         content = { contentPadding, snackbarHostState ->
             // KMK -->
+            BackHandler(enabled = bulkFavoriteState.selectionMode || showingFeedOrderScreen.value) {
+                when {
+                    bulkFavoriteState.selectionMode -> bulkFavoriteScreenModel.backHandler()
+                    showingFeedOrderScreen.value -> showingFeedOrderScreen.value = false
+                }
+            }
             Crossfade(
                 targetState = showingFeedOrderScreen.value,
                 label = "feed_order_crossfade",


### PR DESCRIPTION
Implement a back handler that clears the search query when navigating back on the extensions screen.

## Summary by Sourcery

New Features:
- Clear the extensions screen search query when pressing the system back button while a search is active.