### PR TITLE
feat: split "sync on add" into separate metadata and chapter fetch preferences

### DIFF
--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -200,7 +200,7 @@ class SyncChaptersWithSource(
                 bookmark = chapter.chapterNumber in deletedBookmarkedChapterNumbers,
             )
 
-            // Try to to use the fetch date of the original entry to not pollute 'Updates' tab
+            // Try to use the fetch date of the original entry to not pollute 'Updates' tab
             deletedChapterNumberDateFetchMap[chapter.chapterNumber]?.let {
                 chapter = chapter.copy(dateFetch = it)
             }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -293,9 +293,14 @@ object SettingsLibraryScreen : SearchableSettings {
                     title = stringResource(KMR.strings.pref_show_empty_categories_search),
                 ),
                 Preference.PreferenceItem.SwitchPreference(
-                    preference = libraryPreferences.syncOnAdd(),
-                    title = stringResource(KMR.strings.pref_sync_manga_on_add),
-                    subtitle = stringResource(KMR.strings.pref_sync_manga_on_add_description),
+                    preference = libraryPreferences.fetchMetadataOnAdd(),
+                    title = stringResource(KMR.strings.pref_fetch_manga_metadata_on_add),
+                    subtitle = stringResource(KMR.strings.pref_fetch_manga_metadata_on_add_description),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.fetchChaptersOnAdd(),
+                    title = stringResource(KMR.strings.pref_fetch_manga_chapters_on_add),
+                    subtitle = stringResource(KMR.strings.pref_fetch_manga_chapters_on_add_description),
                 ),
                 // KMK <--
             ),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -83,7 +83,7 @@ class BulkFavoriteScreenModel(
     }
 
     /**
-     * @param toSelectedState set to true to only Select, set to false to only Unselect
+     * @param toSelectedState set to `true` to only Select, set to `false` to only Unselect
      */
     fun toggleSelection(manga: Manga, toSelectedState: Boolean? = null) {
         mutableState.update { state ->
@@ -131,7 +131,7 @@ class BulkFavoriteScreenModel(
             if (entryWithDuplicates != null) {
                 val (index, manga, duplicates) = entryWithDuplicates
                 if (state.value.selection.size == 1) {
-                    // If only one manga is selected, show the multiple duplicates dialog.
+                    // If only one manga is selected, show the multiple-duplicates dialog.
                     setDialog(Dialog.AddDuplicateManga(manga, duplicates))
                 } else {
                     setDialog(Dialog.BulkAllowDuplicate(manga, duplicates, index))
@@ -256,13 +256,19 @@ class BulkFavoriteScreenModel(
                 setMangaDefaultChapterFlags.await(manga)
                 addTracks.bindEnhancedTrackers(manga, source)
                 updateManga.awaitUpdateFavorite(manga.id, true)
-                if (libraryPreferences.syncOnAdd().get()) {
+                val fetchMetadataOnAdd = libraryPreferences.fetchMetadataOnAdd().get()
+                val fetchChaptersOnAdd = libraryPreferences.fetchChaptersOnAdd().get()
+                if (fetchMetadataOnAdd || fetchChaptersOnAdd) {
                     val sManga = manga.toSManga()
-                    val remoteManga = source.getMangaDetails(sManga)
-                    val chapters = source.getChapterList(sManga)
-                    // Use `manga` instead of `new` so its title got updated with source's `getMangaDetails`
-                    updateManga.awaitUpdateFromSource(manga, remoteManga, false, coverCache)
-                    syncChaptersWithSource.await(chapters, manga, source, false)
+                    if (fetchMetadataOnAdd) {
+                        val remoteMetadata = source.getMangaDetails(sManga)
+                        // Use `manga` instead of `new` so its title got updated with source's `getMangaDetails`
+                        updateManga.awaitUpdateFromSource(manga, remoteMetadata, false, coverCache)
+                    }
+                    if (fetchChaptersOnAdd) {
+                        val chapters = source.getChapterList(sManga)
+                        syncChaptersWithSource.await(chapters, manga, source, false)
+                    }
                 }
             } catch (e: Exception) {
                 logcat(LogPriority.ERROR, e)
@@ -351,15 +357,21 @@ class BulkFavoriteScreenModel(
             }
 
             updateManga.await(new.toMangaUpdate())
-            if (new.favorite && libraryPreferences.syncOnAdd().get()) {
+            val fetchMetadataOnAdd = libraryPreferences.fetchMetadataOnAdd().get()
+            val fetchChaptersOnAdd = libraryPreferences.fetchChaptersOnAdd().get()
+            if (new.favorite && (fetchMetadataOnAdd || fetchChaptersOnAdd)) {
                 withIOContext {
                     try {
                         val sManga = manga.toSManga()
-                        val remoteManga = source.getMangaDetails(sManga)
-                        val chapters = source.getChapterList(sManga)
-                        // Use `manga` instead of `new` so its title got updated with source's `getMangaDetails`
-                        updateManga.awaitUpdateFromSource(manga, remoteManga, false, coverCache)
-                        syncChaptersWithSource.await(chapters, manga, source, false)
+                        if (fetchMetadataOnAdd) {
+                            val remoteMetadata = source.getMangaDetails(sManga)
+                            // Use `manga` instead of `new` so its title got updated with source's `getMangaDetails`
+                            updateManga.awaitUpdateFromSource(manga, remoteMetadata, false, coverCache)
+                        }
+                        if (fetchChaptersOnAdd) {
+                            val chapters = source.getChapterList(sManga)
+                            syncChaptersWithSource.await(chapters, manga, source, false)
+                        }
                     } catch (e: Exception) {
                         logcat(LogPriority.ERROR, e)
                         snackbarHostState.showSnackbar(message = "Failed to sync manga: ${e.message}")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.ui.browse
 
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -60,7 +59,6 @@ class BulkFavoriteScreenModel(
     private val setMangaDefaultChapterFlags: SetMangaDefaultChapterFlags = Injekt.get(),
     private val addTracks: AddTracks = Injekt.get(),
     private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get(),
-    val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) : StateScreenModel<BulkFavoriteScreenModel.State>(initialState) {
 
     fun backHandler() {
@@ -272,7 +270,6 @@ class BulkFavoriteScreenModel(
                 }
             } catch (e: Exception) {
                 logcat(LogPriority.ERROR, e)
-                snackbarHostState.showSnackbar(message = "Failed to sync manga: ${e.message}")
             }
         }
     }
@@ -374,7 +371,6 @@ class BulkFavoriteScreenModel(
                         }
                     } catch (e: Exception) {
                         logcat(LogPriority.ERROR, e)
-                        snackbarHostState.showSnackbar(message = "Failed to sync manga: ${e.message}")
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -424,15 +424,21 @@ open class BrowseSourceScreenModel(
 
             updateManga.await(new.toMangaUpdate())
             // KMK -->
-            if (new.favorite && libraryPreferences.syncOnAdd().get()) {
+            val fetchMetadataOnAdd = libraryPreferences.fetchMetadataOnAdd().get()
+            val fetchChaptersOnAdd = libraryPreferences.fetchChaptersOnAdd().get()
+            if (new.favorite && (fetchMetadataOnAdd || fetchChaptersOnAdd)) {
                 withIOContext {
                     try {
                         val sManga = manga.toSManga()
-                        val remoteManga = source.getMangaDetails(sManga)
-                        val chapters = source.getChapterList(sManga)
-                        // Use `manga` instead of `new` so its title got updated with source's `getMangaDetails`
-                        updateManga.awaitUpdateFromSource(manga, remoteManga, false, coverCache)
-                        syncChaptersWithSource.await(chapters, manga, source, false)
+                        if (fetchMetadataOnAdd) {
+                            val remoteMetadata = source.getMangaDetails(sManga)
+                            // Use `manga` instead of `new` so its title got updated with source's `getMangaDetails`
+                            updateManga.awaitUpdateFromSource(manga, remoteMetadata, false, coverCache)
+                        }
+                        if (fetchChaptersOnAdd) {
+                            val chapters = source.getChapterList(sManga)
+                            syncChaptersWithSource.await(chapters, manga, source, false)
+                        }
                     } catch (e: Exception) {
                         logcat(LogPriority.ERROR, e)
                         screenModelScope.launch {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -2,7 +2,6 @@ package eu.kanade.tachiyomi.ui.browse.source.browse
 
 import android.content.res.Configuration
 import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -120,7 +119,6 @@ open class BrowseSourceScreenModel(
     private val toggleIncognito: ToggleIncognito = Injekt.get(),
     private val extensionManager: ExtensionManager = Injekt.get(),
     private val syncChaptersWithSource: SyncChaptersWithSource = Injekt.get(),
-    val snackbarHostState: SnackbarHostState = SnackbarHostState(),
     // KMK <--
 
     // SY -->
@@ -441,9 +439,6 @@ open class BrowseSourceScreenModel(
                         }
                     } catch (e: Exception) {
                         logcat(LogPriority.ERROR, e)
-                        screenModelScope.launch {
-                            snackbarHostState.showSnackbar(message = "Failed to sync manga: ${e.message}")
-                        }
                     }
                 }
             }

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -74,7 +74,8 @@ class LibraryPreferences(
     fun autoUpdateMetadata() = preferenceStore.getBoolean("auto_update_metadata", false)
 
     // KMK -->
-    fun syncOnAdd() = preferenceStore.getBoolean("sync_on_add", false)
+    fun fetchMetadataOnAdd() = preferenceStore.getBoolean("fetch_metadata_on_add", false)
+    fun fetchChaptersOnAdd() = preferenceStore.getBoolean("fetch_chapters_on_add", false)
     // KMK <--
 
     fun showContinueReadingButton() = preferenceStore.getBoolean(

--- a/i18n-kmk/src/commonMain/moko-resources/ar/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/ar/strings.xml
@@ -145,9 +145,11 @@
     <string name="pref_library_filter_categories_details">لن يتم عرض العناصر في الفئات المستبعدة حتى لو كانت موجودة أيضًا في الفئات المشمولة.</string>
     <string name="updating">جاري التحديث</string>
     <string name="pref_show_empty_categories_search">عرض الفئات الفارغة أثناء البحث/التصفية</string>
-    <string name="pref_sync_manga_on_add">مزامنة المانجا عند إضافتها إلى المكتبة</string>
-    <string name="pref_sync_manga_on_add_description">يقوم تلقائيًا بجلب البيانات الوصفية وقائمة الفصول الخاصة بمانجا جديدة عند إضافتها إلى المكتبة</string>
     <string name="pref_track_on_add_library">فتح قائمة المزامنة عند الإضافة للمكتبة</string>
+    <string name="pref_fetch_manga_metadata_on_add">تحديث بيانات المانجا عند الإضافة للمكتبة</string>
+    <string name="pref_fetch_manga_metadata_on_add_description">جلب العنوان والوصف والعلامات وغيرها عند إضافة المانجا إلى المكتبة</string>
+    <string name="pref_fetch_manga_chapters_on_add">جلب الفصول عند الإضافة للمكتبة</string>
+    <string name="pref_fetch_manga_chapters_on_add_description">تحديث قائمة الفصول مباشرة بعد إضافة المانجا إلى المكتبة</string>
     <string name="web_dav">WebDAV</string>
     <string name="pref_webdav_url">رابط سيرفر WebDAV</string>
     <string name="pref_webdav_url_summ">ادخل رابط سيرفر WebDAV</string>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -96,8 +96,10 @@
     <string name="pref_library_filter_categories_details">Entries in excluded categories will not be shown even if they are also in included categories.</string>
     <string name="updating">Updating</string>
     <string name="pref_show_empty_categories_search">Show empty categories during search/filtering</string>
-    <string name="pref_sync_manga_on_add">Sync manga when adding to library</string>
-    <string name="pref_sync_manga_on_add_description">Automatically fetches the metadata and chapter list of a new manga when adding it to the library</string>
+    <string name="pref_fetch_manga_metadata_on_add">Fetch metadata when adding to library</string>
+    <string name="pref_fetch_manga_metadata_on_add_description">Automatically fetches the metadata of a new manga when adding it to the library</string>
+    <string name="pref_fetch_manga_chapters_on_add">Fetch chapters when adding to library</string>
+    <string name="pref_fetch_manga_chapters_on_add_description">Automatically fetches the chapter list of a new manga when adding it to the library</string>
     <!-- Extension section -->
     <string name="extensions_page_need_refresh">Refresh extension page to update list.</string>
     <string name="extensions_page_more">More extensions...</string>

--- a/i18n-kmk/src/commonMain/moko-resources/fil/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/fil/strings.xml
@@ -172,12 +172,14 @@
     <string name="action_filter_unfinished_chapter">Di natapos na kabanata</string>
     <string name="action_filter_non_library_entries">Mga entry na wala sa aklatan</string>
     <string name="custom_theme_palette_casual">Kaswal</string>
-    <string name="pref_sync_manga_on_add">I-sync ang manga kapag nagdadagdag sa aklatan</string>
-    <string name="pref_sync_manga_on_add_description">Awtomatikong kinukuha ang metadata at listahan ng kabanata ng isang bagong manga kapag idinagdag ito sa aklatan</string>
     <string name="pref_webdav_url">Server URL ng WebDAV</string>
     <string name="pref_webdav_url_summ">Ipasok ang address ng WebDAV server</string>
     <string name="pref_webdav_username_summ">Ipasok ang iyong username ng WebDAV account</string>
     <string name="pref_webdav_password_summ">Ipasok ang iyong password ng WebDAV account</string>
     <string name="pref_webdav_folder_summ">Ise-save ng aplikasyon ang data sa folder na ito</string>
     <string name="pref_discord_rpc">Rich Presence ng Discord</string>
+    <string name="pref_fetch_manga_metadata_on_add">Kunin ang metadata ng manga kapag idinadagdag sa aklatan</string>
+    <string name="pref_fetch_manga_metadata_on_add_description">Awtomatikong kunin at i-update ang metadata ng manga kapag idinagdag mo ito sa iyong aklatan</string>
+    <string name="pref_fetch_manga_chapters_on_add">Kunin ang mga kabanata kapag idinadagdag ang manga sa aklatan</string>
+    <string name="pref_fetch_manga_chapters_on_add_description">Awtomatikong i-scan ang source para sa mga kabanata kapag idinagdag ang manga sa iyong aklatan</string>
 </resources>

--- a/i18n-kmk/src/commonMain/moko-resources/it/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/it/strings.xml
@@ -173,7 +173,6 @@
     <string name="pref_discord_configuration">Apri per configurare Discord RPC</string>
     <string name="error_opening_folder">Impossibile aprire cartella</string>
     <string name="pref_show_empty_categories_search">Mostra categorie vuote durante ricerca/filtraggio</string>
-    <string name="pref_sync_manga_on_add">Sincronizzare i manga quando vengono aggiunti alla libreria</string>
     <string name="chapters_from_database">Capitoli e cronologia dal database</string>
     <string name="job_failed_schedule_update_check">Pianificazione aggiornamento automatico libreria fallita: %s</string>
     <string name="job_failed_schedule_backup_check">Pianificazione backup automatico fallito: %s</string>
@@ -186,7 +185,6 @@
     <string name="pref_top_align_cover_summary">Mostra copertina allineata in alto accanto alle informazioni sul manga</string>
     <string name="theme_doom">Doom</string>
     <string name="pref_library_filter_categories_details">Le voci nelle categorie escluse non verranno mostrate anche se presenti nelle categorie incluse.</string>
-    <string name="pref_sync_manga_on_add_description">Recupera automaticamente i metadati e l\'elenco dei capitoli di un nuovo manga quando lo aggiungi alla libreria</string>
     <string name="web_dav">WebDAV</string>
     <string name="migrationConfigScreen_smartSearchSingleEntrySubtitle">Se abilitato, seleziona automaticamente il risultato con la corrispondenza migliore. Altrimenti, mostra tutti i risultati della ricerca per la selezione manuale.</string>
     <string name="pref_connections_summary">Discord, altri in arrivo...</string>

--- a/i18n-kmk/src/commonMain/moko-resources/ru/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/ru/strings.xml
@@ -204,8 +204,10 @@
     <string name="action_filter_unfinished_manga">Незаконченные тайтлы</string>
     <string name="action_filter_unfinished_chapter">Незаконченные главы</string>
     <string name="action_filter_non_library_entries">Тайтлы не в библиотеке</string>
-    <string name="pref_sync_manga_on_add">Синхронизировать тайтлы при добавлении в библиотеку</string>
-    <string name="pref_sync_manga_on_add_description">Автоматически загружает метаданные и список глав при добавлении в библиотеку</string>
     <string name="migrationConfigScreen_smartSearchSingleEntryTitle">Использовать умный поиск</string>
     <string name="migrationConfigScreen_smartSearchSingleEntrySubtitle">Если включено, автоматически выбирает наиболее совпадающий результат. Иначе, показывает все результаты поиска для ручного выбора.</string>
+    <string name="pref_fetch_manga_metadata_on_add">Получать метаданные манги при добавлении</string>
+    <string name="pref_fetch_manga_metadata_on_add_description">Автоматически загружать обложку, описание и другую информацию при добавлении манги в библиотеку</string>
+    <string name="pref_fetch_manga_chapters_on_add">Получать главы при добавлении</string>
+    <string name="pref_fetch_manga_chapters_on_add_description">Автоматически обновлять список глав при добавлении манги в библиотеку</string>
 </resources>

--- a/i18n-kmk/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -195,8 +195,6 @@
     <string name="action_filter_unfinished_manga">尚未讀完</string>
     <string name="action_filter_unfinished_chapter">未讀完章節</string>
     <string name="action_filter_non_library_entries">未收藏項目</string>
-    <string name="pref_sync_manga_on_add">新增至書庫時自動同步</string>
-    <string name="pref_sync_manga_on_add_description">將新漫畫加入書庫時，自動取得其元資料及章節列表</string>
     <string name="web_dav">WebDAV</string>
     <string name="pref_webdav_url">WebDAV 伺服器 URL</string>
     <string name="pref_webdav_url_summ">輸入 WebDAV 伺服器地址</string>
@@ -208,4 +206,8 @@
     <string name="pref_webdav_folder_summ">應用將把資料儲存在這個資料夾中</string>
     <string name="migrationConfigScreen_smartSearchSingleEntryTitle">使用智慧搜尋</string>
     <string name="migrationConfigScreen_smartSearchSingleEntrySubtitle">若已啟用，自動選取最佳匹配結果，否則顯示所有搜尋結果供手動選擇</string>
+    <string name="pref_fetch_manga_metadata_on_add">新增至書櫃時更新漫畫資料</string>
+    <string name="pref_fetch_manga_metadata_on_add_description">在將作品加入書櫃後，自動抓取標題、作者等最新漫畫資訊</string>
+    <string name="pref_fetch_manga_chapters_on_add">新增至書櫃時更新章節列表</string>
+    <string name="pref_fetch_manga_chapters_on_add_description">在將作品加入書櫃後，自動抓取最新章節列表</string>
 </resources>


### PR DESCRIPTION
This change separates the synchronization preferences for fetching metadata and chapters when adding new manga to the library. The new preferences allow users to enable or disable fetching metadata and chapters independently.

## Summary by Sourcery

Split the automatic library sync behavior when adding manga into separate metadata and chapter fetching options and update code paths to honor the new preferences.

New Features:
- Add separate library preferences to fetch manga metadata and to fetch manga chapters when adding titles to the library.

Enhancements:
- Update add-to-library flows to conditionally fetch metadata and/or chapters based on the new preferences instead of a single sync-on-add setting.
- Adjust library settings UI and user-facing strings to expose independent toggles for fetching metadata and chapters on add.
- Tidy up minor comments and parameter documentation in browsing and sync-related classes.