### PR TITLE
Use remember getUiModel

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -121,6 +121,7 @@ fun LibraryUpdateErrorScreen(
             )
         },
         bottomBar = {
+            val headerIndexes = remember(state.items) { state.getHeaderIndexes() }
             LibraryUpdateErrorBottomBar(
                 selected = state.selected,
                 onMultiMigrateClicked = onMultiMigrateClicked,
@@ -141,7 +142,7 @@ fun LibraryUpdateErrorScreen(
                 scrollToPrevious = {
                     scope.launch {
                         listState.scrollToItem(
-                            state.getHeaderIndexes()
+                            headerIndexes
                                 .filter { it < listState.firstVisibleItemIndex }
                                 .maxOrNull() ?: 0,
                         )
@@ -150,7 +151,7 @@ fun LibraryUpdateErrorScreen(
                 scrollToNext = {
                     scope.launch {
                         listState.scrollToItem(
-                            state.getHeaderIndexes()
+                            headerIndexes
                                 .filter { it > listState.firstVisibleItemIndex }
                                 .minOrNull() ?: 0,
                         )
@@ -167,13 +168,14 @@ fun LibraryUpdateErrorScreen(
             )
 
             else -> {
+                val uiModels = remember(state.items) { state.getUiModel() }
                 FastScrollLazyColumn(
                     // Using modifier instead of contentPadding so we can use stickyHeader
                     modifier = Modifier.padding(contentPadding),
                     state = listState,
                 ) {
                     libraryUpdateErrorUiItems(
-                        uiModels = state.getUiModel(),
+                        uiModels = uiModels,
                         selectionMode = state.selectionMode,
                         onErrorSelected = onErrorSelected,
                         onClick = onClick,

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -39,6 +38,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
+import eu.kanade.presentation.libraryUpdateError.components.LibraryUpdateErrorUiModel
 import eu.kanade.presentation.libraryUpdateError.components.libraryUpdateErrorUiItems
 import eu.kanade.presentation.manga.components.Button
 import eu.kanade.tachiyomi.ui.libraryUpdateError.LibraryUpdateErrorItem
@@ -75,9 +75,11 @@ fun LibraryUpdateErrorScreen(
     val scope = rememberCoroutineScope()
     val listState = rememberLazyListState()
 
-    val headerIndexes = remember { mutableStateOf<List<Int>>(emptyList()) }
-    LaunchedEffect(state) {
-        headerIndexes.value = state.getHeaderIndexes()
+    val uiModels = remember(state) { state.getUiModel() }
+    val headerIndexes = remember(state) {
+        uiModels.withIndex()
+            .filter { it.value is LibraryUpdateErrorUiModel.Header }
+            .map { it.index }
     }
 
     val enableScrollToTop by remember {
@@ -94,12 +96,12 @@ fun LibraryUpdateErrorScreen(
 
     val enableScrollToPrevious by remember {
         derivedStateOf {
-            headerIndexes.value.any { it < listState.firstVisibleItemIndex }
+            headerIndexes.any { it < listState.firstVisibleItemIndex }
         }
     }
     val enableScrollToNext by remember {
         derivedStateOf {
-            headerIndexes.value.any { it > listState.firstVisibleItemIndex }
+            headerIndexes.any { it > listState.firstVisibleItemIndex }
         }
     }
 
@@ -141,7 +143,7 @@ fun LibraryUpdateErrorScreen(
                 scrollToPrevious = {
                     scope.launch {
                         listState.scrollToItem(
-                            headerIndexes.value
+                            headerIndexes
                                 .filter { it < listState.firstVisibleItemIndex }
                                 .maxOrNull() ?: 0,
                         )
@@ -150,7 +152,7 @@ fun LibraryUpdateErrorScreen(
                 scrollToNext = {
                     scope.launch {
                         listState.scrollToItem(
-                            headerIndexes.value
+                            headerIndexes
                                 .filter { it > listState.firstVisibleItemIndex }
                                 .minOrNull() ?: 0,
                         )
@@ -167,7 +169,6 @@ fun LibraryUpdateErrorScreen(
             )
 
             else -> {
-                val uiModels = remember(state.items) { state.getUiModel() }
                 FastScrollLazyColumn(
                     // Using modifier instead of contentPadding so we can use stickyHeader
                     modifier = Modifier.padding(contentPadding),

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -121,7 +121,6 @@ fun LibraryUpdateErrorScreen(
             )
         },
         bottomBar = {
-            val headerIndexes = remember(state.items) { state.getHeaderIndexes() }
             LibraryUpdateErrorBottomBar(
                 selected = state.selected,
                 onMultiMigrateClicked = onMultiMigrateClicked,
@@ -142,7 +141,7 @@ fun LibraryUpdateErrorScreen(
                 scrollToPrevious = {
                     scope.launch {
                         listState.scrollToItem(
-                            headerIndexes
+                            headerIndexes.value
                                 .filter { it < listState.firstVisibleItemIndex }
                                 .maxOrNull() ?: 0,
                         )
@@ -151,7 +150,7 @@ fun LibraryUpdateErrorScreen(
                 scrollToNext = {
                     scope.launch {
                         listState.scrollToItem(
-                            headerIndexes
+                            headerIndexes.value
                                 .filter { it > listState.firstVisibleItemIndex }
                                 .minOrNull() ?: 0,
                         )

--- a/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/libraryUpdateError/LibraryUpdateErrorScreen.kt
@@ -82,24 +82,24 @@ fun LibraryUpdateErrorScreen(
             .map { it.index }
     }
 
-    val enableScrollToTop by remember {
+    val enableScrollToTop by remember(listState) {
         derivedStateOf {
             listState.firstVisibleItemIndex > 0
         }
     }
 
-    val enableScrollToBottom by remember {
+    val enableScrollToBottom by remember(listState) {
         derivedStateOf {
             listState.canScrollForward
         }
     }
 
-    val enableScrollToPrevious by remember {
+    val enableScrollToPrevious by remember(headerIndexes, listState) {
         derivedStateOf {
             headerIndexes.any { it < listState.firstVisibleItemIndex }
         }
     }
-    val enableScrollToNext by remember {
+    val enableScrollToNext by remember(headerIndexes, listState) {
         derivedStateOf {
             headerIndexes.any { it > listState.firstVisibleItemIndex }
         }

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -112,6 +112,9 @@ fun UpdateScreen(
             else -> {
                 val scope = rememberCoroutineScope()
                 var isRefreshing by remember { mutableStateOf(false) }
+                // KMK -->
+                val uiModels = remember(state.items) { state.getUiModel() }
+                // KMK <--
 
                 PullRefresh(
                     refreshing = isRefreshing,
@@ -134,8 +137,8 @@ fun UpdateScreen(
                         updatesLastUpdatedItem(lastUpdated)
 
                         updatesUiItems(
-                            uiModels = state.getUiModel(),
                             // KMK -->
+                            uiModels = uiModels,
                             expandedState = state.expandedState,
                             collapseToggle = collapseToggle,
                             usePanoramaCover = usePanoramaCover,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -189,11 +189,6 @@ data class LibraryUpdateErrorScreenState(
         }
         return uiModels
     }
-
-    fun getHeaderIndexes(): List<Int> = getUiModel()
-        .withIndex()
-        .filter { it.value is LibraryUpdateErrorUiModel.Header }
-        .map { it.index }
 }
 
 @Immutable


### PR DESCRIPTION
## Summary by Sourcery

Cache derived UI models in composable screens to avoid recomputing them on every recomposition and use remembered header index values for list scrolling.

Enhancements:
- Remember and reuse UI model lists in LibraryUpdateErrorScreen and UpdateScreen instead of recalculating them on each recomposition.
- Use stored header index state for scrolling between headers in the library update error list.