### PR TITLE
Remove redundant `userSelected` from selection methods (#2976)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -194,7 +194,7 @@ fun MangaScreen(
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
 
     // Chapter selection
-    onChapterSelected: (ChapterList.Item, Boolean, Boolean, Boolean) -> Unit,
+    onChapterSelected: (ChapterList.Item, Boolean, Boolean) -> Unit,
     onAllChapterSelected: (Boolean) -> Unit,
     onInvertSelection: () -> Unit,
 
@@ -404,7 +404,7 @@ private fun MangaScreenSmallImpl(
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
 
     // Chapter selection
-    onChapterSelected: (ChapterList.Item, Boolean, Boolean, Boolean) -> Unit,
+    onChapterSelected: (ChapterList.Item, Boolean, Boolean) -> Unit,
     onAllChapterSelected: (Boolean) -> Unit,
     onInvertSelection: () -> Unit,
 
@@ -868,7 +868,7 @@ private fun MangaScreenLargeImpl(
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
 
     // Chapter selection
-    onChapterSelected: (ChapterList.Item, Boolean, Boolean, Boolean) -> Unit,
+    onChapterSelected: (ChapterList.Item, Boolean, Boolean) -> Unit,
     onAllChapterSelected: (Boolean) -> Unit,
     onInvertSelection: () -> Unit,
 
@@ -1307,7 +1307,7 @@ private fun LazyListScope.sharedChapterItems(
     // SY <--
     onChapterClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
-    onChapterSelected: (ChapterList.Item, Boolean, Boolean, Boolean) -> Unit,
+    onChapterSelected: (ChapterList.Item, Boolean, Boolean) -> Unit,
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
 ) {
     items(
@@ -1376,14 +1376,14 @@ private fun LazyListScope.sharedChapterItems(
                     chapterSwipeStartAction = chapterSwipeStartAction,
                     chapterSwipeEndAction = chapterSwipeEndAction,
                     onLongClick = {
-                        onChapterSelected(item, !item.selected, true, true)
+                        onChapterSelected(item, !item.selected, true)
                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     },
                     onClick = {
                         onChapterItemClick(
                             chapterItem = item,
                             isAnyChapterSelected = isAnyChapterSelected,
-                            onToggleSelection = { onChapterSelected(item, !item.selected, true, false) },
+                            onToggleSelection = { onChapterSelected(item, !item.selected, false) },
                             onChapterClicked = onChapterClicked,
                         )
                     },

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesUiItem.kt
@@ -171,7 +171,6 @@ internal fun LazyListScope.updatesUiItems(
                                 // KMK -->
                                 UpdateSelectionOptions(
                                     selected = !updatesItem.selected,
-                                    userSelected = true,
                                     fromLongPress = true,
                                     isGroup = isLeader && item.isExpandable,
                                     isExpanded = isExpanded,
@@ -186,7 +185,6 @@ internal fun LazyListScope.updatesUiItems(
                                     // KMK -->
                                     UpdateSelectionOptions(
                                         selected = !updatesItem.selected,
-                                        userSelected = true,
                                         fromLongPress = false,
                                         isGroup = isLeader && item.isExpandable,
                                         isExpanded = isExpanded,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1725,7 +1725,6 @@ class MangaScreenModel(
     fun toggleSelection(
         item: ChapterList.Item,
         selected: Boolean,
-        userSelected: Boolean = false,
         fromLongPress: Boolean = false,
     ) {
         updateSuccessState { successState ->
@@ -1740,7 +1739,7 @@ class MangaScreenModel(
                 set(selectedIndex, selectedItem.copy(selected = selected))
                 selectedChapterIds.addOrRemove(item.id, selected)
 
-                if (selected && userSelected && fromLongPress) {
+                if (selected && fromLongPress) {
                     if (firstSelection) {
                         selectedPositions[0] = selectedIndex
                         selectedPositions[1] = selectedIndex
@@ -1766,7 +1765,7 @@ class MangaScreenModel(
                             }
                         }
                     }
-                } else if (userSelected && !fromLongPress) {
+                } else if (!fromLongPress) {
                     if (!selected) {
                         if (selectedIndex == selectedPositions[0]) {
                             selectedPositions[0] = indexOfFirst { it.selected }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -362,7 +362,6 @@ class UpdatesScreenModel(
     /** Bundles all of the boolean flags for update‐selection into one type */
     data class UpdateSelectionOptions(
         val selected: Boolean,
-        val userSelected: Boolean = false,
         val fromLongPress: Boolean = false,
         val isGroup: Boolean = false,
         val isExpanded: Boolean = false,
@@ -376,7 +375,7 @@ class UpdatesScreenModel(
         // KMK <--
     ) {
         // KMK -->
-        val (selected, userSelected, fromLongPress, isGroup, isExpanded) = selectionOptions
+        val (selected, fromLongPress, isGroup, isExpanded) = selectionOptions
         // KMK <--
         mutableState.update { state ->
             val newItems = state.items.toMutableList().apply {
@@ -409,7 +408,7 @@ class UpdatesScreenModel(
                 }
                 // KMK <--
 
-                if (selected && userSelected && fromLongPress) {
+                if (selected && fromLongPress) {
                     if (firstSelection) {
                         selectedPositions[0] = selectedIndex
                         selectedPositions[1] = selectedIndex
@@ -435,7 +434,7 @@ class UpdatesScreenModel(
                             }
                         }
                     }
-                } else if (userSelected && !fromLongPress) {
+                } else if (!fromLongPress) {
                     if (!selected) {
                         if (selectedIndex == selectedPositions[0]) {
                             selectedPositions[0] = indexOfFirst { it.selected }


### PR DESCRIPTION
## Summary by Sourcery

Simplify chapter and update selection handling by removing the redundant user-selected flag from selection APIs and logic.

Enhancements:
- Streamline chapter selection callbacks in manga screens by reducing the onChapterSelected parameters.
- Simplify MangaScreenModel and UpdatesScreenModel selection logic by eliminating the userSelected option and relying only on selection state and long-press origin.
- Clean up updates UI item selection wiring to match the new, reduced selection options.