### PR TITLE
feat(reader): improve center margin and crop borders logic

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -1278,8 +1278,9 @@ class ReaderViewModel @JvmOverloads constructor(
         ImageUtil.findImageType(stream1) ?: throw Exception("Not an image")
         val stream2 = page2.stream!!
         ImageUtil.findImageType(stream2) ?: throw Exception("Not an image")
-        val imageBitmap = ImageDecoder.newInstance(stream1())?.decode()!!
-        val imageBitmap2 = ImageDecoder.newInstance(stream2())?.decode()!!
+        val cropBorders = readerPreferences.cropBorders().get()
+        val imageBitmap = ImageDecoder.newInstance(stream1(), cropBorders)?.decode()!!
+        val imageBitmap2 = ImageDecoder.newInstance(stream2(), cropBorders)?.decode()!!
 
         val chapter = page1.chapter.chapter
 
@@ -1292,7 +1293,7 @@ class ReaderViewModel @JvmOverloads constructor(
 
         return imageSaver.save(
             image = Image.Page(
-                inputStream = { ImageUtil.mergeBitmaps(imageBitmap, imageBitmap2, isLTR, 0, bg).inputStream() },
+                inputStream = { ImageUtil.mergeBitmaps(imageBitmap, imageBitmap2, isLTR, if (cropBorders) 40 else 0, bg).inputStream() },
                 name = filename,
                 location = location,
             ),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -338,8 +338,8 @@ class PagerPageHolder(
         return if (
             !ImageUtil.isAnimatedAndSupported(imageSource) &&
             ImageUtil.isWideImage(imageSource) &&
-            viewer.config.centerMarginType and PagerConfig.CenterMarginType.WIDE_PAGE_CENTER_MARGIN > 0 ||
-            viewer.config.imageCropBorders
+            (viewer.config.centerMarginType and PagerConfig.CenterMarginType.WIDE_PAGE_CENTER_MARGIN > 0 ||
+                viewer.config.imageCropBorders)
         ) {
             ImageUtil.addHorizontalCenterMargin(imageSource, height, context, viewer.config.imageCropBorders)
         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -287,7 +287,7 @@ class PagerPageHolder(
             return imageSource
         }
 
-        val imageBitmap = decodeImage(imageSource)
+        val imageBitmap = decodeImage(imageSource, viewer.config.imageCropBorders)
         if (imageBitmap == null) {
             imageSource2.close()
             page.fullPage = true
@@ -304,7 +304,7 @@ class PagerPageHolder(
             return imageSource
         }
 
-        val imageBitmap2 = decodeImage(imageSource2)
+        val imageBitmap2 = decodeImage(imageSource2, viewer.config.imageCropBorders)
         if (imageBitmap2 == null) {
             imageSource2.close()
             extraPage?.fullPage = true
@@ -338,18 +338,18 @@ class PagerPageHolder(
         return if (
             !ImageUtil.isAnimatedAndSupported(imageSource) &&
             ImageUtil.isWideImage(imageSource) &&
-            viewer.config.centerMarginType and PagerConfig.CenterMarginType.WIDE_PAGE_CENTER_MARGIN > 0 &&
-            !viewer.config.imageCropBorders
+            viewer.config.centerMarginType and PagerConfig.CenterMarginType.WIDE_PAGE_CENTER_MARGIN > 0 ||
+            viewer.config.imageCropBorders
         ) {
-            ImageUtil.addHorizontalCenterMargin(imageSource, height, context)
+            ImageUtil.addHorizontalCenterMargin(imageSource, height, context, viewer.config.imageCropBorders)
         } else {
             imageSource
         }
     }
 
-    private fun decodeImage(imageSource: BufferedSource): Bitmap? {
+    private fun decodeImage(imageSource: BufferedSource, cropBorders: Boolean): Bitmap? {
         return try {
-            ImageDecoder.newInstance(imageSource.inputStream())?.decode()
+            ImageDecoder.newInstance(imageSource.inputStream(), cropBorders)?.decode()
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e) { "Cannot decode image" }
             null
@@ -357,10 +357,9 @@ class PagerPageHolder(
     }
 
     private fun calculateCenterMargin(height: Int, height2: Int): Int {
-        return if (viewer.config.centerMarginType and PagerConfig.CenterMarginType.DOUBLE_PAGE_CENTER_MARGIN > 0 &&
-            !viewer.config.imageCropBorders
-        ) {
-            96 / (this.height.coerceAtLeast(1) / max(height, height2).coerceAtLeast(1)).coerceAtLeast(1)
+        val hasSetting = viewer.config.centerMarginType and PagerConfig.CenterMarginType.DOUBLE_PAGE_CENTER_MARGIN > 0
+        return if (hasSetting || viewer.config.imageCropBorders) {
+            (if (viewer.config.imageCropBorders) 40 else 96) / (this.height.coerceAtLeast(1) / max(height, height2).coerceAtLeast(1)).coerceAtLeast(1)
         } else {
             0
         }
@@ -402,12 +401,10 @@ class PagerPageHolder(
             }
         }
 
-        val sideMargin = if ((viewer.config.centerMarginType and PagerConfig.CenterMarginType.DOUBLE_PAGE_CENTER_MARGIN) >
-            0 &&
-            viewer.config.doublePages &&
-            !viewer.config.imageCropBorders
+        val sideMargin = if (viewer.config.doublePages &&
+            ((viewer.config.centerMarginType and PagerConfig.CenterMarginType.DOUBLE_PAGE_CENTER_MARGIN) > 0 || viewer.config.imageCropBorders)
         ) {
-            48
+            if (viewer.config.imageCropBorders) 20 else 48
         } else {
             0
         }

--- a/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
@@ -216,12 +216,13 @@ object ImageUtil {
         imageSource: BufferedSource,
         viewHeight: Int,
         backgroundContext: Context,
+        cropBorders: Boolean = false,
     ): BufferedSource {
-        val imageBitmap = ImageDecoder.newInstance(imageSource.inputStream())?.decode()!!
+        val imageBitmap = ImageDecoder.newInstance(imageSource.inputStream(), cropBorders)?.decode()!!
         val height = imageBitmap.height
         val width = imageBitmap.width
 
-        val centerPadding = 96 / (max(1, viewHeight) / height).coerceAtLeast(1)
+        val centerPadding = (if (cropBorders) 40 else 96) / (max(1, viewHeight) / height).coerceAtLeast(1)
 
         val leftSourcePart = Rect(0, 0, width / 2, height)
         val rightSourcePart = Rect(width / 2, 0, width, height)


### PR DESCRIPTION
This solved the problem here #1592.

With automatic border cropping enabled, in double-page view the inner margins are also cropped, causing content near the center fold to be cut off.

- Update `PagerPageHolder` to apply horizontal center margins when `imageCropBorders` is enabled.
- Adjust margin calculations to use smaller padding values (40/20 vs 96/48) when cropping borders.
- Pass the `cropBorders` setting to `ImageDecoder` and `ImageUtil.addHorizontalCenterMargin`.
- Ensure border cropping is respected when merging and saving double pages in `ReaderViewModel`.

## Before:
<img width="1231" height="920" alt="Schermata del 2026-04-16 15-03-12" src="https://github.com/user-attachments/assets/562a3f09-a361-4b4b-bd42-61ac999b9397" />

## After:
<img width="1231" height="920" alt="Schermata del 2026-04-16 15-01-38" src="https://github.com/user-attachments/assets/3c8416d1-b340-465c-b3e4-c66b729eee6a" />



<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve reader center margin behavior when border cropping is enabled, ensuring double-page layouts preserve inner content while respecting crop settings.

New Features:
- Apply horizontal center margins even when image border cropping is enabled for wide and double-page images.

Bug Fixes:
- Prevent inner content near the center fold from being cut off in double-page view when automatic border cropping is enabled.

Enhancements:
- Adjust center and side margin values to smaller paddings when border cropping is active for more balanced spacing.
- Propagate the crop-borders setting into image decoding, margin application, and double-page merge/save operations so all image handling respects the same configuration.