### PR TITLE
chore: Avoid race conditions and improve bulk selection

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BulkFavoriteDialogs.kt
@@ -67,7 +67,6 @@ fun Screen.BulkFavoriteDialogs(
             AddDuplicateMangaDialog(
                 dialog = dialog,
                 navigator = navigator,
-                state = bulkFavoriteState,
                 onDismiss = bulkFavoriteScreenModel::dismissDialog,
                 stopRunning = bulkFavoriteScreenModel::stopRunning,
                 toggleSelectionMode = bulkFavoriteScreenModel::toggleSelectionMode,
@@ -134,10 +133,9 @@ private fun Screen.ShowMigrateDialog(
 private fun AddDuplicateMangaDialog(
     dialog: Dialog.AddDuplicateManga,
     navigator: Navigator?,
-    state: BulkFavoriteScreenModel.State,
     onDismiss: () -> Unit,
     stopRunning: () -> Unit,
-    toggleSelectionMode: () -> Unit,
+    toggleSelectionMode: (Boolean) -> Unit,
     addFavorite: (Manga) -> Unit,
     showMigrateDialog: (manga: Manga, duplicate: Manga) -> Unit,
 ) {
@@ -147,9 +145,7 @@ private fun AddDuplicateMangaDialog(
         duplicates = dialog.duplicates,
         onDismissRequest = onDismiss,
         onConfirm = {
-            if (state.selectionMode) {
-                toggleSelectionMode()
-            }
+            toggleSelectionMode(false)
             addFavorite(dialog.manga)
         },
         onOpenManga = { navigator?.push(MangaScreen(it.id)) },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -62,7 +62,7 @@ class BulkFavoriteScreenModel(
 ) : StateScreenModel<BulkFavoriteScreenModel.State>(initialState) {
 
     fun backHandler() {
-        toggleSelectionMode()
+        toggleSelectionMode(false)
     }
 
     fun toggleSelectionMode(newMode: Boolean? = null) {
@@ -152,7 +152,7 @@ class BulkFavoriteScreenModel(
             val mangaList = if (skipAllDuplicates) getNotDuplicateLibraryMangas() else state.value.selection
             if (mangaList.isEmpty()) {
                 stopRunning()
-                toggleSelectionMode()
+                toggleSelectionMode(false)
                 return@launch
             }
             val categories = getCategories()
@@ -241,7 +241,7 @@ class BulkFavoriteScreenModel(
             }
             stopRunning()
         }
-        toggleSelectionMode(newMode = false)
+        toggleSelectionMode(false)
     }
 
     private fun moveMangaToCategoriesAndAddToLibrary(manga: Manga, categories: List<Long>) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/BulkFavoriteScreenModel.kt
@@ -66,14 +66,13 @@ class BulkFavoriteScreenModel(
     }
 
     fun toggleSelectionMode(newMode: Boolean? = null) {
-        if (state.value.selectionMode) {
-            clearSelection()
+        mutableState.update { state ->
+            val mode = newMode ?: !state.selectionMode
+            state.copy(
+                selectionMode = mode,
+                selection = if (mode) state.selection else persistentListOf(),
+            )
         }
-        mutableState.update { it.copy(selectionMode = newMode ?: !it.selectionMode) }
-    }
-
-    private fun clearSelection() {
-        mutableState.update { it.copy(selection = persistentListOf()) }
     }
 
     fun select(manga: Manga) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/migration/manga/MigrateMangaScreenModel.kt
@@ -149,11 +149,10 @@ class MigrateMangaScreenModel(
                 selectedMangaIds.addOrRemove(it.manga.id, selected)
                 it.copy(selected = selected)
             }
+            selectedPositions[0] = -1
+            selectedPositions[1] = -1
             state.copy(titleList = newItems.toImmutableList())
         }
-
-        selectedPositions[0] = -1
-        selectedPositions[1] = -1
     }
 
     fun invertSelection() {
@@ -162,10 +161,10 @@ class MigrateMangaScreenModel(
                 selectedMangaIds.addOrRemove(it.manga.id, !it.selected)
                 it.copy(selected = !it.selected)
             }
+            selectedPositions[0] = -1
+            selectedPositions[1] = -1
             state.copy(titleList = newItems.toImmutableList())
         }
-        selectedPositions[0] = -1
-        selectedPositions[1] = -1
     }
     // KMK <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/libraryUpdateError/LibraryUpdateErrorScreenModel.kt
@@ -129,11 +129,10 @@ class LibraryUpdateErrorScreenModel(
                 selectedErrorIds.addOrRemove(it.error.errorId, selected)
                 it.copy(selected = selected)
             }
+            selectedPositions[0] = -1
+            selectedPositions[1] = -1
             state.copy(items = newItems)
         }
-
-        selectedPositions[0] = -1
-        selectedPositions[1] = -1
     }
 
     fun invertSelection() {
@@ -142,10 +141,10 @@ class LibraryUpdateErrorScreenModel(
                 selectedErrorIds.addOrRemove(it.error.errorId, !it.selected)
                 it.copy(selected = !it.selected)
             }
+            selectedPositions[0] = -1
+            selectedPositions[1] = -1
             state.copy(items = newItems)
         }
-        selectedPositions[0] = -1
-        selectedPositions[1] = -1
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -461,11 +461,12 @@ class UpdatesScreenModel(
                 selectedChapterIds.addOrRemove(it.update.chapterId, selected)
                 it.copy(selected = selected)
             }
+            // KMK -->
+            selectedPositions[0] = -1
+            selectedPositions[1] = -1
+            // KMK <--
             state.copy(items = newItems.toPersistentList())
         }
-
-        selectedPositions[0] = -1
-        selectedPositions[1] = -1
     }
 
     fun invertSelection() {
@@ -474,10 +475,12 @@ class UpdatesScreenModel(
                 selectedChapterIds.addOrRemove(it.update.chapterId, !it.selected)
                 it.copy(selected = !it.selected)
             }
+            // KMK -->
+            selectedPositions[0] = -1
+            selectedPositions[1] = -1
+            // KMK <--
             state.copy(items = newItems.toPersistentList())
         }
-        selectedPositions[0] = -1
-        selectedPositions[1] = -1
     }
 
     fun setDialog(dialog: Dialog?) {

--- a/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
+++ b/app/src/main/java/exh/recs/BrowseRecommendsScreen.kt
@@ -124,7 +124,7 @@ class BrowseRecommendsScreen(
                         scrollBehavior = scrollBehavior,
                         // KMK -->
                         toggleSelectionMode = {
-                            bulkFavoriteScreenModel.toggleSelectionMode()
+                            bulkFavoriteScreenModel.toggleSelectionMode(true)
                         }.takeIf { !isExternalSource },
                         isRunning = bulkFavoriteState.isRunning,
                         // KMK <--


### PR DESCRIPTION
Enhance the bulk selection functionality by addressing race conditions and refining the selection mode toggle behavior.

## Summary by Sourcery

Stabilize bulk selection flows across updates, migration, library update error, and bulk favorite screens to avoid race conditions and make selection mode toggling explicit and predictable.

Bug Fixes:
- Reset bulk selection anchor positions atomically with state updates to prevent race conditions when selecting or inverting selections.
- Ensure bulk favorite selection mode is correctly exited when backing out, completing, or confirming duplicate-handling flows.

Enhancements:
- Make bulk favorite selection mode toggling explicit via a Boolean parameter and propagate it through dialog and recommendations UI flows, improving clarity and control over selection state.