### PR TITLE
refactor(HttpSource): Use response.use to ensure proper resource management

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -165,9 +165,8 @@ class MangaCoverFetcher(
             }
 
             // Fetch from network
-            val response = executeNetworkRequest()
-            val responseBody = checkNotNull(response.body) { "Null response source" }
-            try {
+            executeNetworkRequest().use { response ->
+                val responseBody = checkNotNull(response.body) { "Null response source" }
                 // Read from cover cache after library manga cover updated
                 val responseCoverCache = writeResponseToCoverCache(response, libraryCoverCacheFile)
                 if (responseCoverCache != null) {
@@ -202,9 +201,6 @@ class MangaCoverFetcher(
                     mimeType = "image/*",
                     dataSource = if (response.cacheResponse != null) DataSource.DISK else DataSource.NETWORK,
                 )
-            } catch (e: Exception) {
-                responseBody.close()
-                throw e
             }
         } catch (e: Exception) {
             snapshot?.close()
@@ -309,7 +305,7 @@ class MangaCoverFetcher(
         } catch (e: Exception) {
             try {
                 editor.abort()
-            } catch (ignored: Exception) {
+            } catch (_: Exception) {
             }
             throw e
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/PagePreviewFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/PagePreviewFetcher.kt
@@ -88,9 +88,8 @@ class PagePreviewFetcher(
             }
 
             // Fetch from network
-            val response = executeNetworkRequest()
-            val responseBody = checkNotNull(response.body) { "Null response source" }
-            try {
+            executeNetworkRequest().use { response ->
+                val responseBody = checkNotNull(response.body) { "Null response source" }
                 // Read from page preview cache after page preview updated
                 val responsePagePreviewCache = writeResponseToPagePreviewCache(response)
                 if (responsePagePreviewCache != null) {
@@ -113,9 +112,6 @@ class PagePreviewFetcher(
                     mimeType = "image/*",
                     dataSource = if (response.cacheResponse != null) DataSource.DISK else DataSource.NETWORK,
                 )
-            } catch (e: Exception) {
-                responseBody.close()
-                throw e
             }
         } catch (e: Exception) {
             snapshot?.close()
@@ -220,7 +216,7 @@ class PagePreviewFetcher(
         } catch (e: Exception) {
             try {
                 editor.abort()
-            } catch (ignored: Exception) {
+            } catch (_: Exception) {
             }
             throw e
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -530,6 +530,7 @@ class Downloader(
                 response.body.source().saveTo(file.openOutputStream())
                 val extension = getImageExtension(response, file)
                 file.renameTo("$filename.$extension")
+                response.close()
             } catch (e: Exception) {
                 response.close()
                 file.delete()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -112,6 +112,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 .awaitSuccess()
+                .close()
             track
         }
     }
@@ -134,6 +135,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 .awaitSuccess()
+                .close()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
@@ -56,6 +56,7 @@ class BangumiApi(
             // Returns with 202 Accepted on success with no body
             authClient.newCall(POST(url, body = body, headers = headersOf("Content-Type", APP_JSON)))
                 .awaitSuccess()
+                .close()
             track
         }
     }
@@ -80,6 +81,7 @@ class BangumiApi(
             // Returns with 204 No Content
             authClient.newCall(request)
                 .awaitSuccess()
+                .close()
 
             track
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kavita/KavitaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kavita/KavitaApi.kt
@@ -64,7 +64,7 @@ class KavitaApi(private val client: OkHttpClient, interceptor: KavitaInterceptor
                 }
             }
             // Not sure which one to catch
-        } catch (e: SocketTimeoutException) {
+        } catch (_: SocketTimeoutException) {
             logcat(LogPriority.WARN) {
                 "Could not fetch JWT token. Probably due to connectivity issue or URL '$apiUrl' not available, skipping"
             }
@@ -180,6 +180,7 @@ class KavitaApi(private val client: OkHttpClient, interceptor: KavitaInterceptor
             POST(requestUrl, body = "{}".toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())),
         )
             .awaitSuccess()
+            .close()
         return getTrackSearch(track.tracking_url)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
@@ -113,6 +113,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
                     .build(),
             )
                 .awaitSuccess()
+                .close()
 
             track
         }
@@ -127,6 +128,7 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
                 ),
             )
                 .awaitSuccess()
+                .close()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -6,7 +6,6 @@ import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
 import okhttp3.Headers
@@ -54,7 +53,7 @@ class KomgaApi(
                     .newCall(
                         GET("${url.replace("/api/v1/series/", "/api/v2/series/")}/read-progress/tachiyomi", headers),
                     )
-                    .awaitSuccess().let {
+                    .awaitSuccess().use {
                         with(json) {
                             if (url.contains("/api/v1/series/")) {
                                 it.parseAs<ReadProgressV2Dto>()
@@ -95,6 +94,7 @@ class KomgaApi(
                 .build(),
         )
             .awaitSuccess()
+            .close()
         return getTrackSearch(track.tracking_url)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/mangaupdates/MangaUpdatesApi.kt
@@ -72,7 +72,7 @@ class MangaUpdatesApi(
             ),
         )
             .awaitSuccess()
-            .let {
+            .use {
                 if (it.code == 200) {
                     track.status = status
                     track.last_chapter_read = 1.0
@@ -99,6 +99,7 @@ class MangaUpdatesApi(
             ),
         )
             .awaitSuccess()
+            .close()
 
         updateSeriesRating(track)
     }
@@ -114,6 +115,7 @@ class MangaUpdatesApi(
             ),
         )
             .awaitSuccess()
+            .close()
     }
 
     private suspend fun getSeriesRating(track: Track): MURating? {
@@ -123,7 +125,7 @@ class MangaUpdatesApi(
                     .awaitSuccess()
                     .parseAs<MURating>()
             }
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             null
         }
     }
@@ -141,11 +143,13 @@ class MangaUpdatesApi(
                 ),
             )
                 .awaitSuccess()
+                .close()
         } else {
             authClient.newCall(
                 DELETE(url = "$BASE_URL/v1/series/${track.remote_id}/rating"),
             )
                 .awaitSuccess()
+                .close()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -137,6 +137,7 @@ class MyAnimeListApi(
             authClient
                 .newCall(DELETE(mangaUrl(track.remoteId).toString()))
                 .awaitSuccess()
+                .close()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt
@@ -75,6 +75,7 @@ class ShikimoriApi(
             authClient
                 .newCall(DELETE("$API_URL/v2/user_rates/${track.libraryId}"))
                 .awaitSuccess()
+                .close()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/SuwayomiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/SuwayomiApi.kt
@@ -34,7 +34,7 @@ class SuwayomiApi(private val trackId: Long) {
     private val baseUrl: String by lazy { source.baseUrl.trimEnd('/') }
     private val apiUrl: String by lazy { "$baseUrl/api/graphql" }
 
-    public fun sourcePreferences(): SharedPreferences = configurableSource.sourcePreferences()
+    fun sourcePreferences(): SharedPreferences = configurableSource.sourcePreferences()
 
     suspend fun getTrackSearch(mangaId: Long): TrackSearch = withIOContext {
         val query = $$"""
@@ -146,15 +146,14 @@ class SuwayomiApi(private val trackId: Long) {
                 }
             }
         }
-        with(json) {
-            client.newCall(
-                POST(
-                    apiUrl,
-                    body = markPayload.toString().toRequestBody(jsonMime),
-                ),
-            )
-                .awaitSuccess()
-        }
+        client.newCall(
+            POST(
+                apiUrl,
+                body = markPayload.toString().toRequestBody(jsonMime),
+            ),
+        )
+            .awaitSuccess()
+            .close()
 
         val trackQuery = $$"""
         |mutation TrackManga($mangaId: Int!) {
@@ -177,6 +176,7 @@ class SuwayomiApi(private val trackId: Long) {
                 ),
             )
                 .awaitSuccess()
+                .close()
         }
 
         return getTrackSearch(track.remote_id)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
@@ -180,7 +180,7 @@ class MangaDex(delegate: HttpSource, val context: Context) :
         return client.newCall(request.newBuilder().url(url).build())
             .asObservableSuccess()
             .map { response ->
-                delegate.latestUpdatesParse(response)
+                response.use { delegate.latestUpdatesParse(it) }
             }
     }
 
@@ -191,7 +191,7 @@ class MangaDex(delegate: HttpSource, val context: Context) :
             .build()
 
         val response = client.newCall(request.newBuilder().url(url).build()).awaitSuccess()
-        return delegate.latestUpdatesParse(response)
+        return response.use { delegate.latestUpdatesParse(it) }
     }
 
     @Deprecated("Use the 1.x API instead", replaceWith = ReplaceWith("getMangaDetails"))

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -68,7 +68,7 @@ class NHentai(delegate: HttpSource, val context: Context) :
 
     override suspend fun getMangaDetails(manga: SManga): SManga {
         val response = client.newCall(mangaDetailsRequest(manga)).awaitSuccess()
-        return parseToManga(manga, response)
+        return response.use { parseToManga(manga, it) }
     }
 
     override suspend fun parseIntoMetadata(metadata: NHentaiSearchMetadata, input: Response) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/EightMuses.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/EightMuses.kt
@@ -45,7 +45,7 @@ class EightMuses(delegate: HttpSource, val context: Context) :
 
     override suspend fun getMangaDetails(manga: SManga): SManga {
         val response = client.newCall(mangaDetailsRequest(manga)).awaitSuccess()
-        return parseToManga(manga, response.asJsoup())
+        return response.use { parseToManga(manga, it.asJsoup()) }
     }
 
     data class SelfContents(val albums: List<Element>, val images: List<Element>)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/HBrowse.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/HBrowse.kt
@@ -44,7 +44,7 @@ class HBrowse(delegate: HttpSource, val context: Context) :
 
     override suspend fun getMangaDetails(manga: SManga): SManga {
         val response = client.newCall(mangaDetailsRequest(manga)).awaitSuccess()
-        return parseToManga(manga, response.asJsoup())
+        return response.use { parseToManga(manga, it.asJsoup()) }
     }
 
     override suspend fun parseIntoMetadata(metadata: HBrowseSearchMetadata, input: Document) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Pururin.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Pururin.kt
@@ -69,7 +69,7 @@ class Pururin(delegate: HttpSource, val context: Context) :
 
     override suspend fun getMangaDetails(manga: SManga): SManga {
         val response = client.newCall(mangaDetailsRequest(manga)).awaitSuccess()
-        return parseToManga(manga, response.asJsoup())
+        return response.use { parseToManga(manga, it.asJsoup()) }
     }
 
     override suspend fun parseIntoMetadata(metadata: PururinSearchMetadata, input: Document) {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Tsumino.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/english/Tsumino.kt
@@ -58,7 +58,7 @@ class Tsumino(delegate: HttpSource, val context: Context) :
 
     override suspend fun getMangaDetails(manga: SManga): SManga {
         val response = client.newCall(mangaDetailsRequest(manga)).awaitSuccess()
-        return parseToManga(manga, response.asJsoup())
+        return response.use { parseToManga(manga, it.asJsoup()) }
     }
 
     override suspend fun parseIntoMetadata(metadata: TsuminoSearchMetadata, input: Document) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -41,7 +41,7 @@ internal class HttpPageLoader(
     private val chapterCache: ChapterCache = Injekt.get(),
     // SY -->
     private val readerPreferences: ReaderPreferences = Injekt.get(),
-    private val sourcePreferences: SourcePreferences = Injekt.get(),
+    sourcePreferences: SourcePreferences = Injekt.get(),
     // SY <--
 ) : PageLoader() {
 
@@ -219,8 +219,9 @@ internal class HttpPageLoader(
 
             if (!chapterCache.isImageInCache(imageUrl)) {
                 page.status = Page.State.DownloadImage
-                val imageResponse = source.getImage(page, dataSaver)
-                chapterCache.putImageToCache(imageUrl, imageResponse)
+                source.getImage(page, dataSaver).use { imageResponse ->
+                    chapterCache.putImageToCache(imageUrl, imageResponse)
+                }
             }
 
             page.stream = { chapterCache.getImageFile(imageUrl).inputStream() }

--- a/app/src/main/java/exh/favorites/FavoritesSyncHelper.kt
+++ b/app/src/main/java/exh/favorites/FavoritesSyncHelper.kt
@@ -254,9 +254,11 @@ class FavoritesSyncHelper(val context: Context) {
             try {
                 val resp = withIOContext { exh.client.newCall(request).await() }
 
-                if (resp.isSuccessful) {
-                    success = true
-                    break
+                resp.use {
+                    if (it.isSuccessful) {
+                        success = true
+                        break
+                    }
                 }
             } catch (e: Exception) {
                 logger.w(context.stringResource(SYMR.strings.favorites_sync_network_error), e)

--- a/app/src/main/java/exh/md/handlers/AzukiHandler.kt
+++ b/app/src/main/java/exh/md/handlers/AzukiHandler.kt
@@ -24,7 +24,7 @@ class AzukiHandler(currentClient: OkHttpClient, userAgent: String) {
     suspend fun fetchPageList(externalUrl: String): List<Page> {
         val chapterId = externalUrl.substringAfterLast("/").substringBefore("?")
         val request = pageListRequest(chapterId)
-        return pageListParse(client.newCall(request).awaitSuccess())
+        return client.newCall(request).awaitSuccess().use { pageListParse(it) }
     }
 
     private fun pageListRequest(chapterId: String): Request {

--- a/app/src/main/java/exh/md/handlers/BilibiliHandler.kt
+++ b/app/src/main/java/exh/md/handlers/BilibiliHandler.kt
@@ -97,7 +97,7 @@ class BilibiliHandler(currentClient: OkHttpClient) {
 
     suspend fun getChapterList(mangaUrl: String): List<SChapter> {
         val response = client.newCall(mangaDetailsApiRequest(mangaUrl)).awaitSuccess()
-        return chapterListParse(response)
+        return response.use { chapterListParse(it) }
     }
 
     fun chapterListParse(response: Response): List<SChapter> {
@@ -120,7 +120,7 @@ class BilibiliHandler(currentClient: OkHttpClient) {
 
     private suspend fun fetchPageList(chapterUrl: String): List<Page> {
         val response = client.newCall(pageListRequest(chapterUrl)).awaitSuccess()
-        return pageListParse(response)
+        return response.use { pageListParse(it) }
     }
 
     private fun pageListRequest(chapterUrl: String): Request {
@@ -156,7 +156,7 @@ class BilibiliHandler(currentClient: OkHttpClient) {
 
     suspend fun getImageUrl(page: Page): String {
         val response = client.newCall(imageUrlRequest(page)).awaitSuccess()
-        return imageUrlParse(response)
+        return response.use { imageUrlParse(it) }
     }
 
     fun fetchImageUrl(page: Page): Observable<String> {

--- a/app/src/main/java/exh/md/handlers/MangaHotHandler.kt
+++ b/app/src/main/java/exh/md/handlers/MangaHotHandler.kt
@@ -28,7 +28,7 @@ class MangaHotHandler(currentClient: OkHttpClient, userAgent: String) {
                     .replace("viewer", "v1/works/storyDetail"),
                 headers,
             )
-        return pageListParse(client.newCall(request).awaitSuccess())
+        return client.newCall(request).awaitSuccess().use { pageListParse(it) }
     }
 
     fun pageListParse(response: Response): List<Page> {

--- a/app/src/main/java/exh/md/handlers/MangaPlusHandler.kt
+++ b/app/src/main/java/exh/md/handlers/MangaPlusHandler.kt
@@ -35,7 +35,7 @@ class MangaPlusHandler(currentClient: OkHttpClient) {
 
     suspend fun fetchPageList(chapterId: String, dataSaver: Boolean): List<Page> {
         val response = client.newCall(pageListRequest(chapterId.substringAfterLast("/"), dataSaver)).awaitSuccess()
-        return pageListParse(response)
+        return response.use { pageListParse(it) }
     }
 
     private fun pageListRequest(chapterId: String, dataSaver: Boolean): Request {

--- a/app/src/main/java/exh/md/handlers/NamicomiHandler.kt
+++ b/app/src/main/java/exh/md/handlers/NamicomiHandler.kt
@@ -27,7 +27,9 @@ class NamicomiHandler(currentClient: OkHttpClient, userAgent: String) {
                 "$apiUrl/images/chapter/$chapterId?newQualities=true",
                 headers,
             )
-        return pageListParse(client.newCall(request).awaitSuccess(), chapterId, dataSaver)
+        return client.newCall(request).awaitSuccess().use { response ->
+            pageListParse(response, chapterId, dataSaver)
+        }
     }
 
     private fun pageListParse(response: Response, chapterId: String, dataSaver: Boolean): List<Page> {

--- a/app/src/main/java/exh/md/network/MangaDexLoginHelper.kt
+++ b/app/src/main/java/exh/md/network/MangaDexLoginHelper.kt
@@ -77,6 +77,7 @@ class MangaDexLoginHelper(
                     body = formBody,
                 ),
             ).awaitSuccess()
+                .close()
             mdList.logout()
         }.exceptionOrNull()
 

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
@@ -83,7 +83,7 @@ private suspend fun Call.await(callStack: Array<StackTraceElement>): Response {
                 }
 
                 override fun onFailure(call: Call, e: IOException) {
-                    // Don't bother with resuming the continuation if it is already cancelled.
+                    // Don't bother with resuming the continuation if it is already canceled.
                     if (continuation.isCancelled) return
                     val exception = IOException(e.message, e).apply { stackTrace = callStack }
                     continuation.resumeWithException(exception)
@@ -95,7 +95,7 @@ private suspend fun Call.await(callStack: Array<StackTraceElement>): Response {
         continuation.invokeOnCancellation {
             try {
                 cancel()
-            } catch (ex: Throwable) {
+            } catch (_: Throwable) {
                 // Ignore cancel exception
             }
         }
@@ -135,7 +135,7 @@ fun OkHttpClient.newCachelessCallWithProgress(request: Request, listener: Progre
 }
 
 context(_: Json)
-inline fun <reified T> Response.parseAs(): T {
+inline fun <reified T> Response.parseAs(): T = use {
     return decodeFromJsonResponse(serializer(), this)
 }
 

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -163,7 +163,7 @@ abstract class HttpSource : CatalogueSource {
         return client.newCall(popularMangaRequest(page))
             .asObservableSuccess()
             .map { response ->
-                popularMangaParse(response)
+                response.use { popularMangaParse(it) }
             }
     }
 
@@ -219,7 +219,7 @@ abstract class HttpSource : CatalogueSource {
             }
         }
             .map { response ->
-                searchMangaParse(response)
+                response.use { searchMangaParse(it) }
             }
     }
 
@@ -266,7 +266,7 @@ abstract class HttpSource : CatalogueSource {
         return client.newCall(latestUpdatesRequest(page))
             .asObservableSuccess()
             .map { response ->
-                latestUpdatesParse(response)
+                response.use { latestUpdatesParse(it) }
             }
     }
 
@@ -310,7 +310,7 @@ abstract class HttpSource : CatalogueSource {
         return client.newCall(mangaDetailsRequest(manga))
             .asObservableSuccess()
             .map { response ->
-                mangaDetailsParse(response).apply { initialized = true }
+                response.use { mangaDetailsParse(it).apply { initialized = true } }
             }
     }
 
@@ -355,7 +355,7 @@ abstract class HttpSource : CatalogueSource {
         async {
             client.newCall(relatedMangaListRequest(manga))
                 .execute()
-                .let { response ->
+                .use { response ->
                     relatedMangaListParse(response)
                 }
         }.await()
@@ -405,7 +405,7 @@ abstract class HttpSource : CatalogueSource {
         return client.newCall(chapterListRequest(manga))
             .asObservableSuccess()
             .map { response ->
-                chapterListParse(response)
+                response.use { chapterListParse(it) }
             }
     }
 
@@ -458,7 +458,7 @@ abstract class HttpSource : CatalogueSource {
         return client.newCall(pageListRequest(chapter))
             .asObservableSuccess()
             .map { response ->
-                pageListParse(response)
+                response.use { pageListParse(it) }
             }
     }
 
@@ -503,7 +503,9 @@ abstract class HttpSource : CatalogueSource {
     open fun fetchImageUrl(page: Page): Observable<String> {
         return client.newCall(imageUrlRequest(page))
             .asObservableSuccess()
-            .map { imageUrlParse(it) }
+            .map { response ->
+                response.use { imageUrlParse(it) }
+            }
     }
 
     /**


### PR DESCRIPTION
Ensure proper resource management in HttpSource by utilizing `response.use` for parsing responses. This change enhances the handling of HTTP responses and prevents potential resource leaks. Code has been tested and reviewed for functionality across all relevant themes and tablet modes.

## Summary by Sourcery

Ensure HttpSource closes HTTP responses safely when parsing data from network calls.

Bug Fixes:
- Prevent potential resource leaks in HttpSource by always closing HTTP responses during parsing.

Enhancements:
- Standardize HttpSource response parsing to use scoped response handling across all fetch methods.