### PR TITLE
feat(track): add Yamtrack tracker service

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -101,6 +101,9 @@ object SettingsTrackingScreen : SearchableSettings {
                     TrackingLoginDialog(
                         tracker = tracker,
                         uNameStringRes = uNameStringRes,
+                        // KMK -->
+                        pwStringRes = pwStringRes,
+                        // KMK <--
                         onDismissRequest = { dialog = null },
                     )
                 }
@@ -190,6 +193,19 @@ object SettingsTrackingScreen : SearchableSettings {
                         login = { context.openInBrowser(BangumiApi.authUrl(), forceDefaultBrowser = true) },
                         logout = { dialog = LogoutDialog(trackerManager.bangumi) },
                     ),
+                    // KMK -->
+                    Preference.PreferenceItem.TrackerPreference(
+                        tracker = trackerManager.yamtrack,
+                        login = {
+                            dialog = LoginDialog(
+                                tracker = trackerManager.yamtrack,
+                                uNameStringRes = KMR.strings.yamtrack_host_url,
+                                pwStringRes = KMR.strings.yamtrack_api_token,
+                            )
+                        },
+                        logout = { dialog = LogoutDialog(trackerManager.yamtrack) },
+                    ),
+                    // KMK <--
                     Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.tracking_info)),
                 ),
             ),
@@ -213,6 +229,9 @@ object SettingsTrackingScreen : SearchableSettings {
     private fun TrackingLoginDialog(
         tracker: Tracker,
         uNameStringRes: StringResource,
+        // KMK -->
+        pwStringRes: StringResource = MR.strings.password,
+        // KMK <--
         onDismissRequest: () -> Unit,
     ) {
         val context = LocalContext.current
@@ -260,7 +279,7 @@ object SettingsTrackingScreen : SearchableSettings {
                             .semantics { contentType = ContentType.Password },
                         value = password,
                         onValueChange = { password = it },
-                        label = { Text(text = stringResource(MR.strings.password)) },
+                        label = { Text(text = stringResource(pwStringRes)) },
                         trailingIcon = {
                             IconButton(onClick = { hidePassword = !hidePassword }) {
                                 Icon(
@@ -376,6 +395,9 @@ object SettingsTrackingScreen : SearchableSettings {
 private data class LoginDialog(
     val tracker: Tracker,
     val uNameStringRes: StringResource,
+    // KMK -->
+    val pwStringRes: StringResource = MR.strings.password,
+    // KMK <--
 )
 
 private data class LogoutDialog(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackerManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackerManager.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.data.track.mdlist.MdList
 import eu.kanade.tachiyomi.data.track.myanimelist.MyAnimeList
 import eu.kanade.tachiyomi.data.track.shikimori.Shikimori
 import eu.kanade.tachiyomi.data.track.suwayomi.Suwayomi
+import eu.kanade.tachiyomi.data.track.yamtrack.Yamtrack
 import kotlinx.coroutines.flow.combine
 
 class TrackerManager {
@@ -18,6 +19,10 @@ class TrackerManager {
         const val ANILIST = 2L
         const val KITSU = 3L
         const val KAVITA = 8L
+
+        // KMK -->
+        const val YAMTRACK = 10L
+        // KMK <--
 
         // SY --> Mangadex from Neko
         const val MDLIST = 60L
@@ -36,8 +41,26 @@ class TrackerManager {
     val kavita = Kavita(KAVITA)
     val suwayomi = Suwayomi(9L)
 
+    // KMK -->
+    val yamtrack = Yamtrack(YAMTRACK)
+    // KMK <--
+
     val trackers =
-        listOf(mdList, myAnimeList, aniList, kitsu, shikimori, bangumi, komga, mangaUpdates, kavita, suwayomi)
+        listOf(
+            mdList,
+            myAnimeList,
+            aniList,
+            kitsu,
+            shikimori,
+            bangumi,
+            komga,
+            mangaUpdates,
+            kavita,
+            suwayomi,
+            // KMK -->
+            yamtrack,
+            // KMK <--
+        )
 
     fun loggedInTrackers() = trackers.filter { it.isLoggedIn }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/yamtrack/Yamtrack.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/yamtrack/Yamtrack.kt
@@ -1,0 +1,204 @@
+package eu.kanade.tachiyomi.data.track.yamtrack
+
+import dev.icerock.moko.resources.StringResource
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.track.BaseTracker
+import eu.kanade.tachiyomi.data.track.DeletableTracker
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import eu.kanade.tachiyomi.data.track.yamtrack.dto.copyToTrack
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import tachiyomi.i18n.MR
+import tachiyomi.domain.track.model.Track as DomainTrack
+
+class Yamtrack(id: Long) : BaseTracker(id, "Yamtrack"), DeletableTracker {
+
+    companion object {
+        const val PLANNING = 1L
+        const val READING = 2L
+        const val COMPLETED = 3L
+        const val PAUSED = 4L
+        const val DROPPED = 5L
+
+        const val SOURCE_MANUAL = "manual"
+
+        private const val API_STATUS_PLANNING = "Planning"
+        private const val API_STATUS_IN_PROGRESS = "In progress"
+        private const val API_STATUS_COMPLETED = "Completed"
+        private const val API_STATUS_PAUSED = "Paused"
+        private const val API_STATUS_DROPPED = "Dropped"
+
+        private val SCORE_LIST = (0..10)
+            .flatMap { decimal ->
+                when (decimal) {
+                    10 -> listOf("10.0")
+                    else -> (0..9).map { fraction -> "$decimal.$fraction" }
+                }
+            }
+            .toImmutableList()
+
+        fun statusToApi(status: Long): String = when (status) {
+            PLANNING -> API_STATUS_PLANNING
+            READING -> API_STATUS_IN_PROGRESS
+            COMPLETED -> API_STATUS_COMPLETED
+            PAUSED -> API_STATUS_PAUSED
+            DROPPED -> API_STATUS_DROPPED
+            else -> API_STATUS_PLANNING
+        }
+
+        fun statusFromApi(status: String?): Long = when (status) {
+            API_STATUS_PLANNING -> PLANNING
+            API_STATUS_IN_PROGRESS -> READING
+            API_STATUS_COMPLETED -> COMPLETED
+            API_STATUS_PAUSED -> PAUSED
+            API_STATUS_DROPPED -> DROPPED
+            else -> PLANNING
+        }
+
+        fun buildRemoteId(source: String, mediaId: String): Long {
+            // Track.remote_id is a Long, but Yamtrack identifies entries by (source, media_id).
+            // We derive a stable non-negative Long from the pair so it can be used as a key.
+            val hash = "$source:$mediaId".hashCode().toLong()
+            return hash and 0x7fffffffffffffffL
+        }
+
+        fun buildTrackingUrl(baseUrl: String, source: String, mediaId: String): String {
+            return "${baseUrl.trimEnd('/')}/media/manga/$source/$mediaId"
+        }
+
+        /**
+         * Parses a tracking URL in the form `{base}/media/manga/{source}/{mediaId}` and returns
+         * `(source, mediaId)` if the format matches.
+         */
+        fun parseTrackingUrl(url: String): Pair<String, String>? {
+            if (url.isBlank()) return null
+            val match = Regex("""/media/manga/([^/]+)/([^/?#]+)""").find(url) ?: return null
+            return match.groupValues[1] to match.groupValues[2]
+        }
+    }
+
+    private val interceptor by lazy { YamtrackInterceptor(this) }
+
+    private val api by lazy { YamtrackApi(this, client, interceptor) }
+
+    override fun getLogo(): Int = R.drawable.brand_yamtrack
+
+    override fun getStatusList(): List<Long> = listOf(PLANNING, READING, PAUSED, COMPLETED, DROPPED)
+
+    override fun getStatus(status: Long): StringResource? = when (status) {
+        PLANNING -> MR.strings.plan_to_read
+        READING -> MR.strings.reading
+        PAUSED -> MR.strings.paused
+        COMPLETED -> MR.strings.completed
+        DROPPED -> MR.strings.dropped
+        else -> null
+    }
+
+    override fun getReadingStatus(): Long = READING
+
+    override fun getRereadingStatus(): Long = -1
+
+    override fun getCompletionStatus(): Long = COMPLETED
+
+    override fun getScoreList(): ImmutableList<String> = SCORE_LIST
+
+    override fun indexToScore(index: Int): Double = SCORE_LIST[index].toDouble()
+
+    override fun displayScore(track: DomainTrack): String {
+        return if (track.score > 0.0) "%.1f".format(track.score) else "-"
+    }
+
+    override suspend fun update(track: Track, didReadChapter: Boolean): Track {
+        if (track.status != COMPLETED && didReadChapter) {
+            track.status = if (track.total_chapters > 0L &&
+                track.last_chapter_read.toLong() == track.total_chapters
+            ) {
+                COMPLETED
+            } else {
+                READING
+            }
+        }
+        val (source, mediaId) = parseTrackingUrl(track.tracking_url) ?: return track
+        api.updateMedia(track, source, mediaId)
+        return track
+    }
+
+    override suspend fun bind(track: Track, hasReadChapters: Boolean): Track {
+        val (source, mediaId) = parseTrackingUrl(track.tracking_url)
+            ?: throw IllegalStateException("Invalid Yamtrack tracking URL: ${track.tracking_url}")
+
+        val existing = api.getMediaItem(source, mediaId)
+        return if (existing != null) {
+            existing.copyToTrack(track)
+            track
+        } else {
+            if (track.status == 0L) {
+                track.status = if (hasReadChapters) READING else PLANNING
+            }
+            api.addMedia(track, source, mediaId, track.title)
+            track
+        }
+    }
+
+    override suspend fun search(query: String): List<TrackSearch> {
+        if (query.isBlank()) return emptyList()
+        val baseUrl = getBaseUrl().trimEnd('/')
+        val remoteResults = try {
+            api.search(query)
+        } catch (e: Exception) {
+            emptyList()
+        }
+
+        // Always offer a "manual entry" option so the user can track items that don't appear
+        // in Yamtrack's upstream providers (matches Yamtrack's own `source=manual` flow).
+        val manualEntry = TrackSearch.create(id).apply {
+            remote_id = buildRemoteId(SOURCE_MANUAL, query)
+            title = query
+            cover_url = ""
+            summary = ""
+            tracking_url = buildTrackingUrl(baseUrl, SOURCE_MANUAL, query)
+            publishing_type = "Manual entry"
+        }
+        return remoteResults + manualEntry
+    }
+
+    override suspend fun refresh(track: Track): Track {
+        val (source, mediaId) = parseTrackingUrl(track.tracking_url) ?: return track
+        val remote = api.getMediaItem(source, mediaId) ?: return track
+        remote.copyToTrack(track)
+        return track
+    }
+
+    override suspend fun delete(track: DomainTrack) {
+        api.deleteMedia(track)
+    }
+
+    override suspend fun login(username: String, password: String) {
+        val baseUrl = normalizeBaseUrl(username)
+        val token = password.trim()
+        if (baseUrl.isEmpty() || token.isEmpty()) {
+            throw IllegalArgumentException("Host URL and API token are required")
+        }
+        api.verifyCredentials(baseUrl, token)
+        saveCredentials(baseUrl, token)
+    }
+
+    fun getBaseUrl(): String = getUsername()
+
+    fun getApiToken(): String = getPassword()
+
+    private fun normalizeBaseUrl(input: String): String {
+        val trimmed = input.trim().trimEnd('/')
+        if (trimmed.isEmpty()) return ""
+        return if (trimmed.startsWith("http://", ignoreCase = true) ||
+            trimmed.startsWith("https://", ignoreCase = true)
+        ) {
+            trimmed
+        } else {
+            "https://$trimmed"
+        }
+    }
+
+    override fun hasNotStartedReading(status: Long): Boolean = status == PLANNING
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/yamtrack/YamtrackApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/yamtrack/YamtrackApi.kt
@@ -1,0 +1,136 @@
+package eu.kanade.tachiyomi.data.track.yamtrack
+
+import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import eu.kanade.tachiyomi.data.track.yamtrack.dto.YTMediaItem
+import eu.kanade.tachiyomi.data.track.yamtrack.dto.YTSearchResponse
+import eu.kanade.tachiyomi.data.track.yamtrack.dto.toTrackSearch
+import eu.kanade.tachiyomi.network.DELETE
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.PATCH
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.jsonMime
+import eu.kanade.tachiyomi.network.parseAs
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import tachiyomi.domain.track.model.Track as DomainTrack
+
+class YamtrackApi(
+    private val yamtrack: Yamtrack,
+    private val baseClient: OkHttpClient,
+    interceptor: YamtrackInterceptor,
+) {
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        explicitNulls = false
+        encodeDefaults = false
+    }
+
+    private val authClient by lazy {
+        baseClient.newBuilder()
+            .addInterceptor(interceptor)
+            .build()
+    }
+
+    private fun apiUrl(path: String): String {
+        val base = yamtrack.getBaseUrl().trimEnd('/')
+        return "$base/api/v1$path"
+    }
+
+    suspend fun verifyCredentials(baseUrl: String, token: String) {
+        val url = "${baseUrl.trimEnd('/')}/api/v1/statistics/"
+        val authedClient = baseClient.newBuilder()
+            .addInterceptor { chain ->
+                val authed = chain.request().newBuilder()
+                    .addHeader("Authorization", "Bearer $token")
+                    .header("Accept", "application/json")
+                    .build()
+                chain.proceed(authed)
+            }
+            .build()
+        authedClient.newCall(GET(url)).awaitSuccess().close()
+    }
+
+    suspend fun search(query: String): List<TrackSearch> {
+        val url = apiUrl("/search/manga/").toHttpUrl().newBuilder()
+            .addQueryParameter("search", query)
+            .addQueryParameter("limit", "20")
+            .build()
+
+        val response = with(json) {
+            authClient.newCall(GET(url.toString()))
+                .awaitSuccess()
+                .parseAs<YTSearchResponse>()
+        }
+
+        val baseUrl = yamtrack.getBaseUrl().trimEnd('/')
+        return response.results
+            .filter { it.mediaId.isNotBlank() && it.source.isNotBlank() }
+            .map { it.toTrackSearch(yamtrack.id, baseUrl) }
+    }
+
+    suspend fun getMediaItem(source: String, mediaId: String): YTMediaItem? {
+        return try {
+            with(json) {
+                authClient.newCall(GET(apiUrl("/media/manga/$source/$mediaId/")))
+                    .awaitSuccess()
+                    .parseAs<YTMediaItem>()
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    suspend fun addMedia(track: Track, source: String, mediaId: String, title: String? = null) {
+        val body = buildJsonObject {
+            put("source", source)
+            if (source == Yamtrack.SOURCE_MANUAL) {
+                if (!title.isNullOrBlank()) {
+                    put("title", title)
+                }
+            } else {
+                put("media_id", mediaId)
+            }
+            put("status", Yamtrack.statusToApi(track.status))
+            put("progress", track.last_chapter_read.toInt())
+            if (track.score > 0.0) {
+                put("score", track.score)
+            }
+        }
+        authClient.newCall(
+            POST(
+                url = apiUrl("/media/manga/"),
+                body = body.toString().toRequestBody(jsonMime),
+            ),
+        ).awaitSuccess().close()
+    }
+
+    suspend fun updateMedia(track: Track, source: String, mediaId: String) {
+        val body = buildJsonObject {
+            put("status", Yamtrack.statusToApi(track.status))
+            put("progress", track.last_chapter_read.toInt())
+            if (track.score >= 0.0) {
+                put("score", track.score)
+            }
+        }
+        authClient.newCall(
+            PATCH(
+                url = apiUrl("/media/manga/$source/$mediaId/"),
+                body = body.toString().toRequestBody(jsonMime),
+            ),
+        ).awaitSuccess().close()
+    }
+
+    suspend fun deleteMedia(track: DomainTrack) {
+        val (source, mediaId) = Yamtrack.parseTrackingUrl(track.remoteUrl) ?: return
+        authClient.newCall(
+            DELETE(url = apiUrl("/media/manga/$source/$mediaId/")),
+        ).awaitSuccess().close()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/yamtrack/YamtrackInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/yamtrack/YamtrackInterceptor.kt
@@ -1,0 +1,24 @@
+package eu.kanade.tachiyomi.data.track.yamtrack
+
+import eu.kanade.tachiyomi.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+class YamtrackInterceptor(private val yamtrack: Yamtrack) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = yamtrack.getApiToken()
+        if (token.isBlank()) {
+            throw IOException("Not authenticated with Yamtrack")
+        }
+
+        val authRequest = chain.request().newBuilder()
+            .addHeader("Authorization", "Bearer $token")
+            .header("User-Agent", "Komikku v${BuildConfig.VERSION_NAME} (${BuildConfig.APPLICATION_ID})")
+            .header("Accept", "application/json")
+            .build()
+
+        return chain.proceed(authRequest)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/yamtrack/dto/YTMedia.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/yamtrack/dto/YTMedia.kt
@@ -1,0 +1,69 @@
+package eu.kanade.tachiyomi.data.track.yamtrack.dto
+
+import eu.kanade.tachiyomi.data.database.models.Track
+import eu.kanade.tachiyomi.data.track.model.TrackSearch
+import eu.kanade.tachiyomi.data.track.yamtrack.Yamtrack
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class YTSearchResponse(
+    val count: Int = 0,
+    val next: String? = null,
+    val previous: String? = null,
+    val results: List<YTSearchItem> = emptyList(),
+)
+
+@Serializable
+data class YTSearchItem(
+    @SerialName("media_id")
+    val mediaId: String = "",
+    val source: String = "",
+    val title: String = "",
+    val image: String? = null,
+    @SerialName("media_type")
+    val mediaType: String? = null,
+    val description: String? = null,
+)
+
+@Serializable
+data class YTMediaItem(
+    @SerialName("media_id")
+    val mediaId: String? = null,
+    val source: String? = null,
+    val title: String? = null,
+    val image: String? = null,
+    @SerialName("media_type")
+    val mediaType: String? = null,
+    val description: String? = null,
+    val status: String? = null,
+    val progress: Int? = null,
+    val score: Double? = null,
+    @SerialName("start_date")
+    val startDate: String? = null,
+    @SerialName("end_date")
+    val endDate: String? = null,
+    val notes: String? = null,
+    @SerialName("total_chapters")
+    val totalChapters: Int? = null,
+    val url: String? = null,
+)
+
+fun YTSearchItem.toTrackSearch(trackerId: Long, baseUrl: String): TrackSearch {
+    val item = this
+    return TrackSearch.create(trackerId).apply {
+        remote_id = Yamtrack.buildRemoteId(item.source, item.mediaId)
+        title = item.title
+        cover_url = item.image.orEmpty()
+        summary = item.description.orEmpty()
+        tracking_url = Yamtrack.buildTrackingUrl(baseUrl, item.source, item.mediaId)
+        publishing_type = item.mediaType.orEmpty()
+    }
+}
+
+fun YTMediaItem.copyToTrack(track: Track) {
+    track.status = Yamtrack.statusFromApi(status)
+    track.last_chapter_read = progress?.toDouble() ?: track.last_chapter_read
+    track.score = score ?: 0.0
+    totalChapters?.let { track.total_chapters = it.toLong() }
+}

--- a/app/src/main/res/drawable/brand_yamtrack.xml
+++ b/app/src/main/res/drawable/brand_yamtrack.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+    <path
+        android:pathData="M0,0h192v192H0z"
+        android:fillColor="#1f2937"
+        android:fillType="evenOdd" />
+    <path
+        android:pathData="M40,48 L72,48 L96,96 L120,48 L152,48 L112,124 L112,156 L80,156 L80,124 Z"
+        android:fillColor="#22d3ee"
+        android:fillType="nonZero" />
+</vector>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -238,4 +238,7 @@
     <string name="pref_discord_show_download_button_summary">Displays a button to download the app</string>
     <string name="pref_discord_show_discord_button">Show Discord Button</string>
     <string name="pref_discord_show_discord_button_summary">Displays a button to join the Discord server</string>
+    <!-- Yamtrack tracker -->
+    <string name="yamtrack_host_url">Host URL</string>
+    <string name="yamtrack_api_token">API token</string>
 </resources>


### PR DESCRIPTION
Adds a new self-hosted tracker for Yamtrack using the new REST API introduced in FuzzyGrim/Yamtrack#924.

- Bearer-token authentication with user-supplied host URL + API token
- Search via /api/v1/search/manga/ with manual-entry fallback so users can track items that don't appear in upstream providers
- Add / update / refresh / delete media via /api/v1/media/manga/...
- Status mapping: Planning, In progress, Paused, Completed, Dropped
- 0.0-10.0 score in 0.1 increments
- Extended TrackingLoginDialog with optional pwStringRes so the token field reads "API token" instead of "Password"

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add first-class integration with the Yamtrack self-hosted tracker, wiring it into the tracker manager and tracking settings UI with full login and media synchronization support.

New Features:
- Introduce Yamtrack as a new self-hosted tracking service alongside existing trackers, including REST-based search, add/update/refresh, and delete support with manual-entry fallback.

Enhancements:
- Extend the tracking login dialog to support a customizable password field label and add localized strings for Yamtrack host URL and API token labels.
- Add a dedicated Yamtrack brand icon and interceptor for authenticated API access using bearer tokens.