### PR TITLE
feat: Add Library Duplicates Screen

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -72,6 +72,7 @@ import tachiyomi.domain.history.interactor.RemoveHistory
 import tachiyomi.domain.history.interactor.UpsertHistory
 import tachiyomi.domain.history.repository.HistoryRepository
 import tachiyomi.domain.manga.interactor.FetchInterval
+import tachiyomi.domain.manga.interactor.GetAllDuplicateLibraryManga
 import tachiyomi.domain.manga.interactor.GetDuplicateLibraryManga
 import tachiyomi.domain.manga.interactor.GetFavorites
 import tachiyomi.domain.manga.interactor.GetLibraryManga
@@ -121,6 +122,7 @@ class DomainModule : InjektModule {
 
         addSingletonFactory<MangaRepository> { MangaRepositoryImpl(get()) }
         addFactory { GetDuplicateLibraryManga(get()) }
+        addFactory { GetAllDuplicateLibraryManga(get()) }
         addFactory { GetFavorites(get()) }
         addFactory { GetLibraryManga(get()) }
         addFactory { GetMangaWithChapters(get(), get()) }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -116,6 +116,17 @@ object SettingsLibraryScreen : SearchableSettings {
                         true
                     },
                 ),
+                // KMK -->
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(KMR.strings.pref_duplicated_entries),
+                    subtitle = stringResource(KMR.strings.pref_duplicated_entries_summary),
+                    onClick = {
+                        navigator.push(
+                            eu.kanade.tachiyomi.ui.library.LibraryDuplicatesScreen(),
+                        )
+                    },
+                ),
+                // KMK <--
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDuplicatesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDuplicatesScreen.kt
@@ -1,0 +1,285 @@
+package eu.kanade.tachiyomi.ui.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.outlined.CompareArrows
+import androidx.compose.material.icons.outlined.Merge
+import androidx.compose.material.icons.outlined.OpenInNew
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.manga.components.MangaCover
+import eu.kanade.tachiyomi.ui.manga.MangaScreen
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class LibraryDuplicatesScreen : Screen {
+
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+        val screenModel = rememberScreenModel { LibraryDuplicatesScreenModel() }
+        val state by screenModel.state.collectAsState()
+        val sourceManager = remember { Injekt.get<SourceManager>() }
+
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text(text = stringResource(KMR.strings.pref_duplicated_entries)) },
+                    navigationIcon = {
+                        IconButton(onClick = { navigator.pop() }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                )
+            },
+        ) { paddingValues ->
+            when (val currentState = state) {
+                is LibraryDuplicatesScreenModel.State.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(paddingValues),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                is LibraryDuplicatesScreenModel.State.Empty -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(paddingValues),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(KMR.strings.label_no_duplicates),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+
+                is LibraryDuplicatesScreenModel.State.Error -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(paddingValues),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(
+                                imageVector = Icons.Filled.Warning,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(48.dp),
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                text = currentState.error.message ?: "Unknown error",
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            TextButton(onClick = { screenModel.loadDuplicates() }) {
+                                Text(text = stringResource(MR.strings.action_retry))
+                            }
+                        }
+                    }
+                }
+
+                is LibraryDuplicatesScreenModel.State.Success -> {
+                    val sortedGroups = remember(currentState.duplicateGroups) {
+                        currentState.duplicateGroups.entries
+                            .sortedBy { it.key }
+                    }
+
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(paddingValues),
+                        contentPadding = PaddingValues(
+                            bottom = MaterialTheme.padding.medium,
+                        ),
+                    ) {
+                        sortedGroups.forEach { (_, mangaList) ->
+                            // Group header — use the first manga's actual title
+                            item(key = "header_${mangaList.first().id}") {
+                                DuplicateGroupHeader(
+                                    title = mangaList.first().title,
+                                    count = mangaList.size,
+                                )
+                            }
+                            // Items in this group
+                            items(
+                                items = mangaList,
+                                key = { it.id },
+                            ) { manga ->
+                                DuplicateMangaItem(
+                                    manga = manga,
+                                    sourceName = sourceManager.getOrStub(manga.source).name,
+                                    onOpenClick = {
+                                        navigator.push(MangaScreen(manga.id))
+                                    },
+                                )
+                            }
+                            // Divider between groups
+                            item(key = "divider_${mangaList.first().id}") {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(
+                                        horizontal = MaterialTheme.padding.medium,
+                                        vertical = MaterialTheme.padding.small,
+                                    ),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DuplicateGroupHeader(
+    title: String,
+    count: Int,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+            .padding(
+                horizontal = MaterialTheme.padding.medium,
+                vertical = MaterialTheme.padding.small,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "$count",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.primaryContainer)
+                .padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+@Composable
+private fun DuplicateMangaItem(
+    manga: Manga,
+    sourceName: String,
+    onOpenClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onOpenClick)
+            .padding(
+                horizontal = MaterialTheme.padding.medium,
+                vertical = MaterialTheme.padding.small,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        MangaCover.Square(
+            modifier = Modifier.size(56.dp),
+            data = manga,
+        )
+
+        Spacer(modifier = Modifier.width(MaterialTheme.padding.medium))
+
+        Column(
+            modifier = Modifier.weight(1f),
+        ) {
+            Text(
+                text = manga.title,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (!manga.author.isNullOrBlank()) {
+                Text(
+                    text = manga.author!!,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Text(
+                text = sourceName,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        IconButton(onClick = onOpenClick) {
+            Icon(
+                imageVector = Icons.Outlined.OpenInNew,
+                contentDescription = stringResource(MR.strings.action_open_in_browser),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDuplicatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDuplicatesScreenModel.kt
@@ -1,0 +1,44 @@
+package eu.kanade.tachiyomi.ui.library
+
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import tachiyomi.domain.manga.interactor.GetAllDuplicateLibraryManga
+import tachiyomi.domain.manga.model.Manga
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class LibraryDuplicatesScreenModel(
+    private val getAllDuplicateLibraryManga: GetAllDuplicateLibraryManga = Injekt.get(),
+) : StateScreenModel<LibraryDuplicatesScreenModel.State>(State.Loading) {
+
+    init {
+        loadDuplicates()
+    }
+
+    fun loadDuplicates() {
+        screenModelScope.launch {
+            mutableState.update { State.Loading }
+            try {
+                val duplicates = getAllDuplicateLibraryManga()
+                mutableState.update {
+                    if (duplicates.isEmpty()) {
+                        State.Empty
+                    } else {
+                        State.Success(duplicates)
+                    }
+                }
+            } catch (e: Exception) {
+                mutableState.update { State.Error(e) }
+            }
+        }
+    }
+
+    sealed interface State {
+        data object Loading : State
+        data object Empty : State
+        data class Success(val duplicateGroups: Map<String, List<Manga>>) : State
+        data class Error(val error: Throwable) : State
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetAllDuplicateLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetAllDuplicateLibraryManga.kt
@@ -1,0 +1,117 @@
+package tachiyomi.domain.manga.interactor
+
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.repository.MangaRepository
+
+class GetAllDuplicateLibraryManga(
+    private val mangaRepository: MangaRepository,
+) {
+
+    /**
+     * Returns all library manga grouped by normalized title or extracted alternate names,
+     * filtering to only groups with 2+ entries (duplicates).
+     */
+    suspend operator fun invoke(): Map<String, List<Manga>> {
+        val libraryManga = mangaRepository.getFavorites()
+
+        // Data class to hold normalized properties for faster comparison
+        data class NormalizedManga(
+            val manga: Manga,
+            val title: String = manga.title.normalizeForDuplicateCheck(),
+            val altTitles: List<String> = getAltTitles(manga.description)
+        )
+
+        val normalizedList = libraryManga.map { NormalizedManga(it) }
+        val disjointSet = IntArray(normalizedList.size) { it }
+
+        fun find(i: Int): Int {
+            if (disjointSet[i] == i) return i
+            disjointSet[i] = find(disjointSet[i])
+            return disjointSet[i]
+        }
+
+        fun union(i: Int, j: Int) {
+            val rootI = find(i)
+            val rootJ = find(j)
+            if (rootI != rootJ) {
+                disjointSet[rootI] = rootJ
+            }
+        }
+
+        // Compare all pairs to find duplicates
+        for (i in normalizedList.indices) {
+            for (j in i + 1 until normalizedList.size) {
+                val m1 = normalizedList[i]
+                val m2 = normalizedList[j]
+
+                val isDuplicate = when {
+                    // Exact normalized title match
+                    m1.title == m2.title -> true
+
+                    // Check if m1 title is in m2's alternate titles
+                    m2.altTitles.any { it == m1.title } -> true
+
+                    // Check if m2 title is in m1's alternate titles
+                    m1.altTitles.any { it == m2.title } -> true
+
+                    // Check if they share any alternate titles
+                    m1.altTitles.intersect(m2.altTitles.toSet()).isNotEmpty() -> true
+
+                    else -> false
+                }
+
+                if (isDuplicate) {
+                    union(i, j)
+                }
+            }
+        }
+
+        // Group by root of disjoint set
+        return normalizedList.withIndex()
+            .groupBy { find(it.index) }
+            .filter { it.value.size > 1 }
+            // Map the root index to the title of the first item in the cluster for the UI
+            .mapKeys { entry -> entry.value.first().value.manga.title }
+            .mapValues { entry -> entry.value.map { it.value.manga } }
+    }
+
+    private companion object {
+        /**
+         * Extracts alternate titles from the manga description if available.
+         * Common patterns: "Alternative Titles: ...", "Alt names: ...", "Alternative: ..."
+         */
+        private fun getAltTitles(description: String?): List<String> {
+            if (description.isNullOrBlank()) return emptyList()
+
+            val lines = description.lines()
+            val altTitles = mutableListOf<String>()
+
+            for (line in lines) {
+                val lowerLine = line.lowercase()
+                if (lowerLine.startsWith("alternative:") ||
+                    lowerLine.startsWith("alternative titles:") ||
+                    lowerLine.startsWith("alt name(s):") ||
+                    lowerLine.startsWith("alt names:") ||
+                    lowerLine.startsWith("other names:")
+                ) {
+                    // Extract the part after the colon
+                    val content = line.substringAfter(":").trim()
+                    // Usually separated by comma, semicolon, or slash
+                    val titles = content.split(Regex("[,;/|]+"))
+                    altTitles.addAll(titles.map { it.normalizeForDuplicateCheck() }.filter { it.isNotBlank() })
+                }
+            }
+            return altTitles
+        }
+    }
+}
+
+/**
+ * Normalizes a string for duplicate comparison.
+ * Strips non-alphanumeric characters, collapses whitespace, and lowercases.
+ */
+fun String.normalizeForDuplicateCheck(): String =
+    this.lowercase()
+        .replace(Regex("[^\\p{L}\\p{N}\\s]"), " ")
+        .replace(Regex("\\s+"), " ")
+        .trim()

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -98,6 +98,11 @@
     <string name="pref_show_empty_categories_search">Show empty categories during search/filtering</string>
     <string name="pref_sync_manga_on_add">Sync manga when adding to library</string>
     <string name="pref_sync_manga_on_add_description">Automatically fetches the metadata and chapter list of a new manga when adding it to the library</string>
+    <!-- Library Duplicates -->
+    <string name="pref_duplicated_entries">Duplicated entries</string>
+    <string name="pref_duplicated_entries_summary">Show all duplicated entries in your library</string>
+    <string name="label_no_duplicates">No duplicate entries found</string>
+
     <!-- Extension section -->
     <string name="extensions_page_need_refresh">Refresh extension page to update list.</string>
     <string name="extensions_page_more">More extensions...</string>


### PR DESCRIPTION
## Description
Resolves #1517

This PR introduces a dedicated 'Library Duplicates' screen to help users find and manage duplicate manga entries in their library.

### Key additions:
- **UI:** Added 'LibraryDuplicatesScreen' and its corresponding ScreenModel. Exposes this screen via a new preference item in 'SettingsLibraryScreen' under the Categories group.
- **Domain Logic:** Implemented 'GetAllDuplicateLibraryManga' to group library entries by normalized title.

## Checklists
- [x] Compilation succeeds.
- [x] Code style follows standard Android/Kotlin guidelines.
- [x] 'strings.xml' updated for multi-language support.