### PR TITLE
Fix nullability issues in track creation for MangaDex

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1851,7 +1851,7 @@ class MangaScreenModel(
                             }
                             // KMK: auto track MangaDex
                             mdTrack.id !in tracks.map { it.trackerId } -> {
-                                tracks + createMdListTrack()
+                                (tracks + createMdListTrack()).filterNotNull()
                             }
                             else -> tracks
                         }
@@ -1880,13 +1880,14 @@ class MangaScreenModel(
     }
 
     // SY -->
-    private suspend fun createMdListTrack(): Track {
+    private suspend fun createMdListTrack(): Track? {
         val state = successState!!
         val mdManga = state.manga.takeIf { it.source in mangaDexSourceIds }
             ?: state.mergedData?.manga?.values?.find { it.source in mangaDexSourceIds }
             ?: throw IllegalArgumentException("Could not create initial track")
         val track = trackerManager.mdList.createInitialTracker(state.manga, mdManga)
-            .toDomainTrack(false)!!
+            .toDomainTrack(false)
+            ?: return null
         insertTrack.await(track)
         /* KMK -->
         return TrackItem(
@@ -1894,7 +1895,7 @@ class MangaScreenModel(
              trackerManager.mdList,
          )
         KMK <-- */
-        return getTracks.await(mangaId).first { it.trackerId == trackerManager.mdList.id }
+        return getTracks.await(mangaId).firstOrNull { it.trackerId == trackerManager.mdList.id }
     }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1884,7 +1884,7 @@ class MangaScreenModel(
         val state = successState!!
         val mdManga = state.manga.takeIf { it.source in mangaDexSourceIds }
             ?: state.mergedData?.manga?.values?.find { it.source in mangaDexSourceIds }
-            ?: throw IllegalArgumentException("Could not create initial track")
+            ?: return null
         val track = trackerManager.mdList.createInitialTracker(state.manga, mdManga)
             .toDomainTrack(false)
             ?: return null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -75,6 +75,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import exh.debug.DebugToggles
 import exh.eh.EHentaiUpdateHelper
 import exh.log.xLogD
+import exh.log.xLogE
 import exh.md.utils.FollowStatus
 import exh.metadata.metadata.RaisedSearchMetadata
 import exh.metadata.metadata.base.FlatMetadata
@@ -1881,21 +1882,27 @@ class MangaScreenModel(
 
     // SY -->
     private suspend fun createMdListTrack(): Track? {
-        val state = successState!!
-        val mdManga = state.manga.takeIf { it.source in mangaDexSourceIds }
-            ?: state.mergedData?.manga?.values?.find { it.source in mangaDexSourceIds }
-            ?: return null
-        val track = trackerManager.mdList.createInitialTracker(state.manga, mdManga)
-            .toDomainTrack(false)
-            ?: return null
-        insertTrack.await(track)
-        /* KMK -->
-        return TrackItem(
-            getTracks.await(mangaId).first { it.trackerId == trackerManager.mdList.id },
-             trackerManager.mdList,
-         )
-        KMK <-- */
-        return getTracks.await(mangaId).firstOrNull { it.trackerId == trackerManager.mdList.id }
+        try {
+            val state = successState!!
+            val mdManga = state.manga.takeIf { it.source in mangaDexSourceIds }
+                ?: state.mergedData?.manga?.values?.find { it.source in mangaDexSourceIds }
+                ?: throw IllegalArgumentException("Entry does not belong to MangaDex")
+            val track = trackerManager.mdList.createInitialTracker(state.manga, mdManga)
+                .toDomainTrack(false)
+                ?: throw IllegalStateException("Could not create initial track")
+            insertTrack.await(track)
+            /* KMK -->
+            return TrackItem(
+                getTracks.await(mangaId).first { it.trackerId == trackerManager.mdList.id },
+                 trackerManager.mdList,
+             )
+            KMK <-- */
+            return getTracks.await(mangaId).firstOrNull { it.trackerId == trackerManager.mdList.id }
+                ?: throw IllegalStateException("Could not get MangaDex track for current entry")
+        } catch (e: Exception) {
+            xLogE("Failed to create MangaDex track", e)
+            return null
+        }
     }
     // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1852,7 +1852,7 @@ class MangaScreenModel(
                             }
                             // KMK: auto track MangaDex
                             mdTrack.id !in tracks.map { it.trackerId } -> {
-                                (tracks + createMdListTrack()).filterNotNull()
+                                createMdListTrack()?.let { tracks + it } ?: tracks
                             }
                             else -> tracks
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1897,8 +1897,7 @@ class MangaScreenModel(
                  trackerManager.mdList,
              )
             KMK <-- */
-            return getTracks.await(mangaId).firstOrNull { it.trackerId == trackerManager.mdList.id }
-                ?: throw IllegalStateException("Could not get MangaDex track for current entry")
+            return getTracks.await(mangaId).first { it.trackerId == trackerManager.mdList.id }
         } catch (e: Exception) {
             xLogE("Failed to create MangaDex track", e)
             return null


### PR DESCRIPTION
Improve error handling in the `createMdListTrack` function by returning null instead of throwing exceptions when encountering nullability issues.

## Summary by Sourcery

Handle MangaDex track creation failures gracefully and avoid propagating nullability errors.

Bug Fixes:
- Prevent crashes when automatically creating MangaDex tracking entries by returning null instead of throwing on nullability issues.

Enhancements:
- Log failures during MangaDex track creation to aid in diagnosing tracking issues.