### PR TITLE
feat(Anilist): Parse GraphQL error responses for downtime and token expiry

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -58,7 +58,6 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         } catch (e: Exception) {
             if (e.message?.contains("AniList") == true) throw e
         }
-        
         if (!isSuccessful) {
             throw Exception("AniList error ${code()}")
         }
@@ -66,12 +65,12 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     suspend fun addLibManga(track: Track): Track {
         return withIOContext {
-            val query = """
+            val query = $$"""
             |mutation AddManga($mangaId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean) {
-            |    SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
+            |   SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
             |       id
             |       status
-            |    }
+            |   }
             |}
             |
             """.trimMargin()
@@ -84,39 +83,40 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("private", track.private)
                 }
             }
-            
             val response = authClient.newCall(
                 POST(
                     API_URL,
                     body = payload.toString().toRequestBody(jsonMime),
                 ),
             ).execute()
-
             if (!response.isSuccessful) {
                 response.parseALError()
             }
-
-            val result = json.decodeFromString<ALAddMangaResult>(response.body?.string()!!)
-            track.library_id = result.data.entry.id
-            track
+            with(json) {
+                decodeFromString<ALAddMangaResult>(response.body?.string()!!)
+                    .let {
+                        track.library_id = it.data.entry.id
+                        track
+                    }
+            }
         }
     }
 
     suspend fun updateLibManga(track: Track): Track {
         return withIOContext {
-            val query = """
+            val query = $$"""
             |mutation UpdateManga(
-            |    $listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
-            |    $score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
+            |   $listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
+            |   $score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
             |) {
-            |    SaveMediaListEntry(
-            |        id: $listId, progress: $progress, status: $status, private: $private,
-            |        scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
-            |    ) {
-            |        id
-            |        status
-            |        progress
-            |    }
+            |   SaveMediaListEntry(
+            |       id: $listId, progress: $progress, status: $status, private: $private,
+            |       scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
+            |   ) {
+            |       id
+            |       status
+            |       progress
+            |   }
             |}
             |
             """.trimMargin()
@@ -142,11 +142,11 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     suspend fun deleteLibManga(track: DomainTrack) {
         withIOContext {
-            val query = """
+            val query = $$"""
             |mutation DeleteManga($listId: Int) {
-            |    DeleteMediaListEntry(id: $listId) {
-            |        deleted
-            |    }
+            |   DeleteMediaListEntry(id: $listId) {
+            |       deleted
+            |   }
             |}
             |
             """.trimMargin()
@@ -165,42 +165,42 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     suspend fun search(search: String): List<TrackSearch> {
         return withIOContext {
-            val query = """
+            val query = $$"""
             |query Search($query: String) {
-            |    Page (perPage: 50) {
-            |        media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
-            |            id
-            |            staff {
-            |                edges {
-            |                    role
-            |                    id
-            |                    node {
-            |                        name {
-            |                            full
-            |                            userPreferred
-            |                            native
-            |                        }
-            |                    }
-            |                }
-            |            }
-            |            title {
-            |                userPreferred
-            |            }
-            |            coverImage {
-            |                large
-            |            }
-            |            format
-            |            status
-            |            chapters
-            |            description
-            |            startDate {
-            |                year
-            |                month
-            |                day
-            |            }
-            |            averageScore
-            |        }
-            |    }
+            |   Page (perPage: 50) {
+            |       media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
+            |           id
+            |           staff {
+            |               edges {
+            |                   role
+            |                   id
+            |                   node {
+            |                       name {
+            |                           full
+            |                           userPreferred
+            |                           native
+            |                       }
+            |                   }
+            |               }
+            |           }
+            |           title {
+            |               userPreferred
+            |           }
+            |           coverImage {
+            |               large
+            |           }
+            |           format
+            |           status
+            |           chapters
+            |           description
+            |           startDate {
+            |               year
+            |               month
+            |               day
+            |           }
+            |           averageScore
+            |       }
+            |   }
             |}
             |
             """.trimMargin()
@@ -210,77 +210,77 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("query", search)
                 }
             }
-            
             val response = authClient.newCall(
                 POST(
                     API_URL,
                     body = payload.toString().toRequestBody(jsonMime),
                 ),
             ).execute()
-
             if (!response.isSuccessful) {
                 response.parseALError()
             }
-
-            val result = json.decodeFromString<ALSearchResult>(response.body?.string()!!)
-            result.data.page.media.map { it.toALManga().toTrack() }
+            with(json) {
+                decodeFromString<ALSearchResult>(response.body?.string()!!)
+                    .data.page.media
+                    .map { it.toALManga().toTrack() }
+            }
         }
     }
 
     suspend fun findLibManga(track: Track, userid: Int): Track? {
         return withIOContext {
-            val query = """
+            val query = $$"""
             |query ($id: Int!, $manga_id: Int!) {
-            |    Page {
-            |        mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
-            |            id
-            |            status
-            |            scoreRaw: score(format: POINT_100)
-            |            progress
-            |            private
-            |            startedAt {
-            |                year
-            |                month
-            |                day
-            |            }
-            |            completedAt {
-            |                year
-            |                month
-            |                day
-            |            }
-            |            media {
-            |                id
-            |                title {
-            |                    userPreferred
-            |                }
-            |                coverImage {
-            |                    large
-            |                }
-            |                format
-            |                status
-            |                chapters
-            |                description
-            |                startDate {
-            |                    year
-            |                    month
-            |                    day
-            |                }
-            |                staff {
-            |                    edges {
-            |                        role
-            |                        id
-            |                        node {
-            |                            name {
-            |                                full
-            |                                userPreferred
-            |                                native
-            |                            }
-            |                        }
-            |                    }
-            |                }
-            |            }
-            |        }
-            |    }
+            |   Page {
+            |       mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
+            |           id
+            |           status
+            |           scoreRaw: score(format: POINT_100)
+            |           progress
+            |           private
+            |           startedAt {
+            |               year
+            |               month
+            |               day
+            |           }
+            |           completedAt {
+            |               year
+            |               month
+            |               day
+            |           }
+            |           media {
+            |               id
+            |               title {
+            |                   userPreferred
+            |               }
+            |               coverImage {
+            |                   large
+            |               }
+            |               format
+            |               status
+            |               chapters
+            |               description
+            |               startDate {
+            |                   year
+            |                   month
+            |                   day
+            |               }
+            |               staff {
+            |                   edges {
+            |                       role
+            |                       id
+            |                       node {
+            |                           name {
+            |                               full
+            |                               userPreferred
+            |                               native
+            |                           }
+            |                       }
+            |                   }
+            |               }
+            |           }
+            |       }
+            |   }
             |}
             |
             """.trimMargin()
@@ -291,23 +291,22 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("manga_id", track.remote_id)
                 }
             }
-            
             val response = authClient.newCall(
                 POST(
                     API_URL,
                     body = payload.toString().toRequestBody(jsonMime),
                 ),
             ).execute()
-
             if (!response.isSuccessful) {
                 response.parseALError()
             }
-
-            val result = json.decodeFromString<ALUserListMangaQueryResult>(response.body?.string()!!)
-            result.data.page.mediaList
-                .map { it.toALUserManga() }
-                .firstOrNull()
-                ?.toTrack()
+            with(json) {
+                decodeFromString<ALUserListMangaQueryResult>(response.body?.string()!!)
+                    .data.page.mediaList
+                    .map { it.toALUserManga() }
+                    .firstOrNull()
+                    ?.toTrack()
+            }
         }
     }
 
@@ -323,33 +322,34 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query User {
-            |    Viewer {
-            |        id
-            |        mediaListOptions {
-            |            scoreFormat
-            |        }
-            |    }
+            |   Viewer {
+            |       id
+            |       mediaListOptions {
+            |           scoreFormat
+            |       }
+            |   }
             |}
             |
             """.trimMargin()
             val payload = buildJsonObject {
                 put("query", query)
             }
-            
             val response = authClient.newCall(
                 POST(
                     API_URL,
                     body = payload.toString().toRequestBody(jsonMime),
                 ),
             ).execute()
-
             if (!response.isSuccessful) {
                 response.parseALError()
             }
-
-            val result = json.decodeFromString<ALCurrentUserResult>(response.body?.string()!!)
-            val viewer = result.data.viewer
-            Pair(viewer.id, viewer.mediaListOptions.scoreFormat)
+            with(json) {
+                decodeFromString<ALCurrentUserResult>(response.body?.string()!!)
+                    .let {
+                        val viewer = it.data.viewer
+                        Pair(viewer.id, viewer.mediaListOptions.scoreFormat)
+                    }
+            }
         }
     }
 
@@ -357,29 +357,29 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-            |    Media (id: ${'$'}mangaId) {
-            |        id
-            |        title {
-            |            userPreferred
-            |        }
-            |        coverImage {
-            |            large
-            |        }
-            |        description
-            |        staff {
-            |            edges {
-            |                role
-            |                id
-            |                node {
-            |                    name {
-            |                        full
-            |                        userPreferred
-            |                        native
-            |                    }
-            |                }
-            |            }
-            |        }
-            |    }
+            |   Media (id: ${'$'}mangaId) {
+            |       id
+            |       title {
+            |           userPreferred
+            |       }
+            |       coverImage {
+            |           large
+            |       }
+            |       description
+            |       staff {
+            |           edges {
+            |               role
+            |               id
+            |               node {
+            |                   name {
+            |                       full
+            |                       userPreferred
+            |                       native
+            |                   }
+            |               }
+            |           }
+            |       }
+            |   }
             |}
             |
             """.trimMargin()
@@ -389,36 +389,37 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("mangaId", track.remoteId)
                 }
             }
-            
             val response = authClient.newCall(
                 POST(
                     API_URL,
                     body = payload.toString().toRequestBody(jsonMime),
                 ),
             ).execute()
-
             if (!response.isSuccessful) {
                 response.parseALError()
             }
-
-            val result = json.decodeFromString<ALMangaMetadata>(response.body?.string()!!)
-            val media = result.data.media
-            TrackMangaMetadata(
-                remoteId = media.id,
-                title = media.title.userPreferred,
-                thumbnailUrl = media.coverImage.large,
-                description = media.description?.htmlDecode()?.ifEmpty { null },
-                authors = media.staff.edges
-                    .filter { "Story" in it.role }
-                    .mapNotNull { it.node.name() }
-                    .joinToString(", ")
-                    .ifEmpty { null },
-                artists = media.staff.edges
-                    .filter { "Art" in it.role }
-                    .mapNotNull { it.node.name() }
-                    .joinToString(", ")
-                    .ifEmpty { null },
-            )
+            with(json) {
+                decodeFromString<ALMangaMetadata>(response.body?.string()!!)
+                    .let {
+                        val media = it.data.media
+                        TrackMangaMetadata(
+                            remoteId = media.id,
+                            title = media.title.userPreferred,
+                            thumbnailUrl = media.coverImage.large,
+                            description = media.description?.htmlDecode()?.ifEmpty { null },
+                            authors = media.staff.edges
+                                .filter { "Story" in it.role }
+                                .mapNotNull { it.node.name() }
+                                .joinToString(", ")
+                                .ifEmpty { null },
+                            artists = media.staff.edges
+                                .filter { "Art" in it.role }
+                                .mapNotNull { it.node.name() }
+                                .joinToString(", ")
+                                .ifEmpty { null },
+                        )
+                    }
+            }
         }
     }
 
@@ -427,25 +428,25 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-            |    Media (id: ${'$'}mangaId) {
-            |        id
-            |        title {
-            |            userPreferred
-            |        }
-            |        coverImage {
-            |            large
-            |        }
-            |        format
-            |        status
-            |        chapters
-            |        description
-            |        startDate {
-            |            year
-            |            month
-            |            day
-            |        }
-            |        averageScore
-            |    }
+            |   Media (id: ${'$'}mangaId) {
+            |       id
+            |       title {
+            |           userPreferred
+            |       }
+            |       coverImage {
+            |           large
+            |       }
+            |       format
+            |       status
+            |       chapters
+            |       description
+            |       startDate {
+            |           year
+            |           month
+            |           day
+            |       }
+            |       averageScore
+            |   }
             |}
             |
             """.trimMargin()
@@ -455,20 +456,21 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("mangaId", id)
                 }
             }
-            
             val response = authClient.newCall(
                 POST(
                     API_URL,
                     body = payload.toString().toRequestBody(jsonMime),
                 ),
             ).execute()
-
             if (!response.isSuccessful) {
                 response.parseALError()
             }
-
-            val result = json.decodeFromString<ALIdSearchResult>(response.body?.string()!!)
-            result.data.media.toALManga().toTrack()
+            with(json) {
+                decodeFromString<ALIdSearchResult>(response.body?.string()!!)
+                    .data.media
+                    .toALManga()
+                    .toTrack()
+            }
         }
     }
     // SY <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -46,18 +46,19 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         .build()
 
     private fun Response.parseALError() {
-        val bodyString = peekBody(Long.MAX_VALUE).string()
-        try {
-            val errorObj = json.decodeFromString<ALError>(bodyString)
-            errorObj.errors?.firstOrNull()?.let {
-                val msg = it.message
-                if (msg.contains("Invalid token") || code == 401) {
-                    throw Exception("AniList token expired, please login again")
-                }
-                throw Exception(msg)
-            }
+        val bodyString = peekBody(1024 * 1024).string()
+        val errorObj = try {
+            json.decodeFromString<ALError>(bodyString)
         } catch (e: Exception) {
-            if (e.message?.contains("AniList") == true || e.message?.contains("token") == true) throw e
+            null
+        }
+
+        errorObj?.errors?.firstOrNull()?.let {
+            val msg = it.message
+            if (msg.contains("Invalid token") || it.status == 401) {
+                throw Exception("AniList token expired, please login again")
+            }
+            throw Exception(msg)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -5,6 +5,7 @@ import androidx.core.net.toUri
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALAddMangaResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALCurrentUserResult
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALError
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALIdSearchResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALMangaMetadata
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
@@ -43,14 +44,34 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         .rateLimit(permits = 85, period = 1.minutes)
         .build()
 
+    private fun okhttp3.Response.parseALError() {
+        val bodyString = body?.string() ?: return
+        try {
+            val errorObj = json.decodeFromString<ALError>(bodyString)
+            val message = errorObj.errors?.firstOrNull()?.message
+            if (!message.isNullOrBlank()) {
+                if (message.contains("Invalid token")) {
+                    throw Exception("AniList token expired, please login again")
+                }
+                throw Exception(message)
+            }
+        } catch (e: Exception) {
+            if (e.message?.contains("AniList") == true) throw e
+        }
+        
+        if (!isSuccessful) {
+            throw Exception("AniList error ${code()}")
+        }
+    }
+
     suspend fun addLibManga(track: Track): Track {
         return withIOContext {
-            val query = $$"""
+            val query = """
             |mutation AddManga($mangaId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean) {
-                |SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
-                |   id
-                |   status
-                |}
+            |    SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
+            |       id
+            |       status
+            |    }
             |}
             |
             """.trimMargin()
@@ -63,38 +84,39 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("private", track.private)
                 }
             }
-            with(json) {
-                authClient.newCall(
-                    POST(
-                        API_URL,
-                        body = payload.toString().toRequestBody(jsonMime),
-                    ),
-                )
-                    .awaitSuccess()
-                    .parseAs<ALAddMangaResult>()
-                    .let {
-                        track.library_id = it.data.entry.id
-                        track
-                    }
+            
+            val response = authClient.newCall(
+                POST(
+                    API_URL,
+                    body = payload.toString().toRequestBody(jsonMime),
+                ),
+            ).execute()
+
+            if (!response.isSuccessful) {
+                response.parseALError()
             }
+
+            val result = json.decodeFromString<ALAddMangaResult>(response.body?.string()!!)
+            track.library_id = result.data.entry.id
+            track
         }
     }
 
     suspend fun updateLibManga(track: Track): Track {
         return withIOContext {
-            val query = $$"""
+            val query = """
             |mutation UpdateManga(
-                |$listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
-                |$score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
+            |    $listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
+            |    $score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
             |) {
-                |SaveMediaListEntry(
-                    |id: $listId, progress: $progress, status: $status, private: $private,
-                    |scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
-                |) {
-                    |id
-                    |status
-                    |progress
-                |}
+            |    SaveMediaListEntry(
+            |        id: $listId, progress: $progress, status: $status, private: $private,
+            |        scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
+            |    ) {
+            |        id
+            |        status
+            |        progress
+            |    }
             |}
             |
             """.trimMargin()
@@ -110,19 +132,21 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("private", track.private)
                 }
             }
-            authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
-                .awaitSuccess()
+            val response = authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime))).execute()
+            if (!response.isSuccessful) {
+                response.parseALError()
+            }
             track
         }
     }
 
     suspend fun deleteLibManga(track: DomainTrack) {
         withIOContext {
-            val query = $$"""
+            val query = """
             |mutation DeleteManga($listId: Int) {
-                |DeleteMediaListEntry(id: $listId) {
-                    |deleted
-                |}
+            |    DeleteMediaListEntry(id: $listId) {
+            |        deleted
+            |    }
             |}
             |
             """.trimMargin()
@@ -132,49 +156,51 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("listId", track.libraryId)
                 }
             }
-            authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
-                .awaitSuccess()
+            val response = authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime))).execute()
+            if (!response.isSuccessful) {
+                response.parseALError()
+            }
         }
     }
 
     suspend fun search(search: String): List<TrackSearch> {
         return withIOContext {
-            val query = $$"""
+            val query = """
             |query Search($query: String) {
-                |Page (perPage: 50) {
-                    |media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
-                        |id
-                        |staff {
-                            |edges {
-                                |role
-                                |id
-                                |node {
-                                    |name {
-                                        |full
-                                        |userPreferred
-                                        |native
-                                    |}
-                                |}
-                            |}
-                        |}
-                        |title {
-                            |userPreferred
-                        |}
-                        |coverImage {
-                            |large
-                        |}
-                        |format
-                        |status
-                        |chapters
-                        |description
-                        |startDate {
-                            |year
-                            |month
-                            |day
-                        |}
-                        |averageScore
-                    |}
-                |}
+            |    Page (perPage: 50) {
+            |        media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
+            |            id
+            |            staff {
+            |                edges {
+            |                    role
+            |                    id
+            |                    node {
+            |                        name {
+            |                            full
+            |                            userPreferred
+            |                            native
+            |                        }
+            |                    }
+            |                }
+            |            }
+            |            title {
+            |                userPreferred
+            |            }
+            |            coverImage {
+            |                large
+            |            }
+            |            format
+            |            status
+            |            chapters
+            |            description
+            |            startDate {
+            |                year
+            |                month
+            |                day
+            |            }
+            |            averageScore
+            |        }
+            |    }
             |}
             |
             """.trimMargin()
@@ -184,75 +210,77 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("query", search)
                 }
             }
-            with(json) {
-                authClient.newCall(
-                    POST(
-                        API_URL,
-                        body = payload.toString().toRequestBody(jsonMime),
-                    ),
-                )
-                    .awaitSuccess()
-                    .parseAs<ALSearchResult>()
-                    .data.page.media
-                    .map { it.toALManga().toTrack() }
+            
+            val response = authClient.newCall(
+                POST(
+                    API_URL,
+                    body = payload.toString().toRequestBody(jsonMime),
+                ),
+            ).execute()
+
+            if (!response.isSuccessful) {
+                response.parseALError()
             }
+
+            val result = json.decodeFromString<ALSearchResult>(response.body?.string()!!)
+            result.data.page.media.map { it.toALManga().toTrack() }
         }
     }
 
     suspend fun findLibManga(track: Track, userid: Int): Track? {
         return withIOContext {
-            val query = $$"""
+            val query = """
             |query ($id: Int!, $manga_id: Int!) {
-                |Page {
-                    |mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
-                        |id
-                        |status
-                        |scoreRaw: score(format: POINT_100)
-                        |progress
-                        |private
-                        |startedAt {
-                            |year
-                            |month
-                            |day
-                        |}
-                        |completedAt {
-                            |year
-                            |month
-                            |day
-                        |}
-                        |media {
-                            |id
-                            |title {
-                                |userPreferred
-                            |}
-                            |coverImage {
-                                |large
-                            |}
-                            |format
-                            |status
-                            |chapters
-                            |description
-                            |startDate {
-                                |year
-                                |month
-                                |day
-                            |}
-                            |staff {
-                                |edges {
-                                    |role
-                                    |id
-                                    |node {
-                                        |name {
-                                            |full
-                                            |userPreferred
-                                            |native
-                                        |}
-                                    |}
-                                |}
-                            |}
-                        |}
-                    |}
-                |}
+            |    Page {
+            |        mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
+            |            id
+            |            status
+            |            scoreRaw: score(format: POINT_100)
+            |            progress
+            |            private
+            |            startedAt {
+            |                year
+            |                month
+            |                day
+            |            }
+            |            completedAt {
+            |                year
+            |                month
+            |                day
+            |            }
+            |            media {
+            |                id
+            |                title {
+            |                    userPreferred
+            |                }
+            |                coverImage {
+            |                    large
+            |                }
+            |                format
+            |                status
+            |                chapters
+            |                description
+            |                startDate {
+            |                    year
+            |                    month
+            |                    day
+            |                }
+            |                staff {
+            |                    edges {
+            |                        role
+            |                        id
+            |                        node {
+            |                            name {
+            |                                full
+            |                                userPreferred
+            |                                native
+            |                            }
+            |                        }
+            |                    }
+            |                }
+            |            }
+            |        }
+            |    }
             |}
             |
             """.trimMargin()
@@ -263,20 +291,23 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("manga_id", track.remote_id)
                 }
             }
-            with(json) {
-                authClient.newCall(
-                    POST(
-                        API_URL,
-                        body = payload.toString().toRequestBody(jsonMime),
-                    ),
-                )
-                    .awaitSuccess()
-                    .parseAs<ALUserListMangaQueryResult>()
-                    .data.page.mediaList
-                    .map { it.toALUserManga() }
-                    .firstOrNull()
-                    ?.toTrack()
+            
+            val response = authClient.newCall(
+                POST(
+                    API_URL,
+                    body = payload.toString().toRequestBody(jsonMime),
+                ),
+            ).execute()
+
+            if (!response.isSuccessful) {
+                response.parseALError()
             }
+
+            val result = json.decodeFromString<ALUserListMangaQueryResult>(response.body?.string()!!)
+            result.data.page.mediaList
+                .map { it.toALUserManga() }
+                .firstOrNull()
+                ?.toTrack()
         }
     }
 
@@ -292,32 +323,33 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query User {
-                |Viewer {
-                    |id
-                    |mediaListOptions {
-                        |scoreFormat
-                    |}
-                |}
+            |    Viewer {
+            |        id
+            |        mediaListOptions {
+            |            scoreFormat
+            |        }
+            |    }
             |}
             |
             """.trimMargin()
             val payload = buildJsonObject {
                 put("query", query)
             }
-            with(json) {
-                authClient.newCall(
-                    POST(
-                        API_URL,
-                        body = payload.toString().toRequestBody(jsonMime),
-                    ),
-                )
-                    .awaitSuccess()
-                    .parseAs<ALCurrentUserResult>()
-                    .let {
-                        val viewer = it.data.viewer
-                        Pair(viewer.id, viewer.mediaListOptions.scoreFormat)
-                    }
+            
+            val response = authClient.newCall(
+                POST(
+                    API_URL,
+                    body = payload.toString().toRequestBody(jsonMime),
+                ),
+            ).execute()
+
+            if (!response.isSuccessful) {
+                response.parseALError()
             }
+
+            val result = json.decodeFromString<ALCurrentUserResult>(response.body?.string()!!)
+            val viewer = result.data.viewer
+            Pair(viewer.id, viewer.mediaListOptions.scoreFormat)
         }
     }
 
@@ -325,29 +357,29 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-                |Media (id: ${'$'}mangaId) {
-                    |id
-                    |title {
-                        |userPreferred
-                    |}
-                    |coverImage {
-                        |large
-                    |}
-                    |description
-                    |staff {
-                        |edges {
-                            |role
-                            |id
-                            |node {
-                                |name {
-                                    |full
-                                    |userPreferred
-                                    |native
-                                |}
-                            |}
-                        |}
-                    |}
-                |}
+            |    Media (id: ${'$'}mangaId) {
+            |        id
+            |        title {
+            |            userPreferred
+            |        }
+            |        coverImage {
+            |            large
+            |        }
+            |        description
+            |        staff {
+            |            edges {
+            |                role
+            |                id
+            |                node {
+            |                    name {
+            |                        full
+            |                        userPreferred
+            |                        native
+            |                    }
+            |                }
+            |            }
+            |        }
+            |    }
             |}
             |
             """.trimMargin()
@@ -357,35 +389,36 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("mangaId", track.remoteId)
                 }
             }
-            with(json) {
-                authClient.newCall(
-                    POST(
-                        API_URL,
-                        body = payload.toString().toRequestBody(jsonMime),
-                    ),
-                )
-                    .awaitSuccess()
-                    .parseAs<ALMangaMetadata>()
-                    .let {
-                        val media = it.data.media
-                        TrackMangaMetadata(
-                            remoteId = media.id,
-                            title = media.title.userPreferred,
-                            thumbnailUrl = media.coverImage.large,
-                            description = media.description?.htmlDecode()?.ifEmpty { null },
-                            authors = media.staff.edges
-                                .filter { "Story" in it.role }
-                                .mapNotNull { it.node.name() }
-                                .joinToString(", ")
-                                .ifEmpty { null },
-                            artists = media.staff.edges
-                                .filter { "Art" in it.role }
-                                .mapNotNull { it.node.name() }
-                                .joinToString(", ")
-                                .ifEmpty { null },
-                        )
-                    }
+            
+            val response = authClient.newCall(
+                POST(
+                    API_URL,
+                    body = payload.toString().toRequestBody(jsonMime),
+                ),
+            ).execute()
+
+            if (!response.isSuccessful) {
+                response.parseALError()
             }
+
+            val result = json.decodeFromString<ALMangaMetadata>(response.body?.string()!!)
+            val media = result.data.media
+            TrackMangaMetadata(
+                remoteId = media.id,
+                title = media.title.userPreferred,
+                thumbnailUrl = media.coverImage.large,
+                description = media.description?.htmlDecode()?.ifEmpty { null },
+                authors = media.staff.edges
+                    .filter { "Story" in it.role }
+                    .mapNotNull { it.node.name() }
+                    .joinToString(", ")
+                    .ifEmpty { null },
+                artists = media.staff.edges
+                    .filter { "Art" in it.role }
+                    .mapNotNull { it.node.name() }
+                    .joinToString(", ")
+                    .ifEmpty { null },
+            )
         }
     }
 
@@ -394,25 +427,25 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-                |Media (id: ${'$'}mangaId) {
-                    |id
-                    |title {
-                        |userPreferred
-                    |}
-                    |coverImage {
-                        |large
-                    |}
-                    |format
-                    |status
-                    |chapters
-                    |description
-                    |startDate {
-                        |year
-                        |month
-                        |day
-                    |}
-                    |averageScore
-                |}
+            |    Media (id: ${'$'}mangaId) {
+            |        id
+            |        title {
+            |            userPreferred
+            |        }
+            |        coverImage {
+            |            large
+            |        }
+            |        format
+            |        status
+            |        chapters
+            |        description
+            |        startDate {
+            |            year
+            |            month
+            |            day
+            |        }
+            |        averageScore
+            |    }
             |}
             |
             """.trimMargin()
@@ -422,19 +455,20 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("mangaId", id)
                 }
             }
-            with(json) {
-                authClient.newCall(
-                    POST(
-                        API_URL,
-                        body = payload.toString().toRequestBody(jsonMime),
-                    ),
-                )
-                    .awaitSuccess()
-                    .parseAs<ALIdSearchResult>()
-                    .data.media
-                    .toALManga()
-                    .toTrack()
+            
+            val response = authClient.newCall(
+                POST(
+                    API_URL,
+                    body = payload.toString().toRequestBody(jsonMime),
+                ),
+            ).execute()
+
+            if (!response.isSuccessful) {
+                response.parseALError()
             }
+
+            val result = json.decodeFromString<ALIdSearchResult>(response.body?.string()!!)
+            result.data.media.toALManga().toTrack()
         }
     }
     // SY <--
@@ -457,7 +491,6 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
     }
 
     companion object {
-        // Registered under KMK's MAL account
         private const val CLIENT_ID = "16801"
         private const val API_URL = "https://graphql.anilist.co/"
         private const val BASE_URL = "https://anilist.co/api/v2/"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -5,7 +5,6 @@ import androidx.core.net.toUri
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALAddMangaResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALCurrentUserResult
-import eu.kanade.tachiyomi.data.track.anilist.dto.ALError
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALIdSearchResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALMangaMetadata
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
@@ -44,33 +43,14 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         .rateLimit(permits = 85, period = 1.minutes)
         .build()
 
-    private fun okhttp3.Response.parseALError() {
-        val bodyString = body?.string() ?: return
-        try {
-            val errorObj = json.decodeFromString<ALError>(bodyString)
-            val message = errorObj.errors?.firstOrNull()?.message
-            if (!message.isNullOrBlank()) {
-                if (message.contains("Invalid token")) {
-                    throw Exception("AniList token expired, please login again")
-                }
-                throw Exception(message)
-            }
-        } catch (e: Exception) {
-            if (e.message?.contains("AniList") == true) throw e
-        }
-        if (!isSuccessful) {
-            throw Exception("AniList error ${code()}")
-        }
-    }
-
     suspend fun addLibManga(track: Track): Track {
         return withIOContext {
             val query = $$"""
             |mutation AddManga($mangaId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean) {
-            |   SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
-            |       id
-            |       status
-            |   }
+                |SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
+                |   id
+                |   status
+                |}
             |}
             |
             """.trimMargin()
@@ -83,17 +63,15 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("private", track.private)
                 }
             }
-            val response = authClient.newCall(
-                POST(
-                    API_URL,
-                    body = payload.toString().toRequestBody(jsonMime),
-                ),
-            ).execute()
-            if (!response.isSuccessful) {
-                response.parseALError()
-            }
             with(json) {
-                decodeFromString<ALAddMangaResult>(response.body?.string()!!)
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALAddMangaResult>()
                     .let {
                         track.library_id = it.data.entry.id
                         track
@@ -106,17 +84,17 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |mutation UpdateManga(
-            |   $listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
-            |   $score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
+                |$listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
+                |$score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
             |) {
-            |   SaveMediaListEntry(
-            |       id: $listId, progress: $progress, status: $status, private: $private,
-            |       scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
-            |   ) {
-            |       id
-            |       status
-            |       progress
-            |   }
+                |SaveMediaListEntry(
+                    |id: $listId, progress: $progress, status: $status, private: $private,
+                    |scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
+                |) {
+                    |id
+                    |status
+                    |progress
+                |}
             |}
             |
             """.trimMargin()
@@ -132,10 +110,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("private", track.private)
                 }
             }
-            val response = authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime))).execute()
-            if (!response.isSuccessful) {
-                response.parseALError()
-            }
+            authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
+                .awaitSuccess()
             track
         }
     }
@@ -144,9 +120,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         withIOContext {
             val query = $$"""
             |mutation DeleteManga($listId: Int) {
-            |   DeleteMediaListEntry(id: $listId) {
-            |       deleted
-            |   }
+                |DeleteMediaListEntry(id: $listId) {
+                    |deleted
+                |}
             |}
             |
             """.trimMargin()
@@ -156,10 +132,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("listId", track.libraryId)
                 }
             }
-            val response = authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime))).execute()
-            if (!response.isSuccessful) {
-                response.parseALError()
-            }
+            authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
+                .awaitSuccess()
         }
     }
 
@@ -167,40 +141,40 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |query Search($query: String) {
-            |   Page (perPage: 50) {
-            |       media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
-            |           id
-            |           staff {
-            |               edges {
-            |                   role
-            |                   id
-            |                   node {
-            |                       name {
-            |                           full
-            |                           userPreferred
-            |                           native
-            |                       }
-            |                   }
-            |               }
-            |           }
-            |           title {
-            |               userPreferred
-            |           }
-            |           coverImage {
-            |               large
-            |           }
-            |           format
-            |           status
-            |           chapters
-            |           description
-            |           startDate {
-            |               year
-            |               month
-            |               day
-            |           }
-            |           averageScore
-            |       }
-            |   }
+                |Page (perPage: 50) {
+                    |media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
+                        |id
+                        |staff {
+                            |edges {
+                                |role
+                                |id
+                                |node {
+                                    |name {
+                                        |full
+                                        |userPreferred
+                                        |native
+                                    |}
+                                |}
+                            |}
+                        |}
+                        |title {
+                            |userPreferred
+                        |}
+                        |coverImage {
+                            |large
+                        |}
+                        |format
+                        |status
+                        |chapters
+                        |description
+                        |startDate {
+                            |year
+                            |month
+                            |day
+                        |}
+                        |averageScore
+                    |}
+                |}
             |}
             |
             """.trimMargin()
@@ -210,17 +184,15 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("query", search)
                 }
             }
-            val response = authClient.newCall(
-                POST(
-                    API_URL,
-                    body = payload.toString().toRequestBody(jsonMime),
-                ),
-            ).execute()
-            if (!response.isSuccessful) {
-                response.parseALError()
-            }
             with(json) {
-                decodeFromString<ALSearchResult>(response.body?.string()!!)
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALSearchResult>()
                     .data.page.media
                     .map { it.toALManga().toTrack() }
             }
@@ -231,56 +203,56 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |query ($id: Int!, $manga_id: Int!) {
-            |   Page {
-            |       mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
-            |           id
-            |           status
-            |           scoreRaw: score(format: POINT_100)
-            |           progress
-            |           private
-            |           startedAt {
-            |               year
-            |               month
-            |               day
-            |           }
-            |           completedAt {
-            |               year
-            |               month
-            |               day
-            |           }
-            |           media {
-            |               id
-            |               title {
-            |                   userPreferred
-            |               }
-            |               coverImage {
-            |                   large
-            |               }
-            |               format
-            |               status
-            |               chapters
-            |               description
-            |               startDate {
-            |                   year
-            |                   month
-            |                   day
-            |               }
-            |               staff {
-            |                   edges {
-            |                       role
-            |                       id
-            |                       node {
-            |                           name {
-            |                               full
-            |                               userPreferred
-            |                               native
-            |                           }
-            |                       }
-            |                   }
-            |               }
-            |           }
-            |       }
-            |   }
+                |Page {
+                    |mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
+                        |id
+                        |status
+                        |scoreRaw: score(format: POINT_100)
+                        |progress
+                        |private
+                        |startedAt {
+                            |year
+                            |month
+                            |day
+                        |}
+                        |completedAt {
+                            |year
+                            |month
+                            |day
+                        |}
+                        |media {
+                            |id
+                            |title {
+                                |userPreferred
+                            |}
+                            |coverImage {
+                                |large
+                            |}
+                            |format
+                            |status
+                            |chapters
+                            |description
+                            |startDate {
+                                |year
+                                |month
+                                |day
+                            |}
+                            |staff {
+                                |edges {
+                                    |role
+                                    |id
+                                    |node {
+                                        |name {
+                                            |full
+                                            |userPreferred
+                                            |native
+                                        |}
+                                    |}
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
             |}
             |
             """.trimMargin()
@@ -291,17 +263,15 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("manga_id", track.remote_id)
                 }
             }
-            val response = authClient.newCall(
-                POST(
-                    API_URL,
-                    body = payload.toString().toRequestBody(jsonMime),
-                ),
-            ).execute()
-            if (!response.isSuccessful) {
-                response.parseALError()
-            }
             with(json) {
-                decodeFromString<ALUserListMangaQueryResult>(response.body?.string()!!)
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALUserListMangaQueryResult>()
                     .data.page.mediaList
                     .map { it.toALUserManga() }
                     .firstOrNull()
@@ -322,29 +292,27 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query User {
-            |   Viewer {
-            |       id
-            |       mediaListOptions {
-            |           scoreFormat
-            |       }
-            |   }
+                |Viewer {
+                    |id
+                    |mediaListOptions {
+                        |scoreFormat
+                    |}
+                |}
             |}
             |
             """.trimMargin()
             val payload = buildJsonObject {
                 put("query", query)
             }
-            val response = authClient.newCall(
-                POST(
-                    API_URL,
-                    body = payload.toString().toRequestBody(jsonMime),
-                ),
-            ).execute()
-            if (!response.isSuccessful) {
-                response.parseALError()
-            }
             with(json) {
-                decodeFromString<ALCurrentUserResult>(response.body?.string()!!)
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALCurrentUserResult>()
                     .let {
                         val viewer = it.data.viewer
                         Pair(viewer.id, viewer.mediaListOptions.scoreFormat)
@@ -357,29 +325,29 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-            |   Media (id: ${'$'}mangaId) {
-            |       id
-            |       title {
-            |           userPreferred
-            |       }
-            |       coverImage {
-            |           large
-            |       }
-            |       description
-            |       staff {
-            |           edges {
-            |               role
-            |               id
-            |               node {
-            |                   name {
-            |                       full
-            |                       userPreferred
-            |                       native
-            |                   }
-            |               }
-            |           }
-            |       }
-            |   }
+                |Media (id: ${'$'}mangaId) {
+                    |id
+                    |title {
+                        |userPreferred
+                    |}
+                    |coverImage {
+                        |large
+                    |}
+                    |description
+                    |staff {
+                        |edges {
+                            |role
+                            |id
+                            |node {
+                                |name {
+                                    |full
+                                    |userPreferred
+                                    |native
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
             |}
             |
             """.trimMargin()
@@ -389,17 +357,15 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("mangaId", track.remoteId)
                 }
             }
-            val response = authClient.newCall(
-                POST(
-                    API_URL,
-                    body = payload.toString().toRequestBody(jsonMime),
-                ),
-            ).execute()
-            if (!response.isSuccessful) {
-                response.parseALError()
-            }
             with(json) {
-                decodeFromString<ALMangaMetadata>(response.body?.string()!!)
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALMangaMetadata>()
                     .let {
                         val media = it.data.media
                         TrackMangaMetadata(
@@ -428,25 +394,25 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-            |   Media (id: ${'$'}mangaId) {
-            |       id
-            |       title {
-            |           userPreferred
-            |       }
-            |       coverImage {
-            |           large
-            |       }
-            |       format
-            |       status
-            |       chapters
-            |       description
-            |       startDate {
-            |           year
-            |           month
-            |           day
-            |       }
-            |       averageScore
-            |   }
+                |Media (id: ${'$'}mangaId) {
+                    |id
+                    |title {
+                        |userPreferred
+                    |}
+                    |coverImage {
+                        |large
+                    |}
+                    |format
+                    |status
+                    |chapters
+                    |description
+                    |startDate {
+                        |year
+                        |month
+                        |day
+                    |}
+                    |averageScore
+                |}
             |}
             |
             """.trimMargin()
@@ -456,17 +422,15 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     put("mangaId", id)
                 }
             }
-            val response = authClient.newCall(
-                POST(
-                    API_URL,
-                    body = payload.toString().toRequestBody(jsonMime),
-                ),
-            ).execute()
-            if (!response.isSuccessful) {
-                response.parseALError()
-            }
             with(json) {
-                decodeFromString<ALIdSearchResult>(response.body?.string()!!)
+                authClient.newCall(
+                    POST(
+                        API_URL,
+                        body = payload.toString().toRequestBody(jsonMime),
+                    ),
+                )
+                    .awaitSuccess()
+                    .parseAs<ALIdSearchResult>()
                     .data.media
                     .toALManga()
                     .toTrack()
@@ -493,6 +457,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
     }
 
     companion object {
+        // Registered under KMK's MAL account
         private const val CLIENT_ID = "16801"
         private const val API_URL = "https://graphql.anilist.co/"
         private const val BASE_URL = "https://anilist.co/api/v2/"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -65,10 +65,10 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |mutation AddManga($mangaId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean) {
-            |    SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
-            |       id
-            |       status
-            |    }
+                |SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
+                |   id
+                |   status
+                |}
             |}
             |
             """.trimMargin()
@@ -103,17 +103,17 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |mutation UpdateManga(
-            |    $listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
-            |    $score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
+                |$listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
+                |$score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
             |) {
-            |    SaveMediaListEntry(
-            |        id: $listId, progress: $progress, status: $status, private: $private,
-            |        scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
-            |    ) {
-            |        id
-            |        status
-            |        progress
-            |    }
+                |SaveMediaListEntry(
+                    |id: $listId, progress: $progress, status: $status, private: $private,
+                    |scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
+                |) {
+                    |id
+                    |status
+                    |progress
+                |}
             |}
             |
             """.trimMargin()
@@ -140,9 +140,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         withIOContext {
             val query = $$"""
             |mutation DeleteManga($listId: Int) {
-            |    DeleteMediaListEntry(id: $listId) {
-            |        deleted
-            |    }
+                |DeleteMediaListEntry(id: $listId) {
+                    |deleted
+                |}
             |}
             |
             """.trimMargin()
@@ -162,40 +162,40 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |query Search($query: String) {
-            |    Page (perPage: 50) {
-            |        media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
-            |            id
-            |            staff {
-            |                edges {
-            |                    role
-            |                    id
-            |                    node {
-            |                        name {
-            |                            full
-            |                            userPreferred
-            |                            native
-            |                        }
-            |                    }
-            |                }
-            |            }
-            |            title {
-            |                userPreferred
-            |            }
-            |            coverImage {
-            |                large
-            |            }
-            |            format
-            |            status
-            |            chapters
-            |            description
-            |            startDate {
-            |                year
-            |                month
-            |                day
-            |            }
-            |            averageScore
-            |        }
-            |    }
+                |Page (perPage: 50) {
+                    |media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
+                        |id
+                        |staff {
+                            |edges {
+                                |role
+                                |id
+                                |node {
+                                    |name {
+                                        |full
+                                        |userPreferred
+                                        |native
+                                    |}
+                                |}
+                            |}
+                        |}
+                        |title {
+                            |userPreferred
+                        |}
+                        |coverImage {
+                            |large
+                        |}
+                        |format
+                        |status
+                        |chapters
+                        |description
+                        |startDate {
+                            |year
+                            |month
+                            |day
+                        |}
+                        |averageScore
+                    |}
+                |}
             |}
             |
             """.trimMargin()
@@ -225,56 +225,56 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |query ($id: Int!, $manga_id: Int!) {
-            |    Page {
-            |        mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
-            |            id
-            |            status
-            |            scoreRaw: score(format: POINT_100)
-            |            progress
-            |            private
-            |            startedAt {
-            |                year
-            |                month
-            |                day
-            |            }
-            |            completedAt {
-            |                year
-            |                month
-            |                day
-            |            }
-            |            media {
-            |                id
-            |                title {
-            |                    userPreferred
-            |                }
-            |                coverImage {
-            |                    large
-            |                }
-            |                format
-            |                status
-            |                chapters
-            |                description
-            |                startDate {
-            |                    year
-            |                    month
-            |                    day
-            |                }
-            |                staff {
-            |                    edges {
-            |                        role
-            |                        id
-            |                        node {
-            |                            name {
-            |                                full
-            |                                userPreferred
-            |                                native
-            |                            }
-            |                        }
-            |                    }
-            |                }
-            |            }
-            |        }
-            |    }
+                |Page {
+                    |mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
+                        |id
+                        |status
+                        |scoreRaw: score(format: POINT_100)
+                        |progress
+                        |private
+                        |startedAt {
+                            |year
+                            |month
+                            |day
+                        |}
+                        |completedAt {
+                            |year
+                            |month
+                            |day
+                        |}
+                        |media {
+                            |id
+                            |title {
+                                |userPreferred
+                            |}
+                            |coverImage {
+                                |large
+                            |}
+                            |format
+                            |status
+                            |chapters
+                            |description
+                            |startDate {
+                                |year
+                                |month
+                                |day
+                            |}
+                            |staff {
+                                |edges {
+                                    |role
+                                    |id
+                                    |node {
+                                        |name {
+                                            |full
+                                            |userPreferred
+                                            |native
+                                        |}
+                                    |}
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
             |}
             |
             """.trimMargin()
@@ -315,12 +315,12 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query User {
-            |    Viewer {
-            |        id
-            |        mediaListOptions {
-            |            scoreFormat
-            |        }
-            |    }
+                |Viewer {
+                    |id
+                    |mediaListOptions {
+                        |scoreFormat
+                    |}
+                |}
             |}
             |
             """.trimMargin()
@@ -349,29 +349,29 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-            |    Media (id: ${'$'}mangaId) {
-            |        id
-            |        title {
-            |            userPreferred
-            |        }
-            |        coverImage {
-            |            large
-            |        }
-            |        description
-            |        staff {
-            |            edges {
-            |                role
-            |                id
-            |                node {
-            |                    name {
-            |                        full
-            |                        userPreferred
-            |                        native
-            |                    }
-            |                }
-            |            }
-            |        }
-            |    }
+                |Media (id: ${'$'}mangaId) {
+                    |id
+                    |title {
+                        |userPreferred
+                    |}
+                    |coverImage {
+                        |large
+                    |}
+                    |description
+                    |staff {
+                        |edges {
+                            |role
+                            |id
+                            |node {
+                                |name {
+                                    |full
+                                    |userPreferred
+                                    |native
+                                |}
+                            |}
+                        |}
+                    |}
+                |}
             |}
             |
             """.trimMargin()
@@ -419,25 +419,25 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-            |    Media (id: ${'$'}mangaId) {
-            |        id
-            |        title {
-            |            userPreferred
-            |        }
-            |        coverImage {
-            |            large
-            |        }
-            |        format
-            |        status
-            |        chapters
-            |        description
-            |        startDate {
-            |            year
-            |            month
-            |            day
-            |        }
-            |        averageScore
-            |    }
+                |Media (id: ${'$'}mangaId) {
+                    |id
+                    |title {
+                        |userPreferred
+                    |}
+                    |coverImage {
+                        |large
+                    |}
+                    |format
+                    |status
+                    |chapters
+                    |description
+                    |startDate {
+                        |year
+                        |month
+                        |day
+                    |}
+                    |averageScore
+                |}
             |}
             |
             """.trimMargin()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -5,6 +5,7 @@ import androidx.core.net.toUri
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALAddMangaResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALCurrentUserResult
+import eu.kanade.tachiyomi.data.track.anilist.dto.ALError
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALIdSearchResult
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALMangaMetadata
 import eu.kanade.tachiyomi.data.track.anilist.dto.ALOAuth
@@ -26,6 +27,7 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
 import tachiyomi.core.common.util.lang.withIOContext
 import uy.kohesive.injekt.injectLazy
 import java.time.Instant
@@ -43,14 +45,30 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         .rateLimit(permits = 85, period = 1.minutes)
         .build()
 
+    private fun Response.parseALError() {
+        val bodyString = peekBody(Long.MAX_VALUE).string()
+        try {
+            val errorObj = json.decodeFromString<ALError>(bodyString)
+            errorObj.errors?.firstOrNull()?.let {
+                val msg = it.message
+                if (msg.contains("Invalid token") || code == 401) {
+                    throw Exception("AniList token expired, please login again")
+                }
+                throw Exception(msg)
+            }
+        } catch (e: Exception) {
+            if (e.message?.contains("AniList") == true || e.message?.contains("token") == true) throw e
+        }
+    }
+
     suspend fun addLibManga(track: Track): Track {
         return withIOContext {
             val query = $$"""
             |mutation AddManga($mangaId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean) {
-                |SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
-                |   id
-                |   status
-                |}
+            |    SaveMediaListEntry (mediaId: $mangaId, progress: $progress, status: $status, private: $private) {
+            |       id
+            |       status
+            |    }
             |}
             |
             """.trimMargin()
@@ -71,6 +89,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    .also { it.parseALError() }
                     .parseAs<ALAddMangaResult>()
                     .let {
                         track.library_id = it.data.entry.id
@@ -84,17 +103,17 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |mutation UpdateManga(
-                |$listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
-                |$score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
+            |    $listId: Int, $progress: Int, $status: MediaListStatus, $private: Boolean,
+            |    $score: Int, $startedAt: FuzzyDateInput, $completedAt: FuzzyDateInput
             |) {
-                |SaveMediaListEntry(
-                    |id: $listId, progress: $progress, status: $status, private: $private,
-                    |scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
-                |) {
-                    |id
-                    |status
-                    |progress
-                |}
+            |    SaveMediaListEntry(
+            |        id: $listId, progress: $progress, status: $status, private: $private,
+            |        scoreRaw: $score, startedAt: $startedAt, completedAt: $completedAt
+            |    ) {
+            |        id
+            |        status
+            |        progress
+            |    }
             |}
             |
             """.trimMargin()
@@ -112,6 +131,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 .awaitSuccess()
+                .also { it.parseALError() }
             track
         }
     }
@@ -120,9 +140,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         withIOContext {
             val query = $$"""
             |mutation DeleteManga($listId: Int) {
-                |DeleteMediaListEntry(id: $listId) {
-                    |deleted
-                |}
+            |    DeleteMediaListEntry(id: $listId) {
+            |        deleted
+            |    }
             |}
             |
             """.trimMargin()
@@ -134,6 +154,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 .awaitSuccess()
+                .also { it.parseALError() }
         }
     }
 
@@ -141,40 +162,40 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |query Search($query: String) {
-                |Page (perPage: 50) {
-                    |media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
-                        |id
-                        |staff {
-                            |edges {
-                                |role
-                                |id
-                                |node {
-                                    |name {
-                                        |full
-                                        |userPreferred
-                                        |native
-                                    |}
-                                |}
-                            |}
-                        |}
-                        |title {
-                            |userPreferred
-                        |}
-                        |coverImage {
-                            |large
-                        |}
-                        |format
-                        |status
-                        |chapters
-                        |description
-                        |startDate {
-                            |year
-                            |month
-                            |day
-                        |}
-                        |averageScore
-                    |}
-                |}
+            |    Page (perPage: 50) {
+            |        media(search: $query, type: MANGA, format_not_in: [NOVEL]) {
+            |            id
+            |            staff {
+            |                edges {
+            |                    role
+            |                    id
+            |                    node {
+            |                        name {
+            |                            full
+            |                            userPreferred
+            |                            native
+            |                        }
+            |                    }
+            |                }
+            |            }
+            |            title {
+            |                userPreferred
+            |            }
+            |            coverImage {
+            |                large
+            |            }
+            |            format
+            |            status
+            |            chapters
+            |            description
+            |            startDate {
+            |                year
+            |                month
+            |                day
+            |            }
+            |            averageScore
+            |        }
+            |    }
             |}
             |
             """.trimMargin()
@@ -192,6 +213,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    .also { it.parseALError() }
                     .parseAs<ALSearchResult>()
                     .data.page.media
                     .map { it.toALManga().toTrack() }
@@ -203,56 +225,56 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = $$"""
             |query ($id: Int!, $manga_id: Int!) {
-                |Page {
-                    |mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
-                        |id
-                        |status
-                        |scoreRaw: score(format: POINT_100)
-                        |progress
-                        |private
-                        |startedAt {
-                            |year
-                            |month
-                            |day
-                        |}
-                        |completedAt {
-                            |year
-                            |month
-                            |day
-                        |}
-                        |media {
-                            |id
-                            |title {
-                                |userPreferred
-                            |}
-                            |coverImage {
-                                |large
-                            |}
-                            |format
-                            |status
-                            |chapters
-                            |description
-                            |startDate {
-                                |year
-                                |month
-                                |day
-                            |}
-                            |staff {
-                                |edges {
-                                    |role
-                                    |id
-                                    |node {
-                                        |name {
-                                            |full
-                                            |userPreferred
-                                            |native
-                                        |}
-                                    |}
-                                |}
-                            |}
-                        |}
-                    |}
-                |}
+            |    Page {
+            |        mediaList(userId: $id, type: MANGA, mediaId: $manga_id) {
+            |            id
+            |            status
+            |            scoreRaw: score(format: POINT_100)
+            |            progress
+            |            private
+            |            startedAt {
+            |                year
+            |                month
+            |                day
+            |            }
+            |            completedAt {
+            |                year
+            |                month
+            |                day
+            |            }
+            |            media {
+            |                id
+            |                title {
+            |                    userPreferred
+            |                }
+            |                coverImage {
+            |                    large
+            |                }
+            |                format
+            |                status
+            |                chapters
+            |                description
+            |                startDate {
+            |                    year
+            |                    month
+            |                    day
+            |                }
+            |                staff {
+            |                    edges {
+            |                        role
+            |                        id
+            |                        node {
+            |                            name {
+            |                                full
+            |                                userPreferred
+            |                                native
+            |                            }
+            |                        }
+            |                    }
+            |                }
+            |            }
+            |        }
+            |    }
             |}
             |
             """.trimMargin()
@@ -271,6 +293,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    .also { it.parseALError() }
                     .parseAs<ALUserListMangaQueryResult>()
                     .data.page.mediaList
                     .map { it.toALUserManga() }
@@ -292,12 +315,12 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query User {
-                |Viewer {
-                    |id
-                    |mediaListOptions {
-                        |scoreFormat
-                    |}
-                |}
+            |    Viewer {
+            |        id
+            |        mediaListOptions {
+            |            scoreFormat
+            |        }
+            |    }
             |}
             |
             """.trimMargin()
@@ -312,6 +335,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    .also { it.parseALError() }
                     .parseAs<ALCurrentUserResult>()
                     .let {
                         val viewer = it.data.viewer
@@ -325,29 +349,29 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-                |Media (id: ${'$'}mangaId) {
-                    |id
-                    |title {
-                        |userPreferred
-                    |}
-                    |coverImage {
-                        |large
-                    |}
-                    |description
-                    |staff {
-                        |edges {
-                            |role
-                            |id
-                            |node {
-                                |name {
-                                    |full
-                                    |userPreferred
-                                    |native
-                                |}
-                            |}
-                        |}
-                    |}
-                |}
+            |    Media (id: ${'$'}mangaId) {
+            |        id
+            |        title {
+            |            userPreferred
+            |        }
+            |        coverImage {
+            |            large
+            |        }
+            |        description
+            |        staff {
+            |            edges {
+            |                role
+            |                id
+            |                node {
+            |                    name {
+            |                        full
+            |                        userPreferred
+            |                        native
+            |                    }
+            |                }
+            |            }
+            |        }
+            |    }
             |}
             |
             """.trimMargin()
@@ -365,6 +389,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    .also { it.parseALError() }
                     .parseAs<ALMangaMetadata>()
                     .let {
                         val media = it.data.media
@@ -394,25 +419,25 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         return withIOContext {
             val query = """
             |query (${'$'}mangaId: Int!) {
-                |Media (id: ${'$'}mangaId) {
-                    |id
-                    |title {
-                        |userPreferred
-                    |}
-                    |coverImage {
-                        |large
-                    |}
-                    |format
-                    |status
-                    |chapters
-                    |description
-                    |startDate {
-                        |year
-                        |month
-                        |day
-                    |}
-                    |averageScore
-                |}
+            |    Media (id: ${'$'}mangaId) {
+            |        id
+            |        title {
+            |            userPreferred
+            |        }
+            |        coverImage {
+            |            large
+            |        }
+            |        format
+            |        status
+            |        chapters
+            |        description
+            |        startDate {
+            |            year
+            |            month
+            |            day
+            |        }
+            |        averageScore
+            |    }
             |}
             |
             """.trimMargin()
@@ -430,6 +455,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    .also { it.parseALError() }
                     .parseAs<ALIdSearchResult>()
                     .data.media
                     .toALManga()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -45,6 +45,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         .rateLimit(permits = 85, period = 1.minutes)
         .build()
 
+    // KMK -->
     private fun Response.parseALError() {
         val bodyString = peekBody(1024 * 1024).string()
         val errorObj = try {
@@ -61,6 +62,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             throw Exception(msg)
         }
     }
+    // KMK <--
 
     suspend fun addLibManga(track: Track): Track {
         return withIOContext {
@@ -90,7 +92,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    // KMK -->
                     .also { it.parseALError() }
+                    // KMK <--
                     .parseAs<ALAddMangaResult>()
                     .let {
                         track.library_id = it.data.entry.id
@@ -132,7 +136,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 .awaitSuccess()
+                // KMK -->
                 .use { it.parseALError() }
+            // KMK <--
             track
         }
     }
@@ -155,7 +161,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 .awaitSuccess()
+                // KMK -->
                 .use { it.parseALError() }
+            // KMK <--
         }
     }
 
@@ -214,7 +222,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    // KMK -->
                     .also { it.parseALError() }
+                    // KMK <--
                     .parseAs<ALSearchResult>()
                     .data.page.media
                     .map { it.toALManga().toTrack() }
@@ -294,7 +304,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    // KMK -->
                     .also { it.parseALError() }
+                    // KMK <--
                     .parseAs<ALUserListMangaQueryResult>()
                     .data.page.mediaList
                     .map { it.toALUserManga() }
@@ -336,7 +348,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    // KMK -->
                     .also { it.parseALError() }
+                    // KMK <--
                     .parseAs<ALCurrentUserResult>()
                     .let {
                         val viewer = it.data.viewer
@@ -348,9 +362,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
         return withIOContext {
-            val query = """
-            |query (${'$'}mangaId: Int!) {
-                |Media (id: ${'$'}mangaId) {
+            val query = $$"""
+            |query ($mangaId: Int!) {
+                |Media (id: $mangaId) {
                     |id
                     |title {
                         |userPreferred
@@ -390,10 +404,12 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    // KMK -->
                     .also { it.parseALError() }
+                    // KMK <--
                     .parseAs<ALMangaMetadata>()
-                    .let {
-                        val media = it.data.media
+                    .let { metadata ->
+                        val media = metadata.data.media
                         TrackMangaMetadata(
                             remoteId = media.id,
                             title = media.title.userPreferred,
@@ -418,9 +434,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
     // SY -->
     suspend fun searchById(id: String): TrackSearch {
         return withIOContext {
-            val query = """
-            |query (${'$'}mangaId: Int!) {
-                |Media (id: ${'$'}mangaId) {
+            val query = $$"""
+            |query ($mangaId: Int!) {
+                |Media (id: $mangaId) {
                     |id
                     |title {
                         |userPreferred
@@ -456,7 +472,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                     ),
                 )
                     .awaitSuccess()
+                    // KMK -->
                     .also { it.parseALError() }
+                    // KMK <--
                     .parseAs<ALIdSearchResult>()
                     .data.media
                     .toALManga()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -49,7 +49,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         val bodyString = peekBody(1024 * 1024).string()
         val errorObj = try {
             json.decodeFromString<ALError>(bodyString)
-        } catch (e: Exception) {
+        } catch (_: Exception) {
             null
         }
 
@@ -132,7 +132,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 .awaitSuccess()
-                .also { it.parseALError() }
+                .use { it.parseALError() }
             track
         }
     }
@@ -155,7 +155,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 .awaitSuccess()
-                .also { it.parseALError() }
+                .use { it.parseALError() }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALError.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/dto/ALError.kt
@@ -1,0 +1,14 @@
+package eu.kanade.tachiyomi.data.track.anilist.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ALError(
+    val errors: List<ALErrorItem>? = null,
+)
+
+@Serializable
+data class ALErrorItem(
+    val message: String,
+    val status: Int? = null,
+)


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve AniList tracking API robustness by parsing GraphQL error responses and surfacing meaningful failures.

Bug Fixes:
- Handle AniList GraphQL error responses to detect token expiry and prompt users to re-login when the token is invalid.

Enhancements:
- Parse AniList GraphQL error payloads across all AniList API calls to surface clearer error messages for downtime and other failures.