### PR TITLE
feat(UI): Mask WebDAV password while typing

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -738,7 +738,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                     subtitle = stringResource(SYMR.strings.data_saver_image_quality_summary),
                     enabled = dataSaver != DataSaver.NONE,
                 ),
-                kotlin.run {
+                run {
                     val dataSaverImageFormatJpeg by sourcePreferences.dataSaverImageFormatJpeg()
                         .collectAsState()
                     Preference.PreferenceItem.SwitchPreference(
@@ -808,7 +808,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                     title = stringResource(SYMR.strings.log_level),
                     subtitle = stringResource(SYMR.strings.log_level_summary),
                 ),
-                kotlin.run {
+                run {
                     var enableEncryptDatabase by rememberSaveable { mutableStateOf(false) }
 
                     if (enableEncryptDatabase) {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBrowseScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsBrowseScreen.kt
@@ -85,7 +85,7 @@ object SettingsBrowseScreen : SearchableSettings {
                         enabled = sourcePreferences.relatedMangas().get(),
                     ),
                     // KMK <--
-                    kotlin.run {
+                    run {
                         val count by sourcePreferences.sourcesTabCategories().collectAsState()
                         Preference.PreferenceItem.TextPreference(
                             title = stringResource(MR.strings.action_edit_categories),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -562,7 +562,7 @@ object SettingsDataScreen : SearchableSettings {
                             SyncManager.SyncService.SYNCYOMI.value to stringResource(SYMR.strings.syncyomi),
                             SyncManager.SyncService.GOOGLE_DRIVE.value to stringResource(SYMR.strings.google_drive),
                             // KMK -->
-                            SyncManager.SyncService.WebDAV.value to stringResource(KMR.strings.web_dav),
+                            SyncManager.SyncService.WEB_DAV.value to stringResource(KMR.strings.web_dav),
                             // KMK <--
                         ),
                         title = stringResource(SYMR.strings.pref_sync_service),
@@ -606,7 +606,7 @@ object SettingsDataScreen : SearchableSettings {
             SyncManager.SyncService.SYNCYOMI -> getSelfHostPreferences(syncPreferences)
             SyncManager.SyncService.GOOGLE_DRIVE -> getGoogleDrivePreferences()
             // KMK -->
-            SyncManager.SyncService.WebDAV -> getWebDavPreferences(syncPreferences)
+            SyncManager.SyncService.WEB_DAV -> getWebDavPreferences(syncPreferences)
             // KMK <--
         }
 
@@ -832,7 +832,7 @@ object SettingsDataScreen : SearchableSettings {
             ),
         )
     }
-    // MK <--
+    // KMK <--
 
     @Composable
     private fun getSyncNowPref(): Preference.PreferenceGroup {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -760,7 +760,9 @@ object SettingsDataScreen : SearchableSettings {
                     title = stringResource(SYMR.strings.pref_sync_api_key),
                     subtitle = stringResource(SYMR.strings.pref_sync_api_key_summ),
                     onConfirm = {
-                        syncPreferences.clientAPIKey().set(it)
+                        scope.launch {
+                            syncPreferences.clientAPIKey().set(it)
+                        }
                         true
                     },
                     icon = null,
@@ -816,7 +818,9 @@ object SettingsDataScreen : SearchableSettings {
                         onDismissRequest = { dialogOpen = false },
                         onReturnPassword = { password ->
                             dialogOpen = false
-                            syncPreferences.webDavPassword().set(password.replace("\n", ""))
+                            scope.launch {
+                                syncPreferences.webDavPassword().set(password.replace("\n", ""))
+                            }
                         },
                         title = KMR.strings.pref_webdav_password,
                     )

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -48,6 +48,7 @@ import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import eu.kanade.domain.sync.SyncPreferences
 import eu.kanade.presentation.more.settings.Preference
+import eu.kanade.presentation.more.settings.screen.SettingsSecurityScreen.PasswordDialog
 import eu.kanade.presentation.more.settings.screen.data.CreateBackupScreen
 import eu.kanade.presentation.more.settings.screen.data.RestoreBackupScreen
 import eu.kanade.presentation.more.settings.screen.data.StorageInfo
@@ -808,17 +809,26 @@ object SettingsDataScreen : SearchableSettings {
                     true
                 },
             ),
-            Preference.PreferenceItem.EditTextPreference(
-                preference = syncPreferences.webDavPassword(),
-                title = stringResource(KMR.strings.pref_webdav_password),
-                subtitle = stringResource(KMR.strings.pref_webdav_password_summ),
-                onValueChanged = { newValue ->
-                    scope.launch {
-                        syncPreferences.webDavPassword().set(newValue)
-                    }
-                    true
-                },
-            ),
+            run {
+                var dialogOpen by remember { mutableStateOf(false) }
+                if (dialogOpen) {
+                    PasswordDialog(
+                        onDismissRequest = { dialogOpen = false },
+                        onReturnPassword = { password ->
+                            dialogOpen = false
+                            syncPreferences.webDavPassword().set(password.replace("\n", ""))
+                        },
+                        title = KMR.strings.pref_webdav_password,
+                    )
+                }
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(KMR.strings.pref_webdav_password),
+                    subtitle = stringResource(KMR.strings.pref_webdav_password_summ),
+                    onClick = {
+                        dialogOpen = true
+                    },
+                )
+            },
             Preference.PreferenceItem.EditTextPreference(
                 preference = syncPreferences.webDavFolder(),
                 title = stringResource(KMR.strings.pref_webdav_folder),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -155,7 +155,7 @@ object SettingsSecurityScreen : SearchableSettings {
                     enabled = passwordProtectDownloads,
 
                 ),
-                kotlin.run {
+                run {
                     var dialogOpen by remember { mutableStateOf(false) }
                     if (dialogOpen) {
                         PasswordDialog(
@@ -183,7 +183,7 @@ object SettingsSecurityScreen : SearchableSettings {
                         securityPreferences.cbzPassword().set("")
                     },
                 ),
-                kotlin.run {
+                run {
                     val navigator = LocalNavigator.currentOrThrow
                     val count by securityPreferences.authenticatorTimeRanges().collectAsState()
                     Preference.PreferenceItem.TextPreference(
@@ -199,7 +199,7 @@ object SettingsSecurityScreen : SearchableSettings {
                         },
                     )
                 },
-                kotlin.run {
+                run {
                     val selection by securityPreferences.authenticatorDays().collectAsState()
                     var dialogOpen by remember { mutableStateOf(false) }
                     if (dialogOpen) {
@@ -332,13 +332,16 @@ object SettingsSecurityScreen : SearchableSettings {
     fun PasswordDialog(
         onDismissRequest: () -> Unit,
         onReturnPassword: (String) -> Unit,
+        // KMK -->
+        title: StringResource = SYMR.strings.cbz_archive_password,
+        // KMK <--
     ) {
         var password by rememberSaveable { mutableStateOf("") }
         var passwordVisibility by remember { mutableStateOf(false) }
         AlertDialog(
             onDismissRequest = onDismissRequest,
 
-            title = { Text(text = stringResource(SYMR.strings.cbz_archive_password)) },
+            title = { Text(text = stringResource(title)) },
             text = {
                 TextField(
                     value = password,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncManager.kt
@@ -57,7 +57,7 @@ class SyncManager(
         SYNCYOMI(1),
         GOOGLE_DRIVE(2),
         // KMK -->
-        WebDAV(3),
+        WEB_DAV(3),
         // KMK <--
         ;
 
@@ -142,7 +142,7 @@ class SyncManager(
             }
 
             // KMK -->
-            SyncService.WebDAV -> {
+            SyncService.WEB_DAV -> {
                 WebDavSyncService(context, json, syncPreferences, notifier)
             }
             // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/WebDavSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/WebDavSyncService.kt
@@ -40,7 +40,7 @@ class WebDavSyncService(
     private val url: String = syncPreferences.webDavUrl().get().trim()
     private val folder: String = syncPreferences.webDavFolder().get().trim('/')
     private val username: String = syncPreferences.webDavUsername().get().trim()
-    private val password: String = syncPreferences.webDavPassword().get().trim()
+    private val password: String = syncPreferences.webDavPassword().get()
     private val credentials: String = Credentials.basic(username, password)
 
     private fun buildWebDavFileUrl(fileName: String = "backup.proto"): String {


### PR DESCRIPTION
Implement a masked input for the WebDAV password to enhance security while typing. Refactor existing code for improved readability and maintainability.

## Summary by Sourcery

Introduce a masked dialog-based input for the WebDAV sync password and align WebDAV sync naming with existing conventions.

New Features:
- Add a password dialog flow for configuring the WebDAV sync password, masking input while typing.

Enhancements:
- Reuse the shared PasswordDialog component with a configurable title for both security and WebDAV settings.
- Replace verbose kotlin.run usages with run for cleaner settings composables.
- Align the WebDAV sync service enum name and related references to a consistent WEB_DAV identifier.
- Fix a minor comment tag typo in the data settings screen.