### PR TITLE
feat: add custom headers support for syncyomi

### DIFF
--- a/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/sync/SyncPreferences.kt
@@ -12,6 +12,8 @@ class SyncPreferences(
 ) {
     fun clientHost() = preferenceStore.getString("sync_client_host", "https://sync.tachiyomi.org")
     fun clientAPIKey() = preferenceStore.getString("sync_client_api_key", "")
+
+    fun clientCustomHeaders() = preferenceStore.getString("sync_client_custom_headers", "")
     fun lastSyncTimestamp() = preferenceStore.getLong(Preference.appStateKey("last_sync_timestamp"), 0L)
 
     fun lastSyncEtag() = preferenceStore.getString("sync_etag", "")

--- a/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/Preference.kt
@@ -136,6 +136,7 @@ sealed class Preference {
             override val title: String,
             override val subtitle: String? = "%s",
             override val enabled: Boolean = true,
+            val singleLine: Boolean = true,
             override val onValueChanged: suspend (value: String) -> Boolean = { true },
         ) : PreferenceItem<String, Boolean>() {
             override val icon: ImageVector? = null

--- a/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt
@@ -158,6 +158,7 @@ internal fun PreferenceItem(
                     subtitle = item.subtitle,
                     icon = item.icon,
                     value = values,
+                    singleLine = item.singleLine,
                     onConfirm = {
                         val accepted = item.onValueChanged(it)
                         if (accepted) item.preference.set(it)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -777,6 +777,12 @@ object SettingsDataScreen : SearchableSettings {
                     },
                 )
             },
+            Preference.PreferenceItem.EditTextPreference(
+                preference = syncPreferences.clientCustomHeaders(),
+                title = stringResource(SYMR.strings.pref_sync_custom_headers),
+                subtitle = stringResource(SYMR.strings.pref_sync_custom_headers_summ),
+                singleLine = false,
+            ),
         )
     }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -782,6 +782,15 @@ object SettingsDataScreen : SearchableSettings {
                 title = stringResource(SYMR.strings.pref_sync_custom_headers),
                 subtitle = stringResource(SYMR.strings.pref_sync_custom_headers_summ),
                 singleLine = false,
+                onValueChanged = { newValue ->
+                    val parsedHeaders = eu.kanade.tachiyomi.data.sync.service.CustomHeaderHelper.parse(newValue)
+                    if (parsedHeaders.size > 10) {
+                        context.toast(SYMR.strings.error_custom_headers_limit)
+                        false
+                    } else {
+                        true
+                    }
+                },
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/EditTextPreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/EditTextPreferenceWidget.kt
@@ -32,6 +32,7 @@ fun EditTextPreferenceWidget(
     icon: ImageVector?,
     value: String,
     widget: @Composable (() -> Unit)? = null,
+    singleLine: Boolean = true,
     onConfirm: suspend (String) -> Boolean,
 ) {
     var isDialogShown by remember { mutableStateOf(false) }
@@ -67,7 +68,7 @@ fun EditTextPreferenceWidget(
                         }
                     },
                     isError = textFieldValue.text.isBlank(),
-                    singleLine = true,
+                    singleLine = singleLine,
                     modifier = Modifier.fillMaxWidth(),
                 )
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
@@ -71,6 +71,7 @@ class SyncYomiSyncService(
         if (lastETag != "") {
             headersBuilder.add("If-None-Match", lastETag)
         }
+        headersBuilder.addCustomHeaders()
         val headers = headersBuilder.build()
 
         val downloadRequest = GET(
@@ -135,6 +136,7 @@ class SyncYomiSyncService(
         if (eTag.isNotEmpty()) {
             headersBuilder.add("If-Match", eTag)
         }
+        headersBuilder.addCustomHeaders()
         val headers = headersBuilder.build()
 
         // Set timeout to 30 seconds
@@ -171,5 +173,27 @@ class SyncYomiSyncService(
             notifier.showSyncError("Failed to upload sync data: $responseBody")
             logcat(LogPriority.ERROR) { "SyncError: $responseBody" }
         }
+    }
+
+    private fun Headers.Builder.addCustomHeaders() {
+        val customHeaders = syncPreferences.clientCustomHeaders().get()
+        if (customHeaders.isBlank()) return
+
+        customHeaders.lines()
+            .take(10)
+            .forEach { line ->
+                val parts = line.split(":", limit = 2)
+                if (parts.size == 2) {
+                    val key = parts[0].trim()
+                    val value = parts[1].trim()
+                    if (key.isNotEmpty() && value.isNotEmpty()) {
+                        try {
+                            this.add(key, value)
+                        } catch (e: Exception) {
+                            logcat(LogPriority.ERROR) { "Invalid custom header: $line" }
+                        }
+                    }
+                }
+            }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
@@ -179,20 +179,13 @@ class SyncYomiSyncService(
         val customHeaders = syncPreferences.clientCustomHeaders().get()
         if (customHeaders.isBlank()) return
 
-        customHeaders.lines()
+        CustomHeaderHelper.parse(customHeaders)
             .take(10)
-            .forEach { line ->
-                val parts = line.split(":", limit = 2)
-                if (parts.size == 2) {
-                    val key = parts[0].trim()
-                    val value = parts[1].trim()
-                    if (key.isNotEmpty() && value.isNotEmpty()) {
-                        try {
-                            this.add(key, value)
-                        } catch (e: Exception) {
-                            logcat(LogPriority.ERROR) { "Invalid custom header: $line" }
-                        }
-                    }
+            .forEach { (key, value) ->
+                try {
+                    this.add(key, value)
+                } catch (e: Exception) {
+                    logcat(LogPriority.ERROR) { "Invalid custom header: $key: $value" }
                 }
             }
     }

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -222,6 +222,8 @@
     <string name="pref_sync_host_summ">Enter the host address for synchronizing your library</string>
     <string name="pref_sync_api_key">API key</string>
     <string name="pref_sync_api_key_summ">Enter the API key to synchronize your library</string>
+    <string name="pref_sync_custom_headers">Custom Headers</string>
+    <string name="pref_sync_custom_headers_summ">Add up to 10 custom headers (format: Key: Value). One per line.</string>
     <string name="pref_sync_now_group_title">Sync Actions</string>
     <string name="pref_sync_now">Sync now</string>
     <string name="pref_sync_now_subtitle">Initiate immediate synchronization of your data</string>

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -224,6 +224,7 @@
     <string name="pref_sync_api_key_summ">Enter the API key to synchronize your library</string>
     <string name="pref_sync_custom_headers">Custom Headers</string>
     <string name="pref_sync_custom_headers_summ">Add up to 10 custom headers (format: Key: Value). One per line.</string>
+    <string name="error_custom_headers_limit">Cannot add more than 10 custom headers</string>
     <string name="pref_sync_now_group_title">Sync Actions</string>
     <string name="pref_sync_now">Sync now</string>
     <string name="pref_sync_now_subtitle">Initiate immediate synchronization of your data</string>


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---
Hi!
this might be a niche issue, but I thought of running syncyomi behind a reverse proxy and a custom headers support I thought would be nice for someone else as well
this is the simple result:
<img width="529" height="1076" alt="{612794C8-3DB3-4366-9D1F-C46A7AD2E8E6}" src="https://github.com/user-attachments/assets/dbbf7be9-b3e8-4316-b017-9d3b65160a05" />
You just need to input `headerkey: headervalue` and if not using them it will work as usual.
Tested and working
Full disclosure: I've used a bit of AI to help me, I hope that's ok. I've personally reviewed the changes even if small.


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add configurable custom HTTP headers support to SyncYomi sync requests and expose it via settings.

New Features:
- Allow users to define custom HTTP headers for SyncYomi requests via a multi-line settings field supporting up to 10 headers.

Enhancements:
- Extend sync header construction to append user-defined custom headers while validating basic format and logging invalid entries.
- Update the generic edit-text preference and its widgets to support multi-line input where needed, and localize labels for the new sync headers setting.