### PR TITLE
Add tracker Not in Library tab for MAL and AniList

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/interactor/AddTracks.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/AddTracks.kt
@@ -35,6 +35,7 @@ class AddTracks(
     // TODO: update all trackers based on common data
     suspend fun bind(tracker: Tracker, item: Track, mangaId: Long) = withNonCancellableContext {
         withIOContext {
+            item.manga_id = mangaId
             val allChapters = getChaptersByMangaId.await(mangaId)
             val hasReadChapters = allChapters.any { it.read }
             tracker.bind(item, hasReadChapters)

--- a/app/src/main/java/eu/kanade/domain/track/interactor/BindTrackSearchToManga.kt
+++ b/app/src/main/java/eu/kanade/domain/track/interactor/BindTrackSearchToManga.kt
@@ -1,0 +1,20 @@
+package eu.kanade.domain.track.interactor
+
+import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
+
+suspend fun bindTrackSearchToManga(
+    trackSearch: TrackSearch,
+    mangaId: Long,
+    trackerManager: TrackerManager,
+    addTracks: AddTracks,
+): Boolean {
+    val tracker = trackerManager.get(trackSearch.tracker_id) ?: return false
+
+    return try {
+        addTracks.bind(tracker, trackSearch, mangaId)
+        true
+    } catch (e: Exception) {
+        false
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
@@ -45,6 +45,11 @@ class TrackPreferences(
         AutoTrackState.ALWAYS,
     )
 
+    fun showNotInLibraryTrackerEntries() = preferenceStore.getBoolean(
+        "pref_show_not_in_library_tracker_entries",
+        false,
+    )
+
     // SY -->
     fun resolveUsingSourceMetadata() = preferenceStore.getBoolean(
         "pref_resolve_using_source_metadata_key",

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryBadges.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryBadges.kt
@@ -114,6 +114,39 @@ fun SourceIconBadge(
 }
 // KMK <--
 
+@Composable
+internal fun TrackerLabelBadge(label: String) {
+    if (label.isNotBlank()) {
+        Badge(
+            text = label,
+            color = MaterialTheme.colorScheme.secondaryContainer,
+            textColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+@Composable
+internal fun TrackerStatusBadge(label: String?) {
+    if (!label.isNullOrBlank()) {
+        Badge(
+            text = label,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            textColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        )
+    }
+}
+
+@Composable
+internal fun TrackerProgressBadge(progress: String?) {
+    if (!progress.isNullOrBlank()) {
+        Badge(
+            text = progress,
+            color = MaterialTheme.colorScheme.tertiary,
+            textColor = MaterialTheme.colorScheme.onTertiary,
+        )
+    }
+}
+
 @PreviewLightDark
 @Composable
 private fun BadgePreview() {

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryComfortableGrid.kt
@@ -5,17 +5,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import eu.kanade.tachiyomi.ui.library.LibraryItem
+import eu.kanade.tachiyomi.ui.library.LibraryDisplayItem
+import eu.kanade.tachiyomi.ui.library.RemoteTrackerLibraryItem
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.model.MangaCover
 
 @Composable
 internal fun LibraryComfortableGrid(
-    items: List<LibraryItem>,
+    items: List<LibraryDisplayItem>,
     columns: Int,
     contentPadding: PaddingValues,
     selection: Set<Long>,
     onClick: (LibraryManga) -> Unit,
+    onClickRemoteTrack: (RemoteTrackerLibraryItem) -> Unit,
     onLongClick: (LibraryManga) -> Unit,
     onClickContinueReading: ((LibraryManga) -> Unit)?,
     searchQuery: String?,
@@ -33,46 +35,69 @@ internal fun LibraryComfortableGrid(
 
         items(
             items = items,
-            contentType = { "library_comfortable_grid_item" },
-        ) { libraryItem ->
-            val manga = libraryItem.libraryManga.manga
-            MangaComfortableGridItem(
-                isSelected = manga.id in selection,
-                title = manga.title,
-                coverData = MangaCover(
-                    mangaId = manga.id,
-                    sourceId = manga.source,
-                    isMangaFavorite = manga.favorite,
-                    ogUrl = manga.thumbnailUrl,
-                    lastModified = manga.coverLastModified,
-                ),
-                coverBadgeStart = {
-                    DownloadsBadge(count = libraryItem.downloadCount)
-                    UnreadBadge(count = libraryItem.unreadCount)
-                },
-                coverBadgeEnd = {
-                    LanguageBadge(
-                        isLocal = libraryItem.isLocal,
-                        sourceLanguage = libraryItem.sourceLanguage,
-                        // KMK -->
-                        useLangIcon = libraryItem.useLangIcon,
-                        // KMK <--
+            key = { it.key },
+            contentType = {
+                when (it) {
+                    is LibraryDisplayItem.Local -> "library_comfortable_grid_item"
+                    is LibraryDisplayItem.RemoteTrack -> "remote_tracker_comfortable_grid_item"
+                }
+            },
+        ) { item ->
+            when (item) {
+                is LibraryDisplayItem.Local -> {
+                    val libraryItem = item.item
+                    val manga = libraryItem.libraryManga.manga
+                    MangaComfortableGridItem(
+                        isSelected = manga.id in selection,
+                        title = manga.title,
+                        coverData = MangaCover(
+                            mangaId = manga.id,
+                            sourceId = manga.source,
+                            isMangaFavorite = manga.favorite,
+                            ogUrl = manga.thumbnailUrl,
+                            lastModified = manga.coverLastModified,
+                        ),
+                        coverBadgeStart = {
+                            DownloadsBadge(count = libraryItem.downloadCount)
+                            UnreadBadge(count = libraryItem.unreadCount)
+                        },
+                        coverBadgeEnd = {
+                            LanguageBadge(
+                                isLocal = libraryItem.isLocal,
+                                sourceLanguage = libraryItem.sourceLanguage,
+                                useLangIcon = libraryItem.useLangIcon,
+                            )
+                            SourceIconBadge(source = libraryItem.source)
+                        },
+                        onLongClick = { onLongClick(libraryItem.libraryManga) },
+                        onClick = { onClick(libraryItem.libraryManga) },
+                        onClickContinueReading = if (onClickContinueReading != null && libraryItem.unreadCount > 0) {
+                            { onClickContinueReading(libraryItem.libraryManga) }
+                        } else {
+                            null
+                        },
+                        usePanoramaCover = usePanoramaCover,
                     )
-                    // KMK -->
-                    SourceIconBadge(source = libraryItem.source)
-                    // KMK <--
-                },
-                onLongClick = { onLongClick(libraryItem.libraryManga) },
-                onClick = { onClick(libraryItem.libraryManga) },
-                onClickContinueReading = if (onClickContinueReading != null && libraryItem.unreadCount > 0) {
-                    { onClickContinueReading(libraryItem.libraryManga) }
-                } else {
-                    null
-                },
-                // KMK -->
-                usePanoramaCover = usePanoramaCover,
-                // KMK <--
-            )
+                }
+                is LibraryDisplayItem.RemoteTrack -> {
+                    val remoteItem = item.item
+                    MangaComfortableGridItem(
+                        title = remoteItem.track.title,
+                        coverData = remoteItem.coverData,
+                        coverBadgeStart = {
+                            TrackerStatusBadge(remoteItem.statusText)
+                            TrackerProgressBadge(remoteItem.progressText)
+                        },
+                        coverBadgeEnd = {
+                            TrackerLabelBadge(remoteItem.trackerShortName)
+                        },
+                        onLongClick = {},
+                        onClick = { onClickRemoteTrack(remoteItem) },
+                        libraryColored = false,
+                        usePanoramaCover = usePanoramaCover,
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryCompactGrid.kt
@@ -5,18 +5,20 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import eu.kanade.tachiyomi.ui.library.LibraryItem
+import eu.kanade.tachiyomi.ui.library.LibraryDisplayItem
+import eu.kanade.tachiyomi.ui.library.RemoteTrackerLibraryItem
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.model.MangaCover
 
 @Composable
 internal fun LibraryCompactGrid(
-    items: List<LibraryItem>,
+    items: List<LibraryDisplayItem>,
     showTitle: Boolean,
     columns: Int,
     contentPadding: PaddingValues,
     selection: Set<Long>,
     onClick: (LibraryManga) -> Unit,
+    onClickRemoteTrack: (RemoteTrackerLibraryItem) -> Unit,
     onLongClick: (LibraryManga) -> Unit,
     onClickContinueReading: ((LibraryManga) -> Unit)?,
     searchQuery: String?,
@@ -31,43 +33,67 @@ internal fun LibraryCompactGrid(
 
         items(
             items = items,
-            contentType = { "library_compact_grid_item" },
-        ) { libraryItem ->
-            val manga = libraryItem.libraryManga.manga
-            MangaCompactGridItem(
-                isSelected = manga.id in selection,
-                title = manga.title.takeIf { showTitle },
-                coverData = MangaCover(
-                    mangaId = manga.id,
-                    sourceId = manga.source,
-                    isMangaFavorite = manga.favorite,
-                    ogUrl = manga.thumbnailUrl,
-                    lastModified = manga.coverLastModified,
-                ),
-                coverBadgeStart = {
-                    DownloadsBadge(count = libraryItem.downloadCount)
-                    UnreadBadge(count = libraryItem.unreadCount)
-                },
-                coverBadgeEnd = {
-                    LanguageBadge(
-                        isLocal = libraryItem.isLocal,
-                        sourceLanguage = libraryItem.sourceLanguage,
-                        // KMK -->
-                        useLangIcon = libraryItem.useLangIcon,
-                        // KMK <--
+            key = { it.key },
+            contentType = {
+                when (it) {
+                    is LibraryDisplayItem.Local -> "library_compact_grid_item"
+                    is LibraryDisplayItem.RemoteTrack -> "remote_tracker_compact_grid_item"
+                }
+            },
+        ) { item ->
+            when (item) {
+                is LibraryDisplayItem.Local -> {
+                    val libraryItem = item.item
+                    val manga = libraryItem.libraryManga.manga
+                    MangaCompactGridItem(
+                        isSelected = manga.id in selection,
+                        title = manga.title.takeIf { showTitle },
+                        coverData = MangaCover(
+                            mangaId = manga.id,
+                            sourceId = manga.source,
+                            isMangaFavorite = manga.favorite,
+                            ogUrl = manga.thumbnailUrl,
+                            lastModified = manga.coverLastModified,
+                        ),
+                        coverBadgeStart = {
+                            DownloadsBadge(count = libraryItem.downloadCount)
+                            UnreadBadge(count = libraryItem.unreadCount)
+                        },
+                        coverBadgeEnd = {
+                            LanguageBadge(
+                                isLocal = libraryItem.isLocal,
+                                sourceLanguage = libraryItem.sourceLanguage,
+                                useLangIcon = libraryItem.useLangIcon,
+                            )
+                            SourceIconBadge(source = libraryItem.source)
+                        },
+                        onLongClick = { onLongClick(libraryItem.libraryManga) },
+                        onClick = { onClick(libraryItem.libraryManga) },
+                        onClickContinueReading = if (onClickContinueReading != null && libraryItem.unreadCount > 0) {
+                            { onClickContinueReading(libraryItem.libraryManga) }
+                        } else {
+                            null
+                        },
                     )
-                    // KMK -->
-                    SourceIconBadge(source = libraryItem.source)
-                    // KMK <--
-                },
-                onLongClick = { onLongClick(libraryItem.libraryManga) },
-                onClick = { onClick(libraryItem.libraryManga) },
-                onClickContinueReading = if (onClickContinueReading != null && libraryItem.unreadCount > 0) {
-                    { onClickContinueReading(libraryItem.libraryManga) }
-                } else {
-                    null
-                },
-            )
+                }
+                is LibraryDisplayItem.RemoteTrack -> {
+                    val remoteItem = item.item
+                    MangaCompactGridItem(
+                        title = remoteItem.track.title.takeIf { showTitle },
+                        coverData = remoteItem.coverData,
+                        coverBadgeStart = {
+                            TrackerStatusBadge(remoteItem.statusText)
+                            TrackerProgressBadge(remoteItem.progressText)
+                        },
+                        coverBadgeEnd = {
+                            TrackerLabelBadge(remoteItem.trackerShortName)
+                        },
+                        onLongClick = {},
+                        onClick = { onClickRemoteTrack(remoteItem) },
+                        libraryColored = false,
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import eu.kanade.core.preference.PreferenceMutableState
 import eu.kanade.tachiyomi.ui.library.LibraryItem
+import eu.kanade.tachiyomi.ui.library.LibraryDisplayItem
+import eu.kanade.tachiyomi.ui.library.RemoteTrackerLibraryItem
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import tachiyomi.domain.category.model.Category
@@ -39,6 +41,7 @@ fun LibraryContent(
     showPageTabs: Boolean,
     onChangeCurrentPage: (Int) -> Unit,
     onClickManga: (Long) -> Unit,
+    onClickRemoteTrack: (RemoteTrackerLibraryItem) -> Unit,
     onContinueReadingClicked: ((LibraryManga) -> Unit)?,
     onToggleSelection: (Category, LibraryManga) -> Unit,
     onToggleRangeSelection: (Category, LibraryManga) -> Unit,
@@ -47,7 +50,7 @@ fun LibraryContent(
     getItemCountForCategory: (Category) -> Int?,
     getDisplayMode: (Int) -> PreferenceMutableState<LibraryDisplayMode>,
     getColumnsForOrientation: (Boolean) -> PreferenceMutableState<Int>,
-    getItemsForCategory: (Category) -> List<LibraryItem>,
+    getDisplayItemsForCategory: (Category) -> List<LibraryDisplayItem>,
 ) {
     Column(
         modifier = Modifier.padding(
@@ -111,12 +114,17 @@ fun LibraryContent(
                 getCategoryForPage = { page -> categories[page] },
                 getDisplayMode = getDisplayMode,
                 getColumnsForOrientation = getColumnsForOrientation,
-                getItemsForCategory = getItemsForCategory,
+                getDisplayItemsForCategory = getDisplayItemsForCategory,
                 onClickManga = { category, manga ->
                     if (selection.isNotEmpty()) {
                         onToggleSelection(category, manga)
                     } else {
                         onClickManga(manga.manga.id)
+                    }
+                },
+                onClickRemoteTrack = { item ->
+                    if (selection.isEmpty()) {
+                        onClickRemoteTrack(item)
                     }
                 },
                 onLongClickManga = onToggleRangeSelection,

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryList.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryList.kt
@@ -7,7 +7,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import eu.kanade.tachiyomi.ui.library.LibraryItem
+import eu.kanade.tachiyomi.ui.library.LibraryDisplayItem
+import eu.kanade.tachiyomi.ui.library.RemoteTrackerLibraryItem
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.model.MangaCover
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
@@ -15,10 +16,11 @@ import tachiyomi.presentation.core.util.plus
 
 @Composable
 internal fun LibraryList(
-    items: List<LibraryItem>,
+    items: List<LibraryDisplayItem>,
     contentPadding: PaddingValues,
     selection: Set<Long>,
     onClick: (LibraryManga) -> Unit,
+    onClickRemoteTrack: (RemoteTrackerLibraryItem) -> Unit,
     onLongClick: (LibraryManga) -> Unit,
     onClickContinueReading: ((LibraryManga) -> Unit)?,
     searchQuery: String?,
@@ -40,41 +42,63 @@ internal fun LibraryList(
 
         items(
             items = items,
-            contentType = { "library_list_item" },
-        ) { libraryItem ->
-            val manga = libraryItem.libraryManga.manga
-            MangaListItem(
-                isSelected = manga.id in selection,
-                title = manga.title,
-                coverData = MangaCover(
-                    mangaId = manga.id,
-                    sourceId = manga.source,
-                    isMangaFavorite = manga.favorite,
-                    ogUrl = manga.thumbnailUrl,
-                    lastModified = manga.coverLastModified,
-                ),
-                badge = {
-                    DownloadsBadge(count = libraryItem.downloadCount)
-                    UnreadBadge(count = libraryItem.unreadCount)
-                    LanguageBadge(
-                        isLocal = libraryItem.isLocal,
-                        sourceLanguage = libraryItem.sourceLanguage,
-                        // KMK -->
-                        useLangIcon = libraryItem.useLangIcon,
-                        // KMK <--
+            key = { it.key },
+            contentType = {
+                when (it) {
+                    is LibraryDisplayItem.Local -> "library_list_item"
+                    is LibraryDisplayItem.RemoteTrack -> "remote_tracker_list_item"
+                }
+            },
+        ) { item ->
+            when (item) {
+                is LibraryDisplayItem.Local -> {
+                    val libraryItem = item.item
+                    val manga = libraryItem.libraryManga.manga
+                    MangaListItem(
+                        isSelected = manga.id in selection,
+                        title = manga.title,
+                        coverData = MangaCover(
+                            mangaId = manga.id,
+                            sourceId = manga.source,
+                            isMangaFavorite = manga.favorite,
+                            ogUrl = manga.thumbnailUrl,
+                            lastModified = manga.coverLastModified,
+                        ),
+                        badge = {
+                            DownloadsBadge(count = libraryItem.downloadCount)
+                            UnreadBadge(count = libraryItem.unreadCount)
+                            LanguageBadge(
+                                isLocal = libraryItem.isLocal,
+                                sourceLanguage = libraryItem.sourceLanguage,
+                                useLangIcon = libraryItem.useLangIcon,
+                            )
+                            SourceIconBadge(source = libraryItem.source)
+                        },
+                        onLongClick = { onLongClick(libraryItem.libraryManga) },
+                        onClick = { onClick(libraryItem.libraryManga) },
+                        onClickContinueReading = if (onClickContinueReading != null && libraryItem.unreadCount > 0) {
+                            { onClickContinueReading(libraryItem.libraryManga) }
+                        } else {
+                            null
+                        },
                     )
-                    // KMK -->
-                    SourceIconBadge(source = libraryItem.source)
-                    // KMK <--
-                },
-                onLongClick = { onLongClick(libraryItem.libraryManga) },
-                onClick = { onClick(libraryItem.libraryManga) },
-                onClickContinueReading = if (onClickContinueReading != null && libraryItem.unreadCount > 0) {
-                    { onClickContinueReading(libraryItem.libraryManga) }
-                } else {
-                    null
-                },
-            )
+                }
+                is LibraryDisplayItem.RemoteTrack -> {
+                    val remoteItem = item.item
+                    MangaListItem(
+                        title = remoteItem.track.title,
+                        coverData = remoteItem.coverData,
+                        badge = {
+                            TrackerLabelBadge(remoteItem.trackerShortName)
+                            TrackerStatusBadge(remoteItem.statusText)
+                            TrackerProgressBadge(remoteItem.progressText)
+                        },
+                        onLongClick = {},
+                        onClick = { onClickRemoteTrack(remoteItem) },
+                        libraryColored = false,
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryPager.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryPager.kt
@@ -82,15 +82,15 @@ fun LibraryPager(
 
         when (displayMode) {
             LibraryDisplayMode.List -> {
-            LibraryList(
-                items = items,
-                contentPadding = contentPadding,
-                selection = selection,
-                onClick = onClickManga,
-                onClickRemoteTrack = onClickRemoteTrack,
-                onLongClick = onLongClickManga,
-                onClickContinueReading = onClickContinueReading,
-                searchQuery = searchQuery,
+                LibraryList(
+                    items = items,
+                    contentPadding = contentPadding,
+                    selection = selection,
+                    onClick = onClickManga,
+                    onClickRemoteTrack = onClickRemoteTrack,
+                    onLongClick = onLongClickManga,
+                    onClickContinueReading = onClickContinueReading,
+                    searchQuery = searchQuery,
                     onGlobalSearchClicked = onGlobalSearchClicked,
                 )
             }

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryPager.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryPager.kt
@@ -19,7 +19,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import eu.kanade.core.preference.PreferenceMutableState
-import eu.kanade.tachiyomi.ui.library.LibraryItem
+import eu.kanade.tachiyomi.ui.library.LibraryDisplayItem
+import eu.kanade.tachiyomi.ui.library.RemoteTrackerLibraryItem
 import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.model.LibraryManga
@@ -38,8 +39,9 @@ fun LibraryPager(
     getCategoryForPage: (Int) -> Category,
     getDisplayMode: (Int) -> PreferenceMutableState<LibraryDisplayMode>,
     getColumnsForOrientation: (Boolean) -> PreferenceMutableState<Int>,
-    getItemsForCategory: (Category) -> List<LibraryItem>,
+    getDisplayItemsForCategory: (Category) -> List<LibraryDisplayItem>,
     onClickManga: (Category, LibraryManga) -> Unit,
+    onClickRemoteTrack: (RemoteTrackerLibraryItem) -> Unit,
     onLongClickManga: (Category, LibraryManga) -> Unit,
     onClickContinueReading: ((LibraryManga) -> Unit)?,
 ) {
@@ -53,7 +55,7 @@ fun LibraryPager(
             return@HorizontalPager
         }
         val category = getCategoryForPage(page)
-        val items = getItemsForCategory(category)
+        val items = getDisplayItemsForCategory(category)
 
         if (items.isEmpty()) {
             LibraryPagerEmptyScreen(
@@ -80,14 +82,15 @@ fun LibraryPager(
 
         when (displayMode) {
             LibraryDisplayMode.List -> {
-                LibraryList(
-                    items = items,
-                    contentPadding = contentPadding,
-                    selection = selection,
-                    onClick = onClickManga,
-                    onLongClick = onLongClickManga,
-                    onClickContinueReading = onClickContinueReading,
-                    searchQuery = searchQuery,
+            LibraryList(
+                items = items,
+                contentPadding = contentPadding,
+                selection = selection,
+                onClick = onClickManga,
+                onClickRemoteTrack = onClickRemoteTrack,
+                onLongClick = onLongClickManga,
+                onClickContinueReading = onClickContinueReading,
+                searchQuery = searchQuery,
                     onGlobalSearchClicked = onGlobalSearchClicked,
                 )
             }
@@ -99,6 +102,7 @@ fun LibraryPager(
                     contentPadding = contentPadding,
                     selection = selection,
                     onClick = onClickManga,
+                    onClickRemoteTrack = onClickRemoteTrack,
                     onLongClick = onLongClickManga,
                     onClickContinueReading = onClickContinueReading,
                     searchQuery = searchQuery,
@@ -112,6 +116,7 @@ fun LibraryPager(
                     contentPadding = contentPadding,
                     selection = selection,
                     onClick = onClickManga,
+                    onClickRemoteTrack = onClickRemoteTrack,
                     onLongClick = onLongClickManga,
                     onClickContinueReading = onClickContinueReading,
                     searchQuery = searchQuery,
@@ -126,6 +131,7 @@ fun LibraryPager(
                     contentPadding = contentPadding,
                     selection = selection,
                     onClick = onClickManga,
+                    onClickRemoteTrack = onClickRemoteTrack,
                     onLongClick = onLongClickManga,
                     onClickContinueReading = onClickContinueReading,
                     searchQuery = searchQuery,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
@@ -148,6 +148,7 @@ sealed class Preference {
             val tracker: Tracker,
             val login: () -> Unit,
             val logout: () -> Unit,
+            val supportLabel: String? = null,
         ) : PreferenceItem<String, Unit>() {
             override val title: String = ""
             override val enabled: Boolean = true

--- a/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
@@ -172,6 +172,7 @@ internal fun PreferenceItem(
                 TrackingPreferenceWidget(
                     tracker = item.tracker,
                     checked = isLoggedIn,
+                    supportLabel = item.supportLabel,
                     onClick = { if (isLoggedIn) item.logout() else item.login() },
                 )
             }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -149,6 +149,11 @@ object SettingsTrackingScreen : SearchableSettings {
                 preference = trackPreferences.autoSyncProgressFromTrackers(),
                 title = stringResource(KMR.strings.pref_auto_sync_progress_from_trackers),
             ),
+            Preference.PreferenceItem.SwitchPreference(
+                preference = trackPreferences.showNotInLibraryTrackerEntries(),
+                title = stringResource(MR.strings.pref_tracker_show_not_in_library_entries),
+                subtitle = stringResource(MR.strings.pref_tracker_show_not_in_library_entries_summary),
+            ),
             // KMK <--
             // SY -->
             Preference.PreferenceItem.SwitchPreference(
@@ -164,11 +169,13 @@ object SettingsTrackingScreen : SearchableSettings {
                         tracker = trackerManager.myAnimeList,
                         login = { context.openInBrowser(MyAnimeListApi.authUrl(), forceDefaultBrowser = true) },
                         logout = { dialog = LogoutDialog(trackerManager.myAnimeList) },
+                        supportLabel = stringResource(MR.strings.tracker_not_in_library_supported),
                     ),
                     Preference.PreferenceItem.TrackerPreference(
                         tracker = trackerManager.aniList,
                         login = { context.openInBrowser(AnilistApi.authUrl(), forceDefaultBrowser = true) },
                         logout = { dialog = LogoutDialog(trackerManager.aniList) },
+                        supportLabel = stringResource(MR.strings.tracker_not_in_library_supported),
                     ),
                     Preference.PreferenceItem.TrackerPreference(
                         tracker = trackerManager.kitsu,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/TrackingPreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/TrackingPreferenceWidget.kt
@@ -12,13 +12,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Done
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.more.settings.LocalPreferenceHighlighted
 import eu.kanade.presentation.track.components.TrackLogoIcon
@@ -82,27 +80,20 @@ private fun TrackerLabel(
             fontSize = TitleFontSize,
         )
         supportLabel?.let {
-            SupportPill(text = it)
+            SupportLabel(text = it)
         }
     }
 }
 
 @Composable
-private fun SupportPill(
+private fun SupportLabel(
     text: String,
     modifier: Modifier = Modifier,
-    horizontalPadding: Dp = 8.dp,
 ) {
-    Surface(
+    Text(
+        text = text,
         modifier = modifier,
-        shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-    ) {
-        Text(
-            text = text,
-            modifier = Modifier.padding(horizontal = horizontalPadding, vertical = 2.dp),
-            style = MaterialTheme.typography.labelSmall,
-        )
-    }
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        style = MaterialTheme.typography.labelSmall,
+    )
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/TrackingPreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/TrackingPreferenceWidget.kt
@@ -1,7 +1,9 @@
 package eu.kanade.presentation.more.settings.widget
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,11 +12,13 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Done
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.more.settings.LocalPreferenceHighlighted
 import eu.kanade.presentation.track.components.TrackLogoIcon
@@ -27,6 +31,7 @@ fun TrackingPreferenceWidget(
     modifier: Modifier = Modifier,
     tracker: Tracker,
     checked: Boolean,
+    supportLabel: String? = null,
     onClick: (() -> Unit)? = null,
 ) {
     val highlighted = LocalPreferenceHighlighted.current
@@ -39,14 +44,12 @@ fun TrackingPreferenceWidget(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             TrackLogoIcon(tracker)
-            Text(
-                text = tracker.name,
+            TrackerLabel(
+                name = tracker.name,
+                supportLabel = supportLabel,
                 modifier = Modifier
                     .weight(1f)
                     .padding(horizontal = 16.dp),
-                maxLines = 1,
-                style = MaterialTheme.typography.titleLarge,
-                fontSize = TitleFontSize,
             )
             if (checked) {
                 Icon(
@@ -59,5 +62,47 @@ fun TrackingPreferenceWidget(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun TrackerLabel(
+    name: String,
+    supportLabel: String?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = name,
+            maxLines = 1,
+            style = MaterialTheme.typography.titleLarge,
+            fontSize = TitleFontSize,
+        )
+        supportLabel?.let {
+            SupportPill(text = it)
+        }
+    }
+}
+
+@Composable
+private fun SupportPill(
+    text: String,
+    modifier: Modifier = Modifier,
+    horizontalPadding: Dp = 8.dp,
+) {
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = horizontalPadding, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+        )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackStatus.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackStatus.kt
@@ -20,6 +20,7 @@ enum class TrackStatus(val int: Int, val res: StringResource) {
     COMPLETED(5, MR.strings.completed),
     DROPPED(6, MR.strings.dropped),
     OTHER(7, SYMR.strings.not_tracked),
+    NOT_IN_LIBRARY(8, MR.strings.not_in_library),
     ;
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackerWithNotInLibrary.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackerWithNotInLibrary.kt
@@ -1,0 +1,8 @@
+package eu.kanade.tachiyomi.data.track
+
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
+
+interface TrackerWithNotInLibrary : Tracker {
+
+    suspend fun getNotInLibraryEntries(): List<TrackSearch>
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/Anilist.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
+import eu.kanade.tachiyomi.data.track.TrackerWithNotInLibrary
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
@@ -18,7 +19,7 @@ import tachiyomi.i18n.MR
 import uy.kohesive.injekt.injectLazy
 import tachiyomi.domain.track.model.Track as DomainTrack
 
-class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker {
+class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker, TrackerWithNotInLibrary {
 
     companion object {
         const val READING = 1L
@@ -210,6 +211,10 @@ class Anilist(id: Long) : BaseTracker(id, "AniList"), DeletableTracker {
         track.title = remoteTrack.title
         track.total_chapters = remoteTrack.total_chapters
         return track
+    }
+
+    override suspend fun getNotInLibraryEntries(): List<TrackSearch> {
+        return api.getNotInLibraryEntries(getUsername().toInt())
     }
 
     override suspend fun login(username: String, password: String) = login(password)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -199,12 +199,13 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         }
     }
 
-    suspend fun getNotInLibraryEntries(
-        userId: Int,
-        page: Int = 1,
-    ): List<TrackSearch> {
+    suspend fun getNotInLibraryEntries(userId: Int): List<TrackSearch> {
         return withIOContext {
-            val query = $$"""
+            val entries = mutableListOf<TrackSearch>()
+            var page = 1
+
+            while (true) {
+                val query = $$"""
             |query ($id: Int!, $page: Int!, $perPage: Int!) {
                 |Page(page: $page, perPage: $perPage) {
                     |pageInfo {
@@ -264,36 +265,38 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             |}
             |
             """.trimMargin()
-            val payload = buildJsonObject {
-                put("query", query)
-                putJsonObject("variables") {
-                    put("id", userId)
-                    put("page", page)
-                    put("perPage", 50)
-                }
-            }
-            with(json) {
-                authClient.newCall(
-                    POST(
-                        API_URL,
-                        body = payload.toString().toRequestBody(jsonMime),
-                    ),
-                )
-                    .awaitSuccess()
-                    .parseAs<ALUserListMangaQueryResult>()
-                    .data.page
-                    .let { pageResult ->
-                        val entries = pageResult.mediaList
-                            .map { it.toALUserManga() }
-                            .map { it.toTrackSearch() }
-                        val hasNextPage = pageResult.pageInfo?.hasNextPage == true
-                        if (hasNextPage) {
-                            entries + getNotInLibraryEntries(userId, page + 1)
-                        } else {
-                            entries
-                        }
+                val payload = buildJsonObject {
+                    put("query", query)
+                    putJsonObject("variables") {
+                        put("id", userId)
+                        put("page", page)
+                        put("perPage", 50)
                     }
+                }
+
+                val pageResult = with(json) {
+                    authClient.newCall(
+                        POST(
+                            API_URL,
+                            body = payload.toString().toRequestBody(jsonMime),
+                        ),
+                    )
+                        .awaitSuccess()
+                        .parseAs<ALUserListMangaQueryResult>()
+                        .data.page
+                }
+
+                entries += pageResult.mediaList
+                    .map { it.toALUserManga() }
+                    .map { it.toTrackSearch() }
+
+                if (pageResult.pageInfo?.hasNextPage != true) {
+                    break
+                }
+                page++
             }
+
+            entries
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -199,6 +199,104 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         }
     }
 
+    suspend fun getNotInLibraryEntries(
+        userId: Int,
+        page: Int = 1,
+    ): List<TrackSearch> {
+        return withIOContext {
+            val query = $$"""
+            |query ($id: Int!, $page: Int!, $perPage: Int!) {
+                |Page(page: $page, perPage: $perPage) {
+                    |pageInfo {
+                        |currentPage
+                        |hasNextPage
+                    |}
+                    |mediaList(userId: $id, type: MANGA) {
+                        |id
+                        |status
+                        |scoreRaw: score(format: POINT_100)
+                        |progress
+                        |private
+                        |startedAt {
+                            |year
+                            |month
+                            |day
+                        |}
+                        |completedAt {
+                            |year
+                            |month
+                            |day
+                        |}
+                        |media {
+                            |id
+                            |title {
+                                |userPreferred
+                            |}
+                            |coverImage {
+                                |large
+                            |}
+                            |format
+                            |status
+                            |chapters
+                            |description
+                            |startDate {
+                                |year
+                                |month
+                                |day
+                            |}
+                            |averageScore
+                            |staff {
+                                |edges {
+                                    |role
+                                    |id
+                                    |node {
+                                        |name {
+                                            |full
+                                            |userPreferred
+                                            |native
+                                        |}
+                                    |}
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
+            |}
+            |
+            """.trimMargin()
+            val payload = buildJsonObject {
+                put("query", query)
+                putJsonObject("variables") {
+                    put("id", userId)
+                    put("page", page)
+                    put("perPage", 50)
+                }
+            }
+            with(json) {
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALUserListMangaQueryResult>()
+                    .data.page
+                    .let { pageResult ->
+                        val entries = pageResult.mediaList
+                            .map { it.toALUserManga() }
+                            .map { it.toTrackSearch() }
+                        val hasNextPage = pageResult.pageInfo?.hasNextPage == true
+                        if (hasNextPage) {
+                            entries + getNotInLibraryEntries(userId, page + 1)
+                        } else {
+                            entries
+                        }
+                    }
+            }
+        }
+    }
+
     suspend fun findLibManga(track: Track, userid: Int): Track? {
         return withIOContext {
             val query = $$"""

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALManga.kt
@@ -70,6 +70,20 @@ data class ALUserManga(
         private = this@ALUserManga.private
     }
 
+    fun toTrackSearch() = TrackSearch.create(TrackerManager.ANILIST).apply {
+        remote_id = manga.remoteId
+        title = manga.title
+        status = toTrackStatus()
+        score = scoreRaw.toDouble()
+        last_chapter_read = chaptersRead.toDouble()
+        library_id = libraryId
+        total_chapters = manga.totalChapters
+        private = this@ALUserManga.private
+        cover_url = manga.imageUrl
+        summary = manga.description?.htmlDecode() ?: ""
+        tracking_url = AnilistApi.mangaUrl(remote_id)
+    }
+
     private fun toTrackStatus() = when (listStatus) {
         "CURRENT" -> Anilist.READING
         "COMPLETED" -> Anilist.COMPLETED

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALUserList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALUserList.kt
@@ -17,6 +17,13 @@ data class ALUserListMangaPage(
 @Serializable
 data class ALUserListMediaList(
     val mediaList: List<ALUserListItem>,
+    val pageInfo: ALUserListPageInfo? = null,
+)
+
+@Serializable
+data class ALUserListPageInfo(
+    val currentPage: Int,
+    val hasNextPage: Boolean,
 )
 
 @Serializable

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeList.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
+import eu.kanade.tachiyomi.data.track.TrackerWithNotInLibrary
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALOAuth
@@ -16,7 +17,7 @@ import tachiyomi.i18n.MR
 import uy.kohesive.injekt.injectLazy
 import tachiyomi.domain.track.model.Track as DomainTrack
 
-class MyAnimeList(id: Long) : BaseTracker(id, "MyAnimeList"), DeletableTracker {
+class MyAnimeList(id: Long) : BaseTracker(id, "MyAnimeList"), DeletableTracker, TrackerWithNotInLibrary {
 
     companion object {
         const val READING = 1L
@@ -133,6 +134,10 @@ class MyAnimeList(id: Long) : BaseTracker(id, "MyAnimeList"), DeletableTracker {
 
     override suspend fun refresh(track: Track): Track {
         return api.findListItem(track) ?: add(track)
+    }
+
+    override suspend fun getNotInLibraryEntries(): List<TrackSearch> {
+        return api.getNotInLibraryEntries()
     }
 
     override suspend fun login(username: String, password: String) = login(password)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALManga
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALMangaMetadata
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALOAuth
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALSearchResult
+import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALUserListResult
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALUser
 import eu.kanade.tachiyomi.network.DELETE
 import eu.kanade.tachiyomi.network.GET
@@ -175,6 +176,21 @@ class MyAnimeListApi(
         }
     }
 
+    suspend fun getNotInLibraryEntries(offset: Int = 0): List<TrackSearch> {
+        return withIOContext {
+            val listPage = getUserListPage(offset)
+            val entries = listPage.data.mapNotNull { item ->
+                item.listStatus?.let { parseListSearchItem(item.node, it) }
+            }
+
+            if (!listPage.paging.next.isNullOrBlank()) {
+                entries + getNotInLibraryEntries(offset + LIST_PAGINATION_AMOUNT)
+            } else {
+                entries
+            }
+        }
+    }
+
     // SY -->
     suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
         return withIOContext {
@@ -234,6 +250,27 @@ class MyAnimeListApi(
         }
     }
 
+    private suspend fun getUserListPage(offset: Int): MALUserListResult {
+        return withIOContext {
+            val urlBuilder = "$BASE_API_URL/users/@me/mangalist".toUri().buildUpon()
+                .appendQueryParameter("fields", LIST_FIELDS)
+                .appendQueryParameter("limit", LIST_PAGINATION_AMOUNT.toString())
+            if (offset > 0) {
+                urlBuilder.appendQueryParameter("offset", offset.toString())
+            }
+
+            val request = Request.Builder()
+                .url(urlBuilder.build().toString())
+                .get()
+                .build()
+            with(json) {
+                authClient.newCall(request)
+                    .awaitSuccess()
+                    .parseAs()
+            }
+        }
+    }
+
     private fun parseMangaItem(listStatus: MALListItemStatus, track: Track): Track {
         return track.apply {
             val isRereading = listStatus.isRereading
@@ -267,6 +304,18 @@ class MyAnimeListApi(
         }
     }
 
+    private fun parseListSearchItem(
+        searchItem: MALManga,
+        listStatus: MALListItemStatus,
+    ): TrackSearch {
+        return parseSearchItem(searchItem).apply {
+            val isRereading = listStatus.isRereading
+            status = if (isRereading) MyAnimeList.REREADING else getStatus(listStatus.status)
+            last_chapter_read = listStatus.numChaptersRead
+            score = listStatus.score.toDouble()
+        }
+    }
+
     private fun parseDate(isoDate: String): Long {
         return SimpleDateFormat("yyyy-MM-dd", Locale.US).parse(isoDate)?.time ?: 0L
     }
@@ -292,6 +341,9 @@ class MyAnimeListApi(
 
         private const val SEARCH_FIELDS =
             "id,title,synopsis,num_chapters,mean,main_picture,status,media_type,start_date,authors{first_name,last_name}"
+
+        private const val LIST_FIELDS =
+            "$SEARCH_FIELDS,list_status{is_rereading,status,num_chapters_read,score,start_date,finish_date}"
 
         private const val LIST_PAGINATION_AMOUNT = 250
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -178,16 +178,22 @@ class MyAnimeListApi(
 
     suspend fun getNotInLibraryEntries(offset: Int = 0): List<TrackSearch> {
         return withIOContext {
-            val listPage = getUserListPage(offset)
-            val entries = listPage.data.mapNotNull { item ->
-                item.listStatus?.let { parseListSearchItem(item.node, it) }
+            val entries = mutableListOf<TrackSearch>()
+            var currentOffset = offset
+
+            while (true) {
+                val listPage = getUserListPage(currentOffset)
+                entries += listPage.data.mapNotNull { item ->
+                    item.listStatus?.let { parseListSearchItem(item.node, it) }
+                }
+
+                if (listPage.paging.next.isNullOrBlank()) {
+                    break
+                }
+                currentOffset += LIST_PAGINATION_AMOUNT
             }
 
-            if (!listPage.paging.next.isNullOrBlank()) {
-                entries + getNotInLibraryEntries(offset + LIST_PAGINATION_AMOUNT)
-            } else {
-                entries
-            }
+            entries
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALUserList.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALUserList.kt
@@ -1,0 +1,19 @@
+package eu.kanade.tachiyomi.data.track.myanimelist.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
+
+@Serializable
+data class MALUserListResult(
+    val data: List<MALUserListNode>,
+    val paging: MALSearchPaging,
+)
+
+@Serializable
+data class MALUserListNode(
+    val node: MALManga,
+    @JsonNames("list_status", "my_list_status")
+    @SerialName("list_status")
+    val listStatus: MALListItemStatus? = null,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/search/MigrateSearchScreenModel.kt
@@ -29,6 +29,8 @@ class MigrateSearchScreenModel(
     }
 
     init {
+        shouldPinnedSourcesHidden()
+
         screenModelScope.launch {
             val manga = getManga.await(mangaId)!!
             mutableState.update {
@@ -39,10 +41,6 @@ class MigrateSearchScreenModel(
             }
             search()
         }
-
-        // KMK -->
-        shouldPinnedSourcesHidden()
-        // KMK <--
     }
 
     override fun getEnabledSources(): List<CatalogueSource> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreen.kt
@@ -51,6 +51,7 @@ import eu.kanade.presentation.manga.DuplicateMangaDialog
 import eu.kanade.presentation.more.settings.screen.SettingsEhScreen
 import eu.kanade.presentation.util.AssistContentScreen
 import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -95,6 +96,7 @@ data class BrowseSourceScreen(
     /** being set when called from [SmartSearchScreen] or when click on a manga from this screen
      * which was previously opened from `SmartSearchScreen` */
     private val smartSearchConfig: SourcesScreen.SmartSearchConfig? = null,
+    private val initialTrackSearch: TrackSearch? = null,
     // SY <--
 ) : Screen(), AssistContentScreen {
 
@@ -116,6 +118,7 @@ data class BrowseSourceScreen(
                 // SY -->
                 filtersJson = filtersJson,
                 savedSearch = savedSearch,
+                initialTrackSearch = initialTrackSearch,
                 // SY <--
             )
         }
@@ -369,6 +372,7 @@ data class BrowseSourceScreen(
                                 fromSource = smartSearchConfig == null,
                                 // KMK <--
                                 smartSearchConfig = smartSearchConfig,
+                                initialTrackSearch = initialTrackSearch,
                             ),
                         )
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -25,6 +25,7 @@ import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.interactor.ToggleIncognito
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.track.interactor.AddTracks
+import eu.kanade.domain.track.interactor.bindTrackSearchToManga
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.util.ioCoroutineScope
 import eu.kanade.tachiyomi.data.cache.CoverCache
@@ -455,15 +456,15 @@ open class BrowseSourceScreenModel(
 
     private suspend fun bindPendingTrackSearch(mangaId: Long) {
         val trackSearch = pendingTrackSearch ?: return
-        val tracker = trackerManager.get(trackSearch.tracker_id) ?: return
-
-        try {
-            addTracks.bind(tracker, trackSearch, mangaId)
+        if (
+            bindTrackSearchToManga(
+                trackSearch = trackSearch,
+                mangaId = mangaId,
+                trackerManager = trackerManager,
+                addTracks = addTracks,
+            )
+        ) {
             pendingTrackSearch = null
-        } catch (e: Exception) {
-            logcat(LogPriority.WARN, e) {
-                "Failed to bind pending tracker entry trackerId=${trackSearch.tracker_id} remoteId=${trackSearch.remote_id}"
-            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -28,6 +28,8 @@ import eu.kanade.domain.track.interactor.AddTracks
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.util.ioCoroutineScope
 import eu.kanade.tachiyomi.data.cache.CoverCache
+import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -102,6 +104,7 @@ open class BrowseSourceScreenModel(
     // SY -->
     private val filtersJson: String? = null,
     private val savedSearch: Long? = null,
+    private val initialTrackSearch: TrackSearch? = null,
     // SY <--
     private val sourceManager: SourceManager = Injekt.get(),
     sourcePreferences: SourcePreferences = Injekt.get(),
@@ -115,6 +118,7 @@ open class BrowseSourceScreenModel(
     private val getManga: GetManga = Injekt.get(),
     private val updateManga: UpdateManga = Injekt.get(),
     private val addTracks: AddTracks = Injekt.get(),
+    private val trackerManager: TrackerManager = Injekt.get(),
     private val getIncognitoState: GetIncognitoState = Injekt.get(),
     // KMK -->
     private val toggleIncognito: ToggleIncognito = Injekt.get(),
@@ -132,6 +136,7 @@ open class BrowseSourceScreenModel(
     private val getExhSavedSearch: GetExhSavedSearch = Injekt.get(),
     // SY <--
 ) : StateScreenModel<BrowseSourceScreenModel.State>(State(Listing.valueOf(listingQuery))) {
+    private var pendingTrackSearch: TrackSearch? = initialTrackSearch
 
     var displayMode by sourcePreferences.sourceDisplayMode().asState(screenModelScope)
 
@@ -419,10 +424,13 @@ open class BrowseSourceScreenModel(
                 new = new.removeCovers(coverCache)
             } else {
                 setMangaDefaultChapterFlags.await(manga)
-                addTracks.bindEnhancedTrackers(manga, source)
             }
 
             updateManga.await(new.toMangaUpdate())
+            if (new.favorite) {
+                bindPendingTrackSearch(manga.id)
+                addTracks.bindEnhancedTrackers(manga, source)
+            }
             // KMK -->
             if (new.favorite && libraryPreferences.syncOnAdd().get()) {
                 withIOContext {
@@ -442,6 +450,20 @@ open class BrowseSourceScreenModel(
                 }
             }
             // KMK <--
+        }
+    }
+
+    private suspend fun bindPendingTrackSearch(mangaId: Long) {
+        val trackSearch = pendingTrackSearch ?: return
+        val tracker = trackerManager.get(trackSearch.tracker_id) ?: return
+
+        try {
+            addTracks.bind(tracker, trackSearch, mangaId)
+            pendingTrackSearch = null
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) {
+                "Failed to bind pending tracker entry trackerId=${trackSearch.tracker_id} remoteId=${trackSearch.remote_id}"
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreen.kt
@@ -16,6 +16,7 @@ import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.presentation.browse.GlobalSearchScreen
 import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
@@ -24,6 +25,7 @@ import tachiyomi.presentation.core.screens.LoadingScreen
 class GlobalSearchScreen(
     val searchQuery: String = "",
     private val extensionFilter: String? = null,
+    private val initialTrackSearch: TrackSearch? = null,
 ) : Screen() {
 
     @Composable
@@ -66,7 +68,7 @@ class GlobalSearchScreen(
                     is SearchItemResult.Success -> {
                         val manga = result.result.singleOrNull()
                         if (manga != null) {
-                            navigator.replace(MangaScreen(manga.id, true))
+                            navigator.replace(MangaScreen(manga.id, true, initialTrackSearch = initialTrackSearch))
                         } else {
                             // Backoff to result screen
                             showSingleLoadingScreen = false
@@ -85,7 +87,7 @@ class GlobalSearchScreen(
                 onChangeSearchFilter = screenModel::setSourceFilter,
                 onToggleResults = screenModel::toggleFilterResults,
                 onClickSource = {
-                    navigator.push(BrowseSourceScreen(it.id, state.searchQuery))
+                    navigator.push(BrowseSourceScreen(it.id, state.searchQuery, initialTrackSearch = initialTrackSearch))
                 },
                 onClickItem = { manga ->
                     // KMK -->
@@ -93,7 +95,7 @@ class GlobalSearchScreen(
                         bulkFavoriteScreenModel.toggleSelection(manga)
                     } else {
                         // KMK <--
-                        navigator.push(MangaScreen(manga.id, true))
+                        navigator.push(MangaScreen(manga.id, true, initialTrackSearch = initialTrackSearch))
                     }
                 },
                 onLongClickItem = { manga ->
@@ -102,7 +104,7 @@ class GlobalSearchScreen(
                         bulkFavoriteScreenModel.addRemoveManga(manga, haptic)
                     } else {
                         // KMK <--
-                        navigator.push(MangaScreen(manga.id, true))
+                        navigator.push(MangaScreen(manga.id, true, initialTrackSearch = initialTrackSearch))
                     }
                 },
                 // KMK -->

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/GlobalSearchScreenModel.kt
@@ -9,6 +9,8 @@ class GlobalSearchScreenModel(
 
     init {
         extensionFilter = initialExtensionFilter
+        shouldPinnedSourcesHidden()
+
         if (initialQuery.isNotBlank() || !initialExtensionFilter.isNullOrBlank()) {
             if (extensionFilter != null) {
                 // we're going to use custom extension filter instead
@@ -16,10 +18,6 @@ class GlobalSearchScreenModel(
             }
             search()
         }
-
-        // KMK -->
-        shouldPinnedSourcesHidden()
-        // KMK <--
     }
 
     override fun getEnabledSources(): List<CatalogueSource> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModel.kt
@@ -107,8 +107,13 @@ abstract class SearchScreenModel(
     fun hasPinnedSources(): Boolean = getEnabledSources().any { "${it.id}" in pinnedSources }
 
     fun shouldPinnedSourcesHidden() {
-        if (!hasPinnedSources()) {
-            preferences.globalSearchPinnedState().set(SourceFilter.All)
+        val normalizedFilter = normalizeSearchSourceFilter(
+            currentFilter = state.value.sourceFilter,
+            hasPinnedSources = hasPinnedSources(),
+        )
+        if (normalizedFilter != state.value.sourceFilter) {
+            mutableState.update { it.copy(sourceFilter = normalizedFilter) }
+            preferences.globalSearchPinnedState().set(normalizedFilter)
         }
     }
     // KMK <--
@@ -145,6 +150,8 @@ abstract class SearchScreenModel(
     }
 
     fun search() {
+        shouldPinnedSourcesHidden()
+
         val query = state.value.searchQuery
         val sourceFilter = state.value.sourceFilter
 
@@ -276,5 +283,16 @@ sealed interface SearchItemResult {
 
     fun isVisible(onlyShowHasResults: Boolean): Boolean {
         return !onlyShowHasResults || (this is Success && !this.isEmpty)
+    }
+}
+
+internal fun normalizeSearchSourceFilter(
+    currentFilter: SourceFilter,
+    hasPinnedSources: Boolean,
+): SourceFilter {
+    return if (currentFilter == SourceFilter.PinnedOnly && !hasPinnedSources) {
+        SourceFilter.All
+    } else {
+        currentFilter
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDisplayItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDisplayItem.kt
@@ -68,9 +68,31 @@ internal fun RemoteTrackerTrack.toTrackSearch(): TrackSearch {
     }
 }
 
+/**
+ * Packs tracker and remote ids into a stable synthetic cover id.
+ *
+ * Layout:
+ * - sign bit set to 1 to keep synthetic ids separate from local ids
+ * - 7 bits for tracker id
+ * - 56 bits for remote id
+ */
 internal fun trackerCoverId(
     trackerId: Long,
     remoteId: Long,
 ): Long {
-    return Long.MIN_VALUE or ((trackerId and 0x7FL) shl 56) or (remoteId and 0x00FFFFFFFFFFFFFFL)
+    require(trackerId in 0L..TRACKER_COVER_ID_TRACKER_MASK) {
+        "trackerId must fit in 7 bits, was $trackerId"
+    }
+    require(remoteId in 0L..TRACKER_COVER_ID_REMOTE_MASK) {
+        "remoteId must fit in 56 bits, was $remoteId"
+    }
+
+    return TRACKER_COVER_ID_PREFIX or
+        ((trackerId and TRACKER_COVER_ID_TRACKER_MASK) shl TRACKER_COVER_ID_TRACKER_SHIFT) or
+        (remoteId and TRACKER_COVER_ID_REMOTE_MASK)
 }
+
+private val TRACKER_COVER_ID_PREFIX = Long.MIN_VALUE
+private const val TRACKER_COVER_ID_TRACKER_SHIFT = 56
+private const val TRACKER_COVER_ID_TRACKER_MASK = 0x7FL
+private const val TRACKER_COVER_ID_REMOTE_MASK = 0x00FFFFFFFFFFFFFFL

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDisplayItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDisplayItem.kt
@@ -1,0 +1,65 @@
+package eu.kanade.tachiyomi.ui.library
+
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import tachiyomi.domain.manga.model.MangaCover
+
+sealed interface LibraryDisplayItem {
+    val key: String
+
+    data class Local(val item: LibraryItem) : LibraryDisplayItem {
+        override val key: String = item.id.toString()
+    }
+
+    data class RemoteTrack(val item: RemoteTrackerLibraryItem) : LibraryDisplayItem {
+        override val key: String = item.key
+    }
+}
+
+data class RemoteTrackerTrack(
+    val trackerId: Long,
+    val remoteId: Long,
+    val title: String,
+    val coverUrl: String,
+    val status: Long,
+    val lastChapterRead: Double,
+    val totalChapters: Long,
+    val trackingUrl: String,
+)
+
+data class RemoteTrackerLibraryItem(
+    val track: RemoteTrackerTrack,
+    val trackerName: String,
+    val trackerShortName: String,
+    val statusText: String?,
+    val progressText: String?,
+) {
+    val key: String = "${track.trackerId}:${track.remoteId}"
+
+    val coverData = MangaCover(
+        mangaId = trackerCoverId(track.trackerId, track.remoteId),
+        sourceId = track.trackerId,
+        isMangaFavorite = false,
+        ogUrl = track.coverUrl,
+        lastModified = 0L,
+    )
+}
+
+internal fun TrackSearch.toRemoteTrackerTrack(): RemoteTrackerTrack {
+    return RemoteTrackerTrack(
+        trackerId = tracker_id,
+        remoteId = remote_id,
+        title = title,
+        coverUrl = cover_url,
+        status = status,
+        lastChapterRead = last_chapter_read,
+        totalChapters = total_chapters,
+        trackingUrl = tracking_url,
+    )
+}
+
+internal fun trackerCoverId(
+    trackerId: Long,
+    remoteId: Long,
+): Long {
+    return Long.MIN_VALUE or ((trackerId and 0x7FL) shl 56) or (remoteId and 0x00FFFFFFFFFFFFFFL)
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDisplayItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryDisplayItem.kt
@@ -57,6 +57,17 @@ internal fun TrackSearch.toRemoteTrackerTrack(): RemoteTrackerTrack {
     )
 }
 
+internal fun RemoteTrackerTrack.toTrackSearch(): TrackSearch {
+    return TrackSearch.create(trackerId).apply {
+        remote_id = this@toTrackSearch.remoteId
+        title = this@toTrackSearch.title
+        status = this@toTrackSearch.status
+        last_chapter_read = this@toTrackSearch.lastChapterRead
+        total_chapters = this@toTrackSearch.totalChapters
+        tracking_url = this@toTrackSearch.trackingUrl
+    }
+}
+
 internal fun trackerCoverId(
     trackerId: Long,
     remoteId: Long,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -178,7 +178,10 @@ class LibraryScreenModel(
 
     init {
         mutableState.update { state ->
-            state.copy(activeCategoryIndex = libraryPreferences.lastUsedCategory().get())
+            state.copy(
+                activeCategoryIndex = libraryPreferences.lastUsedCategory().get(),
+                notInLibraryCategoryName = preferences.context.stringResource(TrackStatus.NOT_IN_LIBRARY.res),
+            )
         }
         screenModelScope.launchIO {
             combine(
@@ -1768,38 +1771,20 @@ class LibraryScreenModel(
         val filterCategory: Boolean = false,
         val includedCategories: ImmutableSet<Long> = persistentSetOf(),
         val excludedCategories: ImmutableSet<Long> = persistentSetOf(),
+        val notInLibraryCategoryName: String = "",
         // KMK <--
     ) {
         /**
          * The grouped tabs which is displayed above the library screen.
          * They can be actual [Category] or [Source], [Track]...
          */
-        val displayedCategories: List<Category> = buildList {
-            val localCategories = groupedFavorites.keys.toList()
-            val localCategoriesToDisplay = if (
-                groupType == LibraryGroup.BY_TRACK_STATUS &&
-                remoteTrackerItems.isNotEmpty() &&
-                localCategories.size == 1 &&
-                localCategories.first().id == 0L &&
-                groupedFavorites.values.firstOrNull().isNullOrEmpty()
-            ) {
-                emptyList()
-            } else {
-                localCategories
-            }
-            addAll(localCategoriesToDisplay)
-            if (remoteTrackerItems.isNotEmpty()) {
-                add(
-                    Category(
-                        id = TrackStatus.NOT_IN_LIBRARY.int.toLong(),
-                        name = Injekt.get<Application>().stringResource(TrackStatus.NOT_IN_LIBRARY.res),
-                        order = TrackStatus.NOT_IN_LIBRARY.ordinal.toLong(),
-                        flags = 0,
-                        hidden = false,
-                    ),
-                )
-            }
-        }
+        val displayedCategories: List<Category>
+            get() = buildDisplayedCategories(
+                groupedFavorites = groupedFavorites,
+                remoteTrackerItems = remoteTrackerItems,
+                groupType = groupType,
+                notInLibraryCategoryName = notInLibraryCategoryName,
+            )
 
         val coercedActiveCategoryIndex = /* KMK --> */ displayedCategories.indexOfFirst { it.id == activeCategoryId }
             .takeIf { it != -1 } ?: activeCategoryIndex
@@ -1926,6 +1911,40 @@ class LibraryScreenModel(
         }
     }
     // KMK <--
+}
+
+internal fun buildDisplayedCategories(
+    groupedFavorites: Map<Category, List<Long>>,
+    remoteTrackerItems: List<RemoteTrackerLibraryItem>,
+    groupType: Int,
+    notInLibraryCategoryName: String,
+): List<Category> {
+    return buildList {
+        val localCategories = groupedFavorites.keys.toList()
+        val localCategoriesToDisplay = if (
+            groupType == LibraryGroup.BY_TRACK_STATUS &&
+            remoteTrackerItems.isNotEmpty() &&
+            localCategories.size == 1 &&
+            localCategories.first().id == 0L &&
+            groupedFavorites.values.firstOrNull().isNullOrEmpty()
+        ) {
+            emptyList()
+        } else {
+            localCategories
+        }
+        addAll(localCategoriesToDisplay)
+        if (remoteTrackerItems.isNotEmpty()) {
+            add(
+                Category(
+                    id = TrackStatus.NOT_IN_LIBRARY.int.toLong(),
+                    name = notInLibraryCategoryName,
+                    order = TrackStatus.NOT_IN_LIBRARY.ordinal.toLong(),
+                    flags = 0,
+                    hidden = false,
+                ),
+            )
+        }
+    }
 }
 
 internal data class RemoteTrackKey(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -20,6 +20,7 @@ import eu.kanade.domain.manga.interactor.SmartSearchMerge
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.sync.SyncPreferences
+import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.presentation.components.SEARCH_DEBOUNCE_MILLIS
 import eu.kanade.presentation.library.components.LibraryToolbarTitle
 import eu.kanade.presentation.manga.DownloadAction
@@ -29,6 +30,7 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.track.TrackStatus
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.TrackerWithNotInLibrary
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -63,8 +65,10 @@ import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
+import kotlinx.coroutines.async
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -144,6 +148,7 @@ class LibraryScreenModel(
     private val downloadManager: DownloadManager = Injekt.get(),
     private val downloadCache: DownloadCache = Injekt.get(),
     private val trackerManager: TrackerManager = Injekt.get(),
+    private val trackPreferences: TrackPreferences = Injekt.get(),
     // SY -->
     private val exhPreferences: ExhPreferences = Injekt.get(),
     private val sourcePreferences: SourcePreferences = Injekt.get(),
@@ -167,6 +172,8 @@ class LibraryScreenModel(
     val recommendationSearch = RecommendationSearchHelper(preferences.context)
 
     private var recommendationSearchJob: Job? = null
+    private var remoteTrackerItemsJob: Job? = null
+    private var remoteTrackerFetchConfig = RemoteTrackerFetchConfig()
     // SY <--
 
     init {
@@ -385,6 +392,59 @@ class LibraryScreenModel(
             .distinctUntilChanged()
             .onEach { syncService ->
                 mutableState.update { it.copy(isSyncEnabled = syncService != 0) }
+            }
+            .launchIn(screenModelScope)
+
+        combine(
+            libraryPreferences.groupLibraryBy().changes(),
+            trackPreferences.showNotInLibraryTrackerEntries().changes(),
+            trackerManager.loggedInTrackersFlow(),
+        ) { groupType, enabled, loggedInTrackers ->
+            RemoteTrackerFetchConfig(
+                enabled = groupType == LibraryGroup.BY_TRACK_STATUS && enabled,
+                trackers = loggedInTrackers.filterIsInstance<TrackerWithNotInLibrary>(),
+            )
+        }
+            .distinctUntilChanged { old, new ->
+                old.enabled == new.enabled &&
+                    old.trackers.map { it.id } == new.trackers.map { it.id }
+            }
+            .onEach { config ->
+                remoteTrackerFetchConfig = config
+                if (!config.enabled || config.trackers.isEmpty()) {
+                    remoteTrackerItemsJob?.cancel()
+                    mutableState.update {
+                        it.copy(
+                            rawRemoteTrackerItems = emptyList(),
+                            remoteTrackerItems = emptyList(),
+                        )
+                    }
+                } else {
+                    refreshRemoteTrackerItems()
+                }
+            }
+            .launchIn(screenModelScope)
+
+        combine(
+            state.map { Triple(it.rawRemoteTrackerItems, it.searchQuery, it.libraryData) }.distinctUntilChanged(),
+            libraryPreferences.groupLibraryBy().changes(),
+            trackPreferences.showNotInLibraryTrackerEntries().changes(),
+        ) { (rawRemoteItems, searchQuery, libraryData), groupType, enabled ->
+            if (!enabled || groupType != LibraryGroup.BY_TRACK_STATUS) {
+                emptyList()
+            } else {
+                buildRemoteTrackerLibraryItems(
+                    remoteTracks = rawRemoteItems,
+                    trackedKeys = buildTrackedRemoteKeys(libraryData.favorites, libraryData.tracksMap),
+                    trackerManager = trackerManager,
+                    context = preferences.context,
+                    searchQuery = searchQuery,
+                )
+            }
+        }
+            .distinctUntilChanged()
+            .onEach { remoteTrackerItems ->
+                mutableState.update { it.copy(remoteTrackerItems = remoteTrackerItems) }
             }
             .launchIn(screenModelScope)
         // SY <--
@@ -1140,6 +1200,29 @@ class LibraryScreenModel(
         return state.getItemsForCategoryId(state.activeCategory?.id).randomOrNull()
     }
 
+    fun refreshRemoteTrackerItems(): Boolean {
+        val config = remoteTrackerFetchConfig.takeIf { it.enabled && it.trackers.isNotEmpty() } ?: return false
+
+        remoteTrackerItemsJob?.cancel()
+        remoteTrackerItemsJob = screenModelScope.launchIO {
+            val items = config.trackers.map { tracker ->
+                async {
+                    runCatching { tracker.getNotInLibraryEntries() }
+                        .getOrElse {
+                            xLogE("Failed to fetch remote tracker entries for ${tracker.name}", it)
+                            emptyList()
+                        }
+                        .map { it.toRemoteTrackerTrack() }
+                }
+            }
+                .awaitAll()
+                .flatten()
+
+            mutableState.update { it.copy(rawRemoteTrackerItems = items) }
+        }
+        return true
+    }
+
     fun showSettingsDialog() {
         mutableState.update { it.copy(dialog = Dialog.SettingsSheet) }
     }
@@ -1674,6 +1757,8 @@ class LibraryScreenModel(
         private val activeCategoryId: Long? = null,
         // KMK <--
         private val groupedFavorites: Map<Category, List</* LibraryItem */ Long>> = emptyMap(),
+        val rawRemoteTrackerItems: List<RemoteTrackerTrack> = emptyList(),
+        val remoteTrackerItems: List<RemoteTrackerLibraryItem> = emptyList(),
         // SY -->
         val showSyncExh: Boolean = false,
         val isSyncEnabled: Boolean = false,
@@ -1689,7 +1774,32 @@ class LibraryScreenModel(
          * The grouped tabs which is displayed above the library screen.
          * They can be actual [Category] or [Source], [Track]...
          */
-        val displayedCategories: List<Category> = groupedFavorites.keys.toList()
+        val displayedCategories: List<Category> = buildList {
+            val localCategories = groupedFavorites.keys.toList()
+            val localCategoriesToDisplay = if (
+                groupType == LibraryGroup.BY_TRACK_STATUS &&
+                remoteTrackerItems.isNotEmpty() &&
+                localCategories.size == 1 &&
+                localCategories.first().id == 0L &&
+                groupedFavorites.values.firstOrNull().isNullOrEmpty()
+            ) {
+                emptyList()
+            } else {
+                localCategories
+            }
+            addAll(localCategoriesToDisplay)
+            if (remoteTrackerItems.isNotEmpty()) {
+                add(
+                    Category(
+                        id = TrackStatus.NOT_IN_LIBRARY.int.toLong(),
+                        name = Injekt.get<Application>().stringResource(TrackStatus.NOT_IN_LIBRARY.res),
+                        order = TrackStatus.NOT_IN_LIBRARY.ordinal.toLong(),
+                        flags = 0,
+                        hidden = false,
+                    ),
+                )
+            }
+        }
 
         val coercedActiveCategoryIndex = /* KMK --> */ displayedCategories.indexOfFirst { it.id == activeCategoryId }
             .takeIf { it != -1 } ?: activeCategoryIndex
@@ -1702,6 +1812,7 @@ class LibraryScreenModel(
         val activeCategory: Category? = displayedCategories.getOrNull(coercedActiveCategoryIndex)
 
         val isLibraryEmpty = libraryData.favorites.isEmpty()
+        val hasRemoteTrackerItems = remoteTrackerItems.isNotEmpty()
 
         val selectionMode = selection.isNotEmpty()
 
@@ -1742,8 +1853,24 @@ class LibraryScreenModel(
             return groupedFavorites[category].orEmpty().fastMapNotNull { libraryData.favoritesById[it] }
         }
 
+        fun getDisplayItemsForCategory(category: Category): List<LibraryDisplayItem> {
+            return if (category.id == TrackStatus.NOT_IN_LIBRARY.int.toLong()) {
+                remoteTrackerItems.map(LibraryDisplayItem::RemoteTrack)
+            } else {
+                getItemsForCategory(category).map(LibraryDisplayItem::Local)
+            }
+        }
+
         fun getItemCountForCategory(category: Category): Int? {
-            return if (showMangaCount || !searchQuery.isNullOrEmpty()) groupedFavorites[category]?.size else null
+            return if (showMangaCount || !searchQuery.isNullOrEmpty()) {
+                if (category.id == TrackStatus.NOT_IN_LIBRARY.int.toLong()) {
+                    remoteTrackerItems.size
+                } else {
+                    groupedFavorites[category]?.size
+                }
+            } else {
+                null
+            }
         }
 
         fun getToolbarTitle(
@@ -1765,6 +1892,11 @@ class LibraryScreenModel(
             return LibraryToolbarTitle(title, count)
         }
     }
+
+    private data class RemoteTrackerFetchConfig(
+        val enabled: Boolean = false,
+        val trackers: List<TrackerWithNotInLibrary> = emptyList(),
+    )
 
     // KMK -->
     companion object {
@@ -1794,4 +1926,83 @@ class LibraryScreenModel(
         }
     }
     // KMK <--
+}
+
+internal data class RemoteTrackKey(
+    val trackerId: Long,
+    val remoteId: Long,
+)
+
+internal fun buildTrackedRemoteKeys(
+    favorites: List<LibraryItem>,
+    tracksMap: Map<Long, List<Track>>,
+): Set<RemoteTrackKey> {
+    return favorites
+        .flatMap { libraryItem ->
+            tracksMap[libraryItem.id].orEmpty().map { track ->
+                RemoteTrackKey(track.trackerId, track.remoteId)
+            }
+        }
+        .toSet()
+}
+
+internal fun buildRemoteTrackerLibraryItems(
+    remoteTracks: List<RemoteTrackerTrack>,
+    trackedKeys: Set<RemoteTrackKey>,
+    trackerManager: TrackerManager,
+    context: Context,
+    searchQuery: String?,
+): List<RemoteTrackerLibraryItem> {
+    return remoteTracks
+        .filterNot { track -> RemoteTrackKey(track.trackerId, track.remoteId) in trackedKeys }
+        .mapNotNull { track ->
+            val tracker = trackerManager.get(track.trackerId) ?: return@mapNotNull null
+            val statusText = tracker.getStatus(track.status)?.let(context::stringResource)
+            RemoteTrackerLibraryItem(
+                track = track,
+                trackerName = tracker.name,
+                trackerShortName = trackerBadgeLabel(track.trackerId, tracker.name),
+                statusText = statusText,
+                progressText = remoteTrackerProgressText(track),
+            )
+        }
+        .filter { remoteItem ->
+            searchQuery.isNullOrBlank() || remoteItem.matchesQuery(searchQuery)
+        }
+        .sortedWith(
+            compareBy<RemoteTrackerLibraryItem> { it.track.title.lowercase() }
+                .thenBy { it.trackerName.lowercase() },
+        )
+}
+
+internal fun RemoteTrackerLibraryItem.matchesQuery(query: String): Boolean {
+    val normalizedQuery = query.trim()
+    if (normalizedQuery.isEmpty()) return true
+
+    return track.title.contains(normalizedQuery, ignoreCase = true) ||
+        trackerName.contains(normalizedQuery, ignoreCase = true) ||
+        (statusText?.contains(normalizedQuery, ignoreCase = true) == true) ||
+        (progressText?.contains(normalizedQuery, ignoreCase = true) == true)
+}
+
+internal fun remoteTrackerProgressText(track: RemoteTrackerTrack): String? {
+    val progress = track.lastChapterRead.toInt().takeIf { it > 0 }
+    val total = track.totalChapters.takeIf { it > 0 }
+
+    return when {
+        progress != null && total != null -> "$progress/$total"
+        progress != null -> progress.toString()
+        else -> null
+    }
+}
+
+internal fun trackerBadgeLabel(
+    trackerId: Long,
+    fallbackName: String,
+): String {
+    return when (trackerId) {
+        1L -> "MAL"
+        TrackerManager.ANILIST -> "AL"
+        else -> fallbackName
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -2000,8 +2000,8 @@ internal fun RemoteTrackerLibraryItem.matchesQuery(query: String): Boolean {
 
     return track.title.contains(normalizedQuery, ignoreCase = true) ||
         trackerName.contains(normalizedQuery, ignoreCase = true) ||
-        (statusText?.contains(normalizedQuery, ignoreCase = true) == true) ||
-        (progressText?.contains(normalizedQuery, ignoreCase = true) == true)
+        statusText?.contains(normalizedQuery, ignoreCase = true) == true ||
+        progressText?.contains(normalizedQuery, ignoreCase = true) == true
 }
 
 internal fun remoteTrackerProgressText(track: RemoteTrackerTrack): String? {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -45,6 +45,7 @@ import eu.kanade.tachiyomi.data.connections.discord.DiscordRPCService
 import eu.kanade.tachiyomi.data.connections.discord.DiscordScreen
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
+import eu.kanade.tachiyomi.data.track.TrackStatus
 import eu.kanade.tachiyomi.data.sync.SyncDataJob
 import eu.kanade.tachiyomi.ui.browse.source.SourcesScreen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
@@ -119,28 +120,38 @@ data object LibraryTab : Tab {
         val snackbarHostState = remember { SnackbarHostState() }
 
         val onClickRefresh: (Category?) -> Boolean = { category ->
-            // SY -->
-            val started = LibraryUpdateJob.startNow(
-                context = context,
-                category = if (state.groupType == LibraryGroup.BY_DEFAULT) category else null,
-                group = state.groupType,
-                groupExtra = when (state.groupType) {
-                    LibraryGroup.BY_DEFAULT -> null
-                    LibraryGroup.BY_SOURCE, LibraryGroup.BY_TRACK_STATUS -> category?.id?.toString()
-                    LibraryGroup.BY_STATUS -> category?.id?.minus(1)?.toString()
-                    else -> null
-                },
-            )
-            // SY <--
-            scope.launch {
-                val msgRes = when {
-                    !started -> MR.strings.update_already_running
-                    category != null -> MR.strings.updating_category
-                    else -> MR.strings.updating_library
+            if (category?.id == TrackStatus.NOT_IN_LIBRARY.int.toLong()) {
+                val started = screenModel.refreshRemoteTrackerItems()
+                scope.launch {
+                    if (started) {
+                        snackbarHostState.showSnackbar(context.stringResource(MR.strings.refreshing_tracker_entries))
+                    }
                 }
-                snackbarHostState.showSnackbar(context.stringResource(msgRes))
+                started
+            } else {
+                // SY -->
+                val started = LibraryUpdateJob.startNow(
+                    context = context,
+                    category = if (state.groupType == LibraryGroup.BY_DEFAULT) category else null,
+                    group = state.groupType,
+                    groupExtra = when (state.groupType) {
+                        LibraryGroup.BY_DEFAULT -> null
+                        LibraryGroup.BY_SOURCE, LibraryGroup.BY_TRACK_STATUS -> category?.id?.toString()
+                        LibraryGroup.BY_STATUS -> category?.id?.minus(1)?.toString()
+                        else -> null
+                    },
+                )
+                // SY <--
+                scope.launch {
+                    val msgRes = when {
+                        !started -> MR.strings.update_already_running
+                        category != null -> MR.strings.updating_category
+                        else -> MR.strings.updating_library
+                    }
+                    snackbarHostState.showSnackbar(context.stringResource(msgRes))
+                }
+                started
             }
-            started
         }
 
         Scaffold(
@@ -286,7 +297,7 @@ data object LibraryTab : Tab {
                 state.isLoading -> {
                     LoadingScreen(Modifier.padding(contentPadding))
                 }
-                state.searchQuery.isNullOrEmpty() && !state.hasActiveFilters && state.isLibraryEmpty -> {
+                state.searchQuery.isNullOrEmpty() && !state.hasActiveFilters && state.isLibraryEmpty && !state.hasRemoteTrackerItems -> {
                     val handler = LocalUriHandler.current
                     EmptyScreen(
                         stringRes = MR.strings.information_empty_library,
@@ -314,6 +325,9 @@ data object LibraryTab : Tab {
                         showPageTabs = state.showCategoryTabs || !state.searchQuery.isNullOrEmpty(),
                         onChangeCurrentPage = screenModel::updateActiveCategoryIndex,
                         onClickManga = { navigator.push(MangaScreen(it)) },
+                        onClickRemoteTrack = { item ->
+                            navigator.push(GlobalSearchScreen(item.track.title))
+                        },
                         onContinueReadingClicked = { it: LibraryManga ->
                             scope.launchIO {
                                 val chapter = screenModel.getNextUnreadChapter(it.manga)
@@ -339,7 +353,7 @@ data object LibraryTab : Tab {
                         getItemCountForCategory = { state.getItemCountForCategory(it) },
                         getDisplayMode = { screenModel.getDisplayMode() },
                         getColumnsForOrientation = { screenModel.getColumnsForOrientation(it) },
-                        getItemsForCategory = { state.getItemsForCategory(it) },
+                        getDisplayItemsForCategory = { state.getDisplayItemsForCategory(it) },
                     )
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -326,7 +326,7 @@ data object LibraryTab : Tab {
                         onChangeCurrentPage = screenModel::updateActiveCategoryIndex,
                         onClickManga = { navigator.push(MangaScreen(it)) },
                         onClickRemoteTrack = { item ->
-                            navigator.push(GlobalSearchScreen(item.track.title))
+                            navigator.push(GlobalSearchScreen(item.track.title, initialTrackSearch = item.track.toTrackSearch()))
                         },
                         onContinueReadingClicked = { it: LibraryManga ->
                             scope.launchIO {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -61,6 +61,7 @@ import eu.kanade.presentation.theme.TachiyomiTheme
 import eu.kanade.presentation.util.AssistContentScreen
 import eu.kanade.presentation.util.Screen
 import eu.kanade.presentation.util.isTabletUi
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.isLocalOrStub
@@ -129,6 +130,7 @@ class MangaScreen(
      */
     val fromSource: Boolean = false,
     private val smartSearchConfig: SourcesScreen.SmartSearchConfig? = null,
+    private val initialTrackSearch: TrackSearch? = null,
 ) : Screen(), AssistContentScreen {
 
     private var assistUrl: String? = null
@@ -152,6 +154,7 @@ class MangaScreen(
                 lifecycle = lifecycleOwner.lifecycle,
                 mangaId = mangaId,
                 isFromSource = fromSource,
+                initialTrackSearch = initialTrackSearch,
                 smartSearched = smartSearchConfig != null,
             )
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -57,6 +57,7 @@ import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.track.EnhancedTracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.data.track.mdlist.MdList
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.HttpException
 import eu.kanade.tachiyomi.source.PagePreviewSource
 import eu.kanade.tachiyomi.source.Source
@@ -178,6 +179,7 @@ class MangaScreenModel(
     // SY -->
     /** If it is opened from Source then it will auto expand the manga description */
     private val isFromSource: Boolean,
+    private val initialTrackSearch: TrackSearch? = null,
     private val smartSearched: Boolean,
     // SY <--
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
@@ -270,6 +272,7 @@ class MangaScreenModel(
 
     private val selectedPositions: Array<Int> = arrayOf(-1, -1) // first and last selected index in list
     private val selectedChapterIds: HashSet<Long> = HashSet()
+    private var pendingTrackSearch: TrackSearch? = initialTrackSearch
 
     internal var showTrackDialogAfterCategorySelection: Boolean = false
 
@@ -844,6 +847,7 @@ class MangaScreenModel(
                         val result = updateManga.awaitUpdateFavorite(manga.id, true)
                         if (!result) return@launchIO
                         moveMangaToCategory(defaultCategory)
+                        onMangaAddedToLibrary(manga, state.source, openTrackDialog = true)
                     }
 
                     // Automatic 'Default' or no categories
@@ -851,19 +855,15 @@ class MangaScreenModel(
                         val result = updateManga.awaitUpdateFavorite(manga.id, true)
                         if (!result) return@launchIO
                         moveMangaToCategory(null)
+                        onMangaAddedToLibrary(manga, state.source, openTrackDialog = true)
                     }
 
                     // Choose a category
                     else -> {
                         showTrackDialogAfterCategorySelection = true
                         showChangeCategoryDialog()
+                        return@launchIO
                     }
-                }
-
-                // Finally match with enhanced tracking when available
-                addTracks.bindEnhancedTrackers(manga, state.source)
-                if (autoOpenTrack && !showTrackDialogAfterCategorySelection) {
-                    showTrackDialog()
                 }
             }
         }
@@ -974,7 +974,37 @@ class MangaScreenModel(
         if (manga.favorite) return
 
         screenModelScope.launchIO {
-            updateManga.awaitUpdateFavorite(manga.id, true)
+            if (updateManga.awaitUpdateFavorite(manga.id, true)) {
+                successState?.source?.let { source ->
+                    onMangaAddedToLibrary(manga, source, openTrackDialog = false)
+                }
+            }
+        }
+    }
+
+    private suspend fun onMangaAddedToLibrary(
+        manga: Manga,
+        source: Source,
+        openTrackDialog: Boolean,
+    ) {
+        bindPendingTrackSearch(manga.id)
+        addTracks.bindEnhancedTrackers(manga, source)
+        if (autoOpenTrack && openTrackDialog) {
+            showTrackDialog()
+        }
+    }
+
+    private suspend fun bindPendingTrackSearch(mangaId: Long) {
+        val trackSearch = pendingTrackSearch ?: return
+        val tracker = trackerManager.get(trackSearch.tracker_id) ?: return
+
+        try {
+            addTracks.bind(tracker, trackSearch, mangaId)
+            pendingTrackSearch = null
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) {
+                "Failed to bind pending tracker entry trackerId=${trackSearch.tracker_id} remoteId=${trackSearch.remote_id}"
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -40,6 +40,7 @@ import eu.kanade.domain.manga.model.downloadedFilter
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.track.interactor.AddTracks
+import eu.kanade.domain.track.interactor.bindTrackSearchToManga
 import eu.kanade.domain.track.interactor.RefreshTracks
 import eu.kanade.domain.track.interactor.TrackChapter
 import eu.kanade.domain.track.model.AutoTrackState
@@ -996,15 +997,15 @@ class MangaScreenModel(
 
     private suspend fun bindPendingTrackSearch(mangaId: Long) {
         val trackSearch = pendingTrackSearch ?: return
-        val tracker = trackerManager.get(trackSearch.tracker_id) ?: return
-
-        try {
-            addTracks.bind(tracker, trackSearch, mangaId)
+        if (
+            bindTrackSearchToManga(
+                trackSearch = trackSearch,
+                mangaId = mangaId,
+                trackerManager = trackerManager,
+                addTracks = addTracks,
+            )
+        ) {
             pendingTrackSearch = null
-        } catch (e: Exception) {
-            logcat(LogPriority.WARN, e) {
-                "Failed to bind pending tracker entry trackerId=${trackSearch.tracker_id} remoteId=${trackSearch.remote_id}"
-            }
         }
     }
 

--- a/app/src/test/java/eu/kanade/domain/track/interactor/AddTracksTest.kt
+++ b/app/src/test/java/eu/kanade/domain/track/interactor/AddTracksTest.kt
@@ -1,0 +1,53 @@
+package eu.kanade.domain.track.interactor
+
+import eu.kanade.tachiyomi.data.track.Tracker
+import eu.kanade.tachiyomi.data.track.TrackerManager
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.track.interactor.InsertTrack
+
+class AddTracksTest {
+
+    @Test
+    fun bind_assignsMangaIdBeforeBindingAndInsert() = runBlocking {
+        val insertTrack = mockk<InsertTrack>()
+        val syncChapterProgressWithTrack = mockk<SyncChapterProgressWithTrack>()
+        val getChaptersByMangaId = mockk<GetChaptersByMangaId>()
+        val trackerManager = mockk<TrackerManager>(relaxed = true)
+        val tracker = mockk<Tracker>()
+
+        val trackSearch = TrackSearch.create(1L).apply {
+            remote_id = 321L
+            title = "Blue Box"
+            tracking_url = "https://example.com/track/321"
+        }
+        val insertedTrack = slot<tachiyomi.domain.track.model.Track>()
+
+        coEvery { getChaptersByMangaId.await(42L) } returns emptyList()
+        coEvery { tracker.bind(trackSearch, false) } returns trackSearch
+        coEvery { insertTrack.await(capture(insertedTrack)) } returns Unit
+        coEvery { syncChapterProgressWithTrack.await(42L, any(), tracker) } returns null
+
+        AddTracks(
+            insertTrack = insertTrack,
+            syncChapterProgressWithTrack = syncChapterProgressWithTrack,
+            getChaptersByMangaId = getChaptersByMangaId,
+            trackerManager = trackerManager,
+        ).bind(
+            tracker = tracker,
+            item = trackSearch,
+            mangaId = 42L,
+        )
+
+        assertEquals(42L, trackSearch.manga_id)
+        assertEquals(42L, insertedTrack.captured.mangaId)
+        coVerify(exactly = 1) { tracker.bind(match { it.manga_id == 42L }, false) }
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerRemoteEntryMappingTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerRemoteEntryMappingTest.kt
@@ -1,0 +1,136 @@
+package eu.kanade.tachiyomi.data.track
+
+import eu.kanade.tachiyomi.data.track.anilist.Anilist
+import eu.kanade.tachiyomi.data.track.anilist.AnilistApi
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALEdge
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALFuzzyDate
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALItemTitle
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALSearchItem
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALStaff
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALStaffName
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALStaffNode
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALUserListItem
+import eu.kanade.tachiyomi.data.track.anilist.dto.ItemCover
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALUserListResult
+import eu.kanade.tachiyomi.ui.library.toRemoteTrackerTrack
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class TrackerRemoteEntryMappingTest {
+
+    @Test
+    fun anilistUserListItem_mapsToTrackSearch() {
+        val result = ALUserListItem(
+            id = 55L,
+            status = "CURRENT",
+            scoreRaw = 80,
+            progress = 12,
+            startedAt = ALFuzzyDate(year = 2024, month = 1, day = 2),
+            completedAt = ALFuzzyDate(year = null, month = null, day = null),
+            media = ALSearchItem(
+                id = 1234L,
+                title = ALItemTitle("Blue Box"),
+                coverImage = ItemCover("https://example.com/blue-box.jpg"),
+                description = null,
+                format = "MANGA",
+                status = "RELEASING",
+                startDate = ALFuzzyDate(year = 2021, month = 4, day = 1),
+                chapters = 150L,
+                averageScore = 91,
+                staff = ALStaff(
+                    edges = listOf(
+                        ALEdge("Story", ALStaffNode(ALStaffName(userPreferred = "Author", native = null, full = null))),
+                    ),
+                ),
+            ),
+            private = true,
+        )
+            .toALUserManga()
+            .toTrackSearch()
+
+        assertEquals(TrackerManager.ANILIST, result.tracker_id)
+        assertEquals(1234L, result.remote_id)
+        assertEquals("Blue Box", result.title)
+        assertEquals(Anilist.READING, result.status)
+        assertEquals(12.0, result.last_chapter_read)
+        assertEquals(150L, result.total_chapters)
+        assertEquals("https://example.com/blue-box.jpg", result.cover_url)
+        assertEquals(AnilistApi.mangaUrl(1234L), result.tracking_url)
+        assertEquals(80.0, result.score)
+        assertEquals(55L, result.library_id)
+        assertEquals(true, result.private)
+    }
+
+    @Test
+    fun malUserListResult_deserializesMyListStatusAlias() {
+        val json = Json { ignoreUnknownKeys = true }
+        val result = json.decodeFromString<MALUserListResult>(
+            """
+            {
+              "data": [
+                {
+                  "node": {
+                    "id": 321,
+                    "title": "Blue Box",
+                    "num_chapters": 100,
+                    "main_picture": null,
+                    "status": "finished",
+                    "media_type": "manga",
+                    "start_date": null
+                  },
+                  "my_list_status": {
+                    "is_rereading": true,
+                    "status": "reading",
+                    "num_chapters_read": 40,
+                    "score": 9,
+                    "start_date": "2024-01-01",
+                    "finish_date": null
+                  }
+                }
+              ],
+              "paging": {
+                "next": null
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val entry = result.data.single()
+        assertEquals(321L, entry.node.id)
+        assertEquals("Blue Box", entry.node.title)
+        assertEquals(100L, entry.node.numChapters)
+        assertEquals(true, entry.listStatus?.isRereading)
+        assertEquals("reading", entry.listStatus?.status)
+        assertEquals(40.0, entry.listStatus?.numChaptersRead)
+        assertEquals(9, entry.listStatus?.score)
+        assertEquals("2024-01-01", entry.listStatus?.startDate)
+        assertNull(entry.listStatus?.finishDate)
+    }
+
+    @Test
+    fun trackSearch_mapsToRemoteTrackerTrack_withoutDroppingFields() {
+        val track = TrackSearch.create(TrackerManager.ANILIST).apply {
+            remote_id = 9001L
+            title = "Remote Title"
+            cover_url = "https://example.com/cover.jpg"
+            status = 7L
+            last_chapter_read = 22.0
+            total_chapters = 24L
+            tracking_url = "https://example.com/title"
+        }
+
+        val result = track.toRemoteTrackerTrack()
+
+        assertEquals(TrackerManager.ANILIST, result.trackerId)
+        assertEquals(9001L, result.remoteId)
+        assertEquals("Remote Title", result.title)
+        assertEquals("https://example.com/cover.jpg", result.coverUrl)
+        assertEquals(7L, result.status)
+        assertEquals(22.0, result.lastChapterRead)
+        assertEquals(24L, result.totalChapters)
+        assertEquals("https://example.com/title", result.trackingUrl)
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerRemoteEntryMappingTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerRemoteEntryMappingTest.kt
@@ -12,7 +12,9 @@ import eu.kanade.tachiyomi.data.track.anilist.dto.ALStaffNode
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALUserListItem
 import eu.kanade.tachiyomi.data.track.anilist.dto.ItemCover
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import eu.kanade.tachiyomi.ui.library.RemoteTrackerTrack
 import eu.kanade.tachiyomi.data.track.myanimelist.dto.MALUserListResult
+import eu.kanade.tachiyomi.ui.library.toTrackSearch
 import eu.kanade.tachiyomi.ui.library.toRemoteTrackerTrack
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -132,5 +134,29 @@ class TrackerRemoteEntryMappingTest {
         assertEquals(22.0, result.lastChapterRead)
         assertEquals(24L, result.totalChapters)
         assertEquals("https://example.com/title", result.trackingUrl)
+    }
+
+    @Test
+    fun remoteTrackerTrack_mapsBackToTrackSearch_forPendingBinding() {
+        val track = RemoteTrackerTrack(
+            trackerId = 1L,
+            remoteId = 321L,
+            title = "Blue Box",
+            coverUrl = "https://example.com/cover.jpg",
+            status = 4L,
+            lastChapterRead = 40.0,
+            totalChapters = 100L,
+            trackingUrl = "https://example.com/tracking",
+        )
+
+        val result = track.toTrackSearch()
+
+        assertEquals(1L, result.tracker_id)
+        assertEquals(321L, result.remote_id)
+        assertEquals("Blue Box", result.title)
+        assertEquals(4L, result.status)
+        assertEquals(40.0, result.last_chapter_read)
+        assertEquals(100L, result.total_chapters)
+        assertEquals("https://example.com/tracking", result.tracking_url)
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/source/globalsearch/SearchScreenModelTest.kt
@@ -1,0 +1,36 @@
+package eu.kanade.tachiyomi.ui.browse.source.globalsearch
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SearchScreenModelTest {
+
+    @Test
+    fun normalizeSearchSourceFilter_switchesToAllWhenPinnedOnlyHasNoPinnedSources() {
+        assertEquals(
+            SourceFilter.All,
+            normalizeSearchSourceFilter(
+                currentFilter = SourceFilter.PinnedOnly,
+                hasPinnedSources = false,
+            ),
+        )
+    }
+
+    @Test
+    fun normalizeSearchSourceFilter_keepsCurrentFilterOtherwise() {
+        assertEquals(
+            SourceFilter.PinnedOnly,
+            normalizeSearchSourceFilter(
+                currentFilter = SourceFilter.PinnedOnly,
+                hasPinnedSources = true,
+            ),
+        )
+        assertEquals(
+            SourceFilter.All,
+            normalizeSearchSourceFilter(
+                currentFilter = SourceFilter.All,
+                hasPinnedSources = false,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/library/RemoteTrackerLibraryTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/library/RemoteTrackerLibraryTest.kt
@@ -1,0 +1,255 @@
+package eu.kanade.tachiyomi.ui.library
+
+import android.content.Context
+import eu.kanade.tachiyomi.data.track.BaseTracker
+import eu.kanade.tachiyomi.data.track.Tracker
+import eu.kanade.tachiyomi.data.track.TrackerManager
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.library.model.LibraryManga
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.domain.track.model.Track
+
+class RemoteTrackerLibraryTest {
+
+    @Test
+    fun buildTrackedRemoteKeys_onlyIncludesFavoriteLibraryTracks() {
+        val favorites = listOf(
+            libraryItem(id = 10L),
+            libraryItem(id = 30L),
+        )
+        val tracksMap = mapOf(
+            10L to listOf(track(mangaId = 10L, trackerId = 1L, remoteId = 100L)),
+            20L to listOf(track(mangaId = 20L, trackerId = 2L, remoteId = 200L)),
+            30L to listOf(track(mangaId = 30L, trackerId = TrackerManager.ANILIST, remoteId = 300L)),
+        )
+
+        val result = buildTrackedRemoteKeys(favorites, tracksMap)
+
+        assertEquals(
+            setOf(
+                RemoteTrackKey(1L, 100L),
+                RemoteTrackKey(TrackerManager.ANILIST, 300L),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun buildRemoteTrackerLibraryItems_excludesTrackedAndUnsupportedEntries() {
+        val trackerManager = trackerManager(
+            tracker(trackerId = 1L, trackerName = "MyAnimeList"),
+            tracker(trackerId = TrackerManager.ANILIST, trackerName = "AniList"),
+        )
+
+        val result = buildRemoteTrackerLibraryItems(
+            remoteTracks = listOf(
+                remoteTrack(trackerId = 1L, remoteId = 100L, title = "Tracked"),
+                remoteTrack(
+                    trackerId = TrackerManager.ANILIST,
+                    remoteId = 200L,
+                    title = "Keep Me",
+                    lastChapterRead = 5.0,
+                    totalChapters = 12L,
+                ),
+                remoteTrack(trackerId = 99L, remoteId = 300L, title = "Unsupported"),
+            ),
+            trackedKeys = setOf(RemoteTrackKey(1L, 100L)),
+            trackerManager = trackerManager,
+            context = mockk(relaxed = true),
+            searchQuery = null,
+        )
+
+        assertEquals(1, result.size)
+        assertEquals("Keep Me", result.single().track.title)
+        assertEquals("AniList", result.single().trackerName)
+        assertEquals("AL", result.single().trackerShortName)
+        assertEquals("5/12", result.single().progressText)
+    }
+
+    @Test
+    fun buildRemoteTrackerLibraryItems_sortsAndFiltersByQuery() {
+        val trackerManager = trackerManager(
+            tracker(trackerId = 1L, trackerName = "MyAnimeList"),
+            tracker(trackerId = TrackerManager.ANILIST, trackerName = "AniList"),
+        )
+        val remoteTracks = listOf(
+            remoteTrack(
+                trackerId = 1L,
+                remoteId = 100L,
+                title = "Alpha",
+                lastChapterRead = 1.0,
+                totalChapters = 10L,
+            ),
+            remoteTrack(
+                trackerId = TrackerManager.ANILIST,
+                remoteId = 200L,
+                title = "alpha",
+                lastChapterRead = 5.0,
+                totalChapters = 12L,
+            ),
+            remoteTrack(trackerId = 1L, remoteId = 300L, title = "Zeta"),
+        )
+
+        val sorted = buildRemoteTrackerLibraryItems(
+            remoteTracks = remoteTracks,
+            trackedKeys = emptySet(),
+            trackerManager = trackerManager,
+            context = mockk(relaxed = true),
+            searchQuery = null,
+        )
+
+        assertEquals(
+            listOf(
+                "${TrackerManager.ANILIST}:200",
+                "1:100",
+                "1:300",
+            ),
+            sorted.map { it.key },
+        )
+
+        val byTracker = buildRemoteTrackerLibraryItems(
+            remoteTracks = remoteTracks,
+            trackedKeys = emptySet(),
+            trackerManager = trackerManager,
+            context = mockk(relaxed = true),
+            searchQuery = "MyAnimeList",
+        )
+        assertEquals(listOf("Alpha", "Zeta"), byTracker.map { it.track.title })
+
+        val byProgress = buildRemoteTrackerLibraryItems(
+            remoteTracks = remoteTracks,
+            trackedKeys = emptySet(),
+            trackerManager = trackerManager,
+            context = mockk(relaxed = true),
+            searchQuery = "5/12",
+        )
+        assertEquals(listOf("alpha"), byProgress.map { it.track.title })
+    }
+
+    @Test
+    fun remoteTrackerItemMatchesQuery_checksAllVisibleFields() {
+        val item = RemoteTrackerLibraryItem(
+            track = remoteTrack(trackerId = 1L, remoteId = 100L, title = "Blue Box"),
+            trackerName = "MyAnimeList",
+            trackerShortName = "MAL",
+            statusText = "Reading",
+            progressText = "7/12",
+        )
+
+        assertTrue(item.matchesQuery("blue"))
+        assertTrue(item.matchesQuery("anime"))
+        assertTrue(item.matchesQuery("reading"))
+        assertTrue(item.matchesQuery("7/12"))
+        assertFalse(item.matchesQuery("dropped"))
+    }
+
+    @Test
+    fun remoteTrackerProgressText_formatsOnlyAvailableValues() {
+        assertEquals(
+            "3/10",
+            remoteTrackerProgressText(remoteTrack(trackerId = 1L, remoteId = 1L, title = "A", lastChapterRead = 3.0, totalChapters = 10L)),
+        )
+        assertEquals(
+            "3",
+            remoteTrackerProgressText(remoteTrack(trackerId = 1L, remoteId = 2L, title = "B", lastChapterRead = 3.0)),
+        )
+        assertEquals(
+            null,
+            remoteTrackerProgressText(remoteTrack(trackerId = 1L, remoteId = 3L, title = "C")),
+        )
+    }
+
+    @Test
+    fun trackerBadgeLabel_usesKnownShortNames() {
+        assertEquals("MAL", trackerBadgeLabel(1L, "MyAnimeList"))
+        assertEquals("AL", trackerBadgeLabel(TrackerManager.ANILIST, "AniList"))
+        assertEquals("Custom", trackerBadgeLabel(99L, "Custom"))
+    }
+
+    private fun trackerManager(vararg trackers: BaseTracker): TrackerManager {
+        val trackersById = trackers.associateBy { it.id }
+        val trackerManager = mockk<TrackerManager>()
+        trackersById.forEach { (trackerId, tracker) ->
+            every { trackerManager.get(trackerId) } returns tracker
+        }
+        every { trackerManager.get(match { it !in trackersById }) } returns null
+        return trackerManager
+    }
+
+    private fun tracker(
+        trackerId: Long,
+        trackerName: String,
+    ): BaseTracker {
+        return mockk(relaxed = true) {
+            every { this@mockk.id } returns trackerId
+            every { this@mockk.name } returns trackerName
+            every { getStatus(any()) } returns null
+        }
+    }
+
+    private fun remoteTrack(
+        trackerId: Long,
+        remoteId: Long,
+        title: String,
+        lastChapterRead: Double = 0.0,
+        totalChapters: Long = 0L,
+    ) = RemoteTrackerTrack(
+        trackerId = trackerId,
+        remoteId = remoteId,
+        title = title,
+        coverUrl = "",
+        status = 999L,
+        lastChapterRead = lastChapterRead,
+        totalChapters = totalChapters,
+        trackingUrl = "",
+    )
+
+    private fun libraryItem(id: Long): LibraryItem {
+        return LibraryItem(
+            libraryManga = LibraryManga(
+                manga = Manga.create().copy(
+                    id = id,
+                    source = 1L,
+                    ogTitle = "Manga $id",
+                ),
+                categories = emptyList(),
+                totalChapters = 0L,
+                readCount = 0L,
+                bookmarkCount = 0L,
+                bookmarkReadCount = 0L,
+                chapterFlags = 0L,
+                latestUpload = 0L,
+                chapterFetchedAt = 0L,
+                lastRead = 0L,
+            ),
+            sourceManager = mockk<SourceManager>(relaxed = true),
+        )
+    }
+
+    private fun track(
+        mangaId: Long,
+        trackerId: Long,
+        remoteId: Long,
+    ) = Track(
+        id = remoteId,
+        mangaId = mangaId,
+        trackerId = trackerId,
+        remoteId = remoteId,
+        libraryId = null,
+        title = "Track $remoteId",
+        lastChapterRead = 0.0,
+        totalChapters = 0L,
+        status = 0L,
+        score = 0.0,
+        remoteUrl = "",
+        startDate = 0L,
+        finishDate = 0L,
+        private = false,
+    )
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/library/RemoteTrackerLibraryTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/library/RemoteTrackerLibraryTest.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.library
 
 import android.content.Context
 import eu.kanade.tachiyomi.data.track.BaseTracker
+import eu.kanade.tachiyomi.data.track.TrackStatus
 import eu.kanade.tachiyomi.data.track.Tracker
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import io.mockk.every
@@ -9,7 +10,10 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.library.model.LibraryGroup
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.service.SourceManager
@@ -170,6 +174,52 @@ class RemoteTrackerLibraryTest {
         assertEquals("MAL", trackerBadgeLabel(1L, "MyAnimeList"))
         assertEquals("AL", trackerBadgeLabel(TrackerManager.ANILIST, "AniList"))
         assertEquals("Custom", trackerBadgeLabel(99L, "Custom"))
+    }
+
+    @Test
+    fun trackerCoverId_packsValuesAndRejectsOutOfRangeInputs() {
+        assertEquals(
+            Long.MIN_VALUE or (1L shl 56) or 2L,
+            trackerCoverId(trackerId = 1L, remoteId = 2L),
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            trackerCoverId(trackerId = 128L, remoteId = 2L)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            trackerCoverId(trackerId = 1L, remoteId = 0x0100000000000000L)
+        }
+    }
+
+    @Test
+    fun buildDisplayedCategories_appendsSyntheticNotInLibraryCategory() {
+        val localCategory = Category(
+            id = 1L,
+            name = "Reading",
+            order = 1L,
+            flags = 0,
+            hidden = false,
+        )
+
+        val categories = buildDisplayedCategories(
+            groupedFavorites = mapOf(localCategory to listOf(1L)),
+            remoteTrackerItems = listOf(
+                RemoteTrackerLibraryItem(
+                    track = remoteTrack(trackerId = 1L, remoteId = 100L, title = "Blue Box"),
+                    trackerName = "MyAnimeList",
+                    trackerShortName = "MAL",
+                    statusText = "Reading",
+                    progressText = "1/10",
+                ),
+            ),
+            groupType = LibraryGroup.BY_TRACK_STATUS,
+            notInLibraryCategoryName = "Not in Library",
+        )
+
+        assertEquals(
+            listOf(1L, TrackStatus.NOT_IN_LIBRARY.int.toLong()),
+            categories.map { it.id },
+        )
+        assertEquals("Not in Library", categories.last().name)
     }
 
     private fun trackerManager(vararg trackers: BaseTracker): TrackerManager {

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -535,6 +535,9 @@
     <string name="pref_auto_update_manga_on_mark_read">Update progress when marked as read</string>
     <string name="services">Trackers</string>
     <string name="tracking_info">One-way sync to update the chapter progress in external tracker services. Set up tracking for individual entries from their tracking button.</string>
+    <string name="pref_tracker_show_not_in_library_entries">Show tracker entries not in library</string>
+    <string name="pref_tracker_show_not_in_library_entries_summary">When grouping by tracker status, add a Not in Library tab for supported trackers.</string>
+    <string name="tracker_not_in_library_supported">Not in Library</string>
     <string name="enhanced_services">Enhanced trackers</string>
     <string name="enhanced_services_not_installed">Available but source not installed: %s</string>
     <string name="enhanced_tracking_info">Provides enhanced features for specific sources. Entries are automatically tracked when added to your library.</string>
@@ -885,6 +888,8 @@
     <string name="copy">Copy</string>
     <string name="empty_screen">Well, this is awkward</string>
     <string name="not_installed">Not installed</string>
+    <string name="not_in_library">Not in Library</string>
+    <string name="refreshing_tracker_entries">Refreshing tracker entries</string>
 
     <!-- Crash screen -->
     <string name="crash_screen_title">Whoops!</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -537,7 +537,7 @@
     <string name="tracking_info">One-way sync to update the chapter progress in external tracker services. Set up tracking for individual entries from their tracking button.</string>
     <string name="pref_tracker_show_not_in_library_entries">Show tracker entries not in library</string>
     <string name="pref_tracker_show_not_in_library_entries_summary">When grouping by tracker status, add a Not in Library tab for supported trackers.</string>
-    <string name="tracker_not_in_library_supported">Not in Library</string>
+    <string name="tracker_not_in_library_supported">Supports &quot;Not in Library&quot; tracking</string>
     <string name="enhanced_services">Enhanced trackers</string>
     <string name="enhanced_services_not_installed">Available but source not installed: %s</string>
     <string name="enhanced_tracking_info">Provides enhanced features for specific sources. Entries are automatically tracked when added to your library.</string>


### PR DESCRIPTION
## Summary
Closes #1556.

Adds an opt-in tracker-only `Not in Library` tab when the library is grouped by `Tracker Status`, with support for MyAnimeList and AniList.

## What changed
- added a new Tracking preference to enable or disable tracker-only `Not in Library` entries
- marked the supported tracker rows in settings with `Supports "Not in Library" tracking`
- added explicit remote-list support for MyAnimeList and AniList so their unmatched tracker entries can be loaded into the library UI
- added a synthetic `Not in Library` tracker-status tab that appears after the normal tracker-status groups
- rendered tracker-only entries in the existing library list/grid layouts with tracker badge, status, and progress
- routed tracker-only entries to Global Search with the tracker title prefilled
- carried the originating tracker entry through the add-to-library flow so favoriting the manga automatically binds the existing tracker record
- fixed the cold-start Global Search handoff so the first tap works even when no pinned sources are configured
- added regression coverage for tracker entry mapping, remote-only library grouping, the pending bind flow, and the search filter normalization

## Verification
- `:app:testDebugUnitTest --tests 'eu.kanade.domain.track.interactor.AddTracksTest' --tests 'eu.kanade.tachiyomi.ui.browse.source.globalsearch.SearchScreenModelTest' --tests 'eu.kanade.tachiyomi.data.track.TrackerRemoteEntryMappingTest' --tests 'eu.kanade.tachiyomi.ui.library.RemoteTrackerLibraryTest'`
- `:app:compileDebugKotlin`
- `:app:assembleDebug`
- manual APK testing covered:
  - the `Not in Library` tab and supported tracker indicator
  - adding a title from the tracker-only handoff and confirming it no longer ends up in `Not tracked`
  - opening Global Search from a `Not in Library` item on a cold start

## Notes
- the `Not in Library` tab is intentionally opt-in to avoid unexpected tracker list fetches
- tracker-only rows are ephemeral UI entries and do not participate in library selection or bulk actions
- entries from different trackers are shown separately rather than cross-deduplicated

## Summary by Sourcery

Add an opt-in "Not in Library" tracker tab and remote tracker entry integration for supported services when grouping the library by tracker status.

New Features:
- Introduce a library grouping tab that surfaces tracker entries not yet in the local library for supported trackers when enabled in settings.
- Allow opening tracker-only entries into Global Search and carrying the tracker context through to source and manga screens so adding to library auto-binds the track record.

Bug Fixes:
- Normalize global search source filter behavior so cold-start searches work when no pinned sources are configured.

Enhancements:
- Render tracker-only items alongside local library entries in list and grid layouts with appropriate tracker badges and progress display.
- Extend MyAnimeList and AniList APIs and tracker implementations to fetch and map full remote lists for use as tracker-only library entries.
- Augment tracking settings UI to indicate trackers that support "Not in Library" entries and add a toggle to show or hide these entries.
- Refine library pager and refresh behavior to support the synthetic "Not in Library" category without affecting normal library updates.

Tests:
- Add unit tests covering remote tracker entry mapping, library display of remote-only items, pending tracker binding on add-to-library, and global search filter normalization.