### PR TITLE
chore(ci): Add SSH key setup for Codeberg repository mirroring

### DIFF
--- a/.github/workflows/codeberg_mirror.yml
+++ b/.github/workflows/codeberg_mirror.yml
@@ -16,6 +16,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.CODEBERG_SSH }}" >> ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
       - uses: pixta-dev/repository-mirroring-action@674e65a7d483ca28dafaacba0d07351bdcc8bd75 # v1.1.1
         with:
           target_repo_url: "git@codeberg.org:cuong-tran/komikku.git"


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add SSH key setup step in the Codeberg mirror GitHub Actions workflow using the CODEBERG_SSH secret.