### PR TITLE
fix(delegate): migrate NH to the v2 api

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -91,15 +91,9 @@ class NHentai(delegate: HttpSource, val context: Context) :
 
             preferredTitle = this@NHentai.preferredTitle
 
-            jsonResponse.cover?.path?.let {
-                coverImageUrl = "$thumbServer/$it"
-                coverImageType = it.parseType()
-            }
-
-            jsonResponse.thumbnail?.path?.let {
-                thumbnailImageUrl = "$thumbServer/$it"
-                thumbnailImageType = it.parseType()
-            }
+            coverImageUrl =
+                jsonResponse.cover?.path?.let { "$thumbServer/$it" }
+                    ?: jsonResponse.thumbnail?.path?.let { "$thumbServer/$it" }
 
             pageImagePreviewUrls = jsonResponse.pages.mapNotNull { it.thumbnail }
 
@@ -121,8 +115,6 @@ class NHentai(delegate: HttpSource, val context: Context) :
             }
         }
     }
-
-    private fun String.parseType(): String = this.substringAfterLast('.').first().toString()
 
     @Serializable
     data class JsonConfig(

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -30,7 +30,6 @@ import kotlinx.serialization.json.Json
 import okhttp3.CacheControl
 import okhttp3.Response
 import tachiyomi.core.common.util.lang.withIOContext
-import java.io.IOException
 
 class NHentai(delegate: HttpSource, val context: Context) :
     DelegatedHttpSource(delegate),

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -200,9 +200,8 @@ class NHentai(delegate: HttpSource, val context: Context) :
     var nhConfig: JsonConfig? = null
     suspend fun getNhConfig() {
         try {
-            val response =
-                withIOContext { client.newCall(GET("https://nhentai.net/api/v2/config", headers)).awaitSuccess() }
-            val body = response.body.string()
+            val body = withIOContext { client.newCall(GET("https://nhentai.net/api/v2/config", headers)).awaitSuccess() }
+                .use { it.body.string() }
             nhConfig = jsonParser.decodeFromString<JsonConfig>(body)
         } catch (_: Exception) {
             nhConfig = JsonConfig(

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -240,8 +240,6 @@ class NHentai(delegate: HttpSource, val context: Context) :
         private val jsonParser = Json {
             ignoreUnknownKeys = true
         }
-
-        private val UNICODE_ESCAPE_REGEX = Regex("\\\\u([0-9a-fA-F]{4})")
         private const val TITLE_PREF = "Display manga title as:"
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -212,7 +212,7 @@ class NHentai(delegate: HttpSource, val context: Context) :
     }
 
     val thumbServer
-        get() = nhConfig?.thumbServers?.random()
+        get() = nhConfig?.thumbServers?.randomOrNull() ?: "https://t1.nhentai.net"
 
     override suspend fun fetchPreviewImage(page: PagePreviewInfo, cacheControl: CacheControl?): Response {
         return client.newCachelessCallWithProgress(

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -17,7 +17,6 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.source.online.MetadataSource
 import eu.kanade.tachiyomi.source.online.NamespaceSource
 import eu.kanade.tachiyomi.source.online.UrlImportableSource
-import eu.kanade.tachiyomi.util.asJsoup
 import exh.metadata.metadata.NHentaiSearchMetadata
 import exh.metadata.metadata.RaisedSearchMetadata
 import exh.metadata.metadata.base.RaisedTag
@@ -30,7 +29,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.CacheControl
 import okhttp3.Response
-import org.jsoup.nodes.Document
+import java.io.IOException
 
 class NHentai(delegate: HttpSource, val context: Context) :
     DelegatedHttpSource(delegate),
@@ -72,9 +71,8 @@ class NHentai(delegate: HttpSource, val context: Context) :
     }
 
     override suspend fun parseIntoMetadata(metadata: NHentaiSearchMetadata, input: Response) {
-        val body = input.body.string()
-        val server = MEDIA_SERVER_REGEX.find(body)?.groupValues?.get(1)?.toInt() ?: 1
-        val json = GALLERY_JSON_REGEX.find(body)!!.groupValues[1].replace(
+        val server = (1..4).random()
+        val json = input.body.string().replace(
             UNICODE_ESCAPE_REGEX,
         ) { it.groupValues[1].toInt(radix = 16).toChar().toString() }
         val jsonResponse = jsonParser.decodeFromString<JsonResponse>(json)
@@ -98,16 +96,17 @@ class NHentai(delegate: HttpSource, val context: Context) :
 
             preferredTitle = this@NHentai.preferredTitle
 
-            jsonResponse.images?.let { images ->
-                coverImageType = input.asJsoup(body).parseCoverType()
-                    ?: images.cover?.type
-                images.pages.mapNotNull {
-                    it.type
-                }.let {
-                    pageImageTypes = it
-                }
-                thumbnailImageType = images.thumbnail?.type
+            jsonResponse.cover?.path?.let {
+                coverImageUrl = "$thumbServer/$it"
+                coverImageType = it.parseType()
             }
+
+            jsonResponse.thumbnail?.path?.let {
+                thumbnailImageUrl = "$thumbServer/$it"
+                thumbnailImageType = it.parseType()
+            }
+
+            pageImagePreviewUrls = jsonResponse.pages.mapNotNull { it.thumbnail }
 
             scanlator = jsonResponse.scanlator?.trimOrNull()
 
@@ -132,13 +131,16 @@ class NHentai(delegate: HttpSource, val context: Context) :
     /**
      * Site JSON is saying cover of type `w` but instead it's using cover like `cover.jpg.webp`
      */
-    private fun Document.parseCoverType(): String? {
-        return selectFirst("#cover > a > img")?.attr("data-src")
-            ?.substringAfterLast('/')
-            ?.substringAfter('.')
-            ?.first()?.toString()
-    }
+    private fun String.parseType(): String = this.substringAfterLast('/').substringAfter('.').first().toString()
     // KMK <--
+
+    @Serializable
+    data class JsonConfig(
+        @SerialName("image_servers")
+        val imageServers: List<String> = emptyList(),
+        @SerialName("thumb_servers")
+        val thumbServers: List<String> = emptyList(),
+    )
 
     @Serializable
     data class JsonResponse(
@@ -146,7 +148,8 @@ class NHentai(delegate: HttpSource, val context: Context) :
         @SerialName("media_id")
         val mediaId: String? = null,
         val title: JsonTitle? = null,
-        val images: JsonImages? = null,
+        val cover: JsonPage? = null,
+        val thumbnail: JsonPage? = null,
         val scanlator: String? = null,
         @SerialName("upload_date")
         val uploadDate: Long? = null,
@@ -155,6 +158,7 @@ class NHentai(delegate: HttpSource, val context: Context) :
         val numPages: Int? = null,
         @SerialName("num_favorites")
         val numFavorites: Long? = null,
+        val pages: List<JsonPage> = emptyList(),
     )
 
     @Serializable
@@ -165,20 +169,11 @@ class NHentai(delegate: HttpSource, val context: Context) :
     )
 
     @Serializable
-    data class JsonImages(
-        val pages: List<JsonPage> = emptyList(),
-        val cover: JsonPage? = null,
-        val thumbnail: JsonPage? = null,
-    )
-
-    @Serializable
     data class JsonPage(
-        @SerialName("t")
-        val type: String? = null,
-        @SerialName("w")
+        val path: String? = null,
         val width: Long? = null,
-        @SerialName("h")
         val height: Long? = null,
+        val thumbnail: String? = null,
     )
 
     @Serializable
@@ -208,15 +203,10 @@ class NHentai(delegate: HttpSource, val context: Context) :
         }
         return PagePreviewPage(
             page,
-            metadata.pageImageTypes.mapIndexed { index, s ->
+            metadata.pageImagePreviewUrls.mapIndexed { index, path ->
                 PagePreviewInfo(
                     index + 1,
-                    imageUrl = thumbnailUrlFromType(
-                        metadata.mediaId!!,
-                        metadata.mediaServer ?: 1,
-                        index + 1,
-                        s,
-                    )!!,
+                    imageUrl = "$thumbServer/$path",
                 )
             },
             false,
@@ -224,14 +214,21 @@ class NHentai(delegate: HttpSource, val context: Context) :
         )
     }
 
-    private fun thumbnailUrlFromType(
-        mediaId: String,
-        mediaServer: Int,
-        page: Int,
-        t: String,
-    ) = NHentaiSearchMetadata.typeToExtension(t)?.let {
-        "https://t$mediaServer.nhentai.net/galleries/$mediaId/${page}t.$it"
+    val nhConfig: JsonConfig by lazy {
+        try {
+            val response = client.newCall(GET("https://nhentai.net/api/v2/config", headers)).execute()
+            val body = response.body.string()
+            jsonParser.decodeFromString<JsonConfig>(body)
+        } catch (_: IOException) {
+            JsonConfig(
+                (1..4).map { n -> "https://i$n.nhentai.net" }.toList(),
+                (1..4).map { n -> "https://t$n.nhentai.net" }.toList(),
+            )
+        }
     }
+
+    val thumbServer
+        get() = nhConfig.thumbServers.random()
 
     override suspend fun fetchPreviewImage(page: PagePreviewInfo, cacheControl: CacheControl?): Response {
         return client.newCachelessCallWithProgress(
@@ -249,8 +246,6 @@ class NHentai(delegate: HttpSource, val context: Context) :
             ignoreUnknownKeys = true
         }
 
-        private val GALLERY_JSON_REGEX = Regex(".parse\\(\"(.*)\"\\);")
-        private val MEDIA_SERVER_REGEX = Regex("media_server\\s*:\\s*(\\d+)")
         private val UNICODE_ESCAPE_REGEX = Regex("\\\\u([0-9a-fA-F]{4})")
         private const val TITLE_PREF = "Display manga title as:"
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -122,7 +122,6 @@ class NHentai(delegate: HttpSource, val context: Context) :
         }
     }
 
-    // Site converted all the images to webp, like `cover.jpg.webp`
     private fun String.parseType(): String = this.substringAfterLast('.').first().toString()
 
     @Serializable

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -40,6 +40,7 @@ class NHentai(delegate: HttpSource, val context: Context) :
     override val metaClass = NHentaiSearchMetadata::class
     override fun newMetaInstance() = NHentaiSearchMetadata()
     override val lang = delegate.lang
+    override val versionId = 2
 
     private val sourcePreferences: SharedPreferences by lazy {
         context.getSharedPreferences("source_$id", 0x0000)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -40,7 +40,6 @@ class NHentai(delegate: HttpSource, val context: Context) :
     override val metaClass = NHentaiSearchMetadata::class
     override fun newMetaInstance() = NHentaiSearchMetadata()
     override val lang = delegate.lang
-    override val versionId = 2
 
     private val sourcePreferences: SharedPreferences by lazy {
         context.getSharedPreferences("source_$id", 0x0000)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import okhttp3.CacheControl
 import okhttp3.Response
+import tachiyomi.core.common.util.lang.withIOContext
 import java.io.IOException
 
 class NHentai(delegate: HttpSource, val context: Context) :
@@ -71,11 +72,8 @@ class NHentai(delegate: HttpSource, val context: Context) :
     }
 
     override suspend fun parseIntoMetadata(metadata: NHentaiSearchMetadata, input: Response) {
-        val server = (1..4).random()
-        val json = input.body.string().replace(
-            UNICODE_ESCAPE_REGEX,
-        ) { it.groupValues[1].toInt(radix = 16).toChar().toString() }
-        val jsonResponse = jsonParser.decodeFromString<JsonResponse>(json)
+        if (nhConfig == null) getNhConfig()
+        val jsonResponse = jsonParser.decodeFromString<JsonResponse>(input.body.string())
 
         with(metadata) {
             nhId = jsonResponse.id
@@ -85,8 +83,6 @@ class NHentai(delegate: HttpSource, val context: Context) :
             favoritesCount = jsonResponse.numFavorites
 
             mediaId = jsonResponse.mediaId
-
-            mediaServer = server
 
             jsonResponse.title?.let { title ->
                 japaneseTitle = title.japanese
@@ -127,12 +123,8 @@ class NHentai(delegate: HttpSource, val context: Context) :
         }
     }
 
-    // KMK -->
-    /**
-     * Site JSON is saying cover of type `w` but instead it's using cover like `cover.jpg.webp`
-     */
-    private fun String.parseType(): String = this.substringAfterLast('/').substringAfter('.').first().toString()
-    // KMK <--
+    // Site converted all the images to webp, like `cover.jpg.webp`
+    private fun String.parseType(): String = this.substringAfterLast('.').first().toString()
 
     @Serializable
     data class JsonConfig(
@@ -198,6 +190,7 @@ class NHentai(delegate: HttpSource, val context: Context) :
     }
 
     override suspend fun getPagePreviewList(manga: SManga, chapters: List<SChapter>, page: Int): PagePreviewPage {
+        if (nhConfig == null) getNhConfig()
         val metadata = fetchOrLoadMetadata(manga.id()) {
             client.newCall(mangaDetailsRequest(manga)).awaitSuccess()
         }
@@ -214,21 +207,23 @@ class NHentai(delegate: HttpSource, val context: Context) :
         )
     }
 
-    val nhConfig: JsonConfig by lazy {
+    var nhConfig: JsonConfig? = null
+    suspend fun getNhConfig() {
         try {
-            val response = client.newCall(GET("https://nhentai.net/api/v2/config", headers)).execute()
+            val response =
+                withIOContext { client.newCall(GET("https://nhentai.net/api/v2/config", headers)).awaitSuccess() }
             val body = response.body.string()
-            jsonParser.decodeFromString<JsonConfig>(body)
-        } catch (_: IOException) {
-            JsonConfig(
-                (1..4).map { n -> "https://i$n.nhentai.net" }.toList(),
-                (1..4).map { n -> "https://t$n.nhentai.net" }.toList(),
+            nhConfig = jsonParser.decodeFromString<JsonConfig>(body)
+        } catch (_: Exception) {
+            nhConfig = JsonConfig(
+                (1..4).map { n -> "https://i$n.nhentai.net" },
+                (1..4).map { n -> "https://t$n.nhentai.net" },
             )
         }
     }
 
     val thumbServer
-        get() = nhConfig.thumbServers.random()
+        get() = nhConfig?.thumbServers?.random()
 
     override suspend fun fetchPreviewImage(page: PagePreviewInfo, cacheControl: CacheControl?): Response {
         return client.newCachelessCallWithProgress(

--- a/app/src/main/java/exh/ui/metadata/adapters/NHentaiDescriptionAdapter.kt
+++ b/app/src/main/java/exh/ui/metadata/adapters/NHentaiDescriptionAdapter.kt
@@ -81,8 +81,8 @@ fun NHentaiDescription(state: State.Success, openMetadataViewer: () -> Unit) {
 
             binding.pages.text = context.pluralStringResource(
                 SYMR.plurals.num_pages,
-                meta.pageImageTypes.size,
-                meta.pageImageTypes.size,
+                meta.pageImagePreviewUrls.size,
+                meta.pageImagePreviewUrls.size,
             )
             // KMK -->
             binding.pages.bindDrawable(context, R.drawable.ic_baseline_menu_book_24, iconColor, 4.dpToPx)

--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
@@ -34,12 +34,7 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
     var shortTitle by titleDelegate(TITLE_TYPE_SHORT)
 
     var coverImageUrl: String? = null
-    var coverImageType: String? = null
-
     var pageImagePreviewUrls: List<String> = emptyList()
-
-    var thumbnailImageUrl: String? = null
-    var thumbnailImageType: String? = null
 
     var scanlator: String? = null
 
@@ -80,7 +75,7 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
 
         return manga.copy(
             url = key ?: manga.url,
-            thumbnail_url = coverImageUrl ?: thumbnailImageUrl ?: manga.thumbnail_url,
+            thumbnail_url = coverImageUrl ?: manga.thumbnail_url,
             title = title,
             artist = group ?: manga.artist,
             author = artist ?: manga.artist,
@@ -108,9 +103,8 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
                 getItem(japaneseTitle) { stringResource(SYMR.strings.japanese_title) },
                 getItem(englishTitle) { stringResource(SYMR.strings.english_title) },
                 getItem(shortTitle) { stringResource(SYMR.strings.short_title) },
-                getItem(coverImageType) { stringResource(SYMR.strings.cover_image_file_type) },
+                getItem(coverImageUrl) { stringResource(SYMR.strings.thumbnail_url) },
                 getItem(pageImagePreviewUrls.size) { stringResource(SYMR.strings.page_count) },
-                getItem(thumbnailImageType) { stringResource(SYMR.strings.thumbnail_image_file_type) },
                 getItem(scanlator) { stringResource(MR.strings.scanlator) },
             )
         }
@@ -128,15 +122,6 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
         private const val NHENTAI_ARTIST_NAMESPACE = "artist"
         private const val NHENTAI_GROUP_NAMESPACE = "group"
         const val NHENTAI_CATEGORIES_NAMESPACE = "category"
-
-        fun typeToExtension(t: String?) =
-            when (t) {
-                "p" -> "png"
-                "j" -> "jpg"
-                "g" -> "gif"
-                "w" -> "webp"
-                else -> null
-            }
 
         fun nhUrlToId(url: String) =
             url.split("/").last { it.isNotBlank() }.toLong()

--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
@@ -1,7 +1,6 @@
 package exh.metadata.metadata
 
 import android.content.Context
-import android.util.Log
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.copy
 import exh.metadata.MetadataUtil

--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
@@ -80,7 +80,7 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
 
         return manga.copy(
             url = key ?: manga.url,
-            thumbnail_url = coverImageUrl ?: thumbnailImageUrl?: manga.thumbnail_url,
+            thumbnail_url = coverImageUrl ?: thumbnailImageUrl ?: manga.thumbnail_url,
             title = title,
             artist = group ?: manga.artist,
             author = artist ?: manga.artist,

--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
@@ -30,8 +30,6 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
 
     var mediaId: String? = null
 
-    var mediaServer: Int? = null
-
     var japaneseTitle by titleDelegate(TITLE_TYPE_JAPANESE)
     var englishTitle by titleDelegate(TITLE_TYPE_ENGLISH)
     var shortTitle by titleDelegate(TITLE_TYPE_SHORT)

--- a/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
+++ b/source-api/src/commonMain/kotlin/exh/metadata/metadata/NHentaiSearchMetadata.kt
@@ -1,6 +1,7 @@
 package exh.metadata.metadata
 
 import android.content.Context
+import android.util.Log
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.copy
 import exh.metadata.MetadataUtil
@@ -35,8 +36,12 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
     var englishTitle by titleDelegate(TITLE_TYPE_ENGLISH)
     var shortTitle by titleDelegate(TITLE_TYPE_SHORT)
 
+    var coverImageUrl: String? = null
     var coverImageType: String? = null
-    var pageImageTypes: List<String> = emptyList()
+
+    var pageImagePreviewUrls: List<String> = emptyList()
+
+    var thumbnailImageUrl: String? = null
     var thumbnailImageType: String? = null
 
     var scanlator: String? = null
@@ -45,16 +50,6 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
 
     override fun createMangaInfo(manga: SManga): SManga {
         val key = nhId?.let { nhIdToPath(it) }
-
-        val cover = if (mediaId != null) {
-            // Default media server for cover is always 1 (see in page header)
-            val server = mediaServer ?: 1
-            typeToExtension(coverImageType)?.let {
-                "https://t$server.nhentai.net/galleries/$mediaId/cover.$it"
-            }
-        } else {
-            null
-        }
 
         val title = when (preferredTitle) {
             TITLE_TYPE_SHORT -> shortTitle ?: englishTitle ?: japaneseTitle ?: manga.title
@@ -88,7 +83,7 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
 
         return manga.copy(
             url = key ?: manga.url,
-            thumbnail_url = cover ?: manga.thumbnail_url,
+            thumbnail_url = coverImageUrl ?: thumbnailImageUrl?: manga.thumbnail_url,
             title = title,
             artist = group ?: manga.artist,
             author = artist ?: manga.artist,
@@ -117,7 +112,7 @@ class NHentaiSearchMetadata : RaisedSearchMetadata() {
                 getItem(englishTitle) { stringResource(SYMR.strings.english_title) },
                 getItem(shortTitle) { stringResource(SYMR.strings.short_title) },
                 getItem(coverImageType) { stringResource(SYMR.strings.cover_image_file_type) },
-                getItem(pageImageTypes.size) { stringResource(SYMR.strings.page_count) },
+                getItem(pageImagePreviewUrls.size) { stringResource(SYMR.strings.page_count) },
                 getItem(thumbnailImageType) { stringResource(SYMR.strings.thumbnail_image_file_type) },
                 getItem(scanlator) { stringResource(MR.strings.scanlator) },
             )


### PR DESCRIPTION
(This fix can be cherry-picked from upstream)

Parses a json instead of an html page

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Migrate the NHentai delegate to use the v2 JSON API for gallery data and image previews instead of parsing HTML.

New Features:
- Support configurable NHentai image and thumbnail servers via the v2 API config endpoint.
- Store full cover and thumbnail image URLs and per-page preview URLs in NHentai metadata for downstream use.

Bug Fixes:
- Fix cover, thumbnail, and page preview loading for NHentai by switching from fragile HTML scraping to the official JSON API.

Enhancements:
- Simplify NHentai image type handling by deriving file types from API-provided paths rather than inferred extensions.
- Update UI bindings and metadata to rely on preview URL lists instead of page image type lists.

## Summary by Sourcery

Migrate the NHentai delegate to use the v2 JSON API for gallery metadata and previews instead of parsing HTML and inferring image types.

Bug Fixes:
- Restore reliable loading of NHentai covers, thumbnails, and page previews by switching from fragile HTML scraping to the JSON API responses.

Enhancements:
- Store full cover and per-page preview URLs in NHentai metadata and use them throughout the app instead of media server IDs and image-type codes.
- Fetch NHentai image/thumb server configuration from the v2 config endpoint with sensible fallbacks when unavailable.
- Simplify NHentai metadata and UI bindings by basing page counts and thumbnails on preview URL lists rather than page image type lists.