### PR TITLE
Improve source display name format for merged entries

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -1,11 +1,15 @@
 package eu.kanade.tachiyomi.source
 
+import android.app.Application
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import exh.source.EH_PACKAGE
 import exh.source.LOCAL_SOURCE_PACKAGE
+import exh.source.MERGED_SOURCE_ID
 import exh.source.isEhBasedSource
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.source.model.StubSource
+import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.icons.FlagEmoji
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
@@ -52,8 +56,11 @@ private fun getMergedSourcesString(
     enabledLangs: List<String>,
     onlyName: Boolean,
 ): String {
-    return if (onlyName) {
-        mergeSources.joinToString { source ->
+    // KMK --> Filter out MergedSource itself so it's not displayed in the list
+    val realSources = mergeSources.filterNot { it.id == MERGED_SOURCE_ID }
+    // KMK <--
+    val sourceNames = if (onlyName) {
+        realSources.joinToString { source ->
             when {
                 // KMK -->
                 source.isLocalOrStub() -> source.toString()
@@ -67,7 +74,7 @@ private fun getMergedSourcesString(
             }
         }
     } else {
-        mergeSources.joinToString { source ->
+        realSources.joinToString { source ->
             // KMK -->
             if (source.isLocalOrStub()) {
                 source.toString()
@@ -77,6 +84,17 @@ private fun getMergedSourcesString(
             // KMK <--
         }
     }
+
+    // KMK --> Always show "Merged Entry" prefix for merged entries.
+    // The onlyName parameter only controls whether language flags are shown or not.
+    val mergedLabel = Injekt.get<Application>().stringResource(MR.strings.label_merged_entry)
+
+    return if (sourceNames.isBlank()) {
+        mergedLabel
+    } else {
+        "$mergedLabel ($sourceNames)"
+    }
+    // KMK <--
 }
 // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.source
 
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
+import eu.kanade.tachiyomi.source.online.all.MergedSource
 import exh.source.EH_PACKAGE
 import exh.source.LOCAL_SOURCE_PACKAGE
 import exh.source.isEhBasedSource
@@ -52,8 +53,11 @@ private fun getMergedSourcesString(
     enabledLangs: List<String>,
     onlyName: Boolean,
 ): String {
-    return if (onlyName) {
-        mergeSources.joinToString { source ->
+    // KMK --> Filter out MergedSource itself
+    val filteredSources = mergeSources.filterNot { it is MergedSource }
+    // KMK <--
+    val sourceNames = if (onlyName) {
+        filteredSources.joinToString { source ->
             when {
                 // KMK -->
                 source.isLocalOrStub() -> source.toString()
@@ -67,7 +71,7 @@ private fun getMergedSourcesString(
             }
         }
     } else {
-        mergeSources.joinToString { source ->
+        filteredSources.joinToString { source ->
             // KMK -->
             if (source.isLocalOrStub()) {
                 source.toString()
@@ -77,6 +81,7 @@ private fun getMergedSourcesString(
             // KMK <--
         }
     }
+    return "Merged Entry ($sourceNames)"
 }
 // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -1,12 +1,15 @@
 package eu.kanade.tachiyomi.source
 
+import android.app.Application
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
-import eu.kanade.tachiyomi.source.online.all.MergedSource
 import exh.source.EH_PACKAGE
 import exh.source.LOCAL_SOURCE_PACKAGE
+import exh.source.MERGED_SOURCE_ID
 import exh.source.isEhBasedSource
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.source.model.StubSource
+import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.icons.FlagEmoji
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
@@ -53,11 +56,11 @@ private fun getMergedSourcesString(
     enabledLangs: List<String>,
     onlyName: Boolean,
 ): String {
-    // KMK --> Filter out MergedSource itself
-    val filteredSources = mergeSources.filterNot { it is MergedSource }
+    // KMK --> Filter out MergedSource itself so it's not displayed in the list
+    val realSources = mergeSources.filterNot { it.id == MERGED_SOURCE_ID }
     // KMK <--
     val sourceNames = if (onlyName) {
-        filteredSources.joinToString { source ->
+        realSources.joinToString { source ->
             when {
                 // KMK -->
                 source.isLocalOrStub() -> source.toString()
@@ -71,7 +74,7 @@ private fun getMergedSourcesString(
             }
         }
     } else {
-        filteredSources.joinToString { source ->
+        realSources.joinToString { source ->
             // KMK -->
             if (source.isLocalOrStub()) {
                 source.toString()
@@ -81,7 +84,17 @@ private fun getMergedSourcesString(
             // KMK <--
         }
     }
-    return "Merged Entry ($sourceNames)"
+
+    // KMK --> Always show "Merged Entry" prefix for merged entries.
+    // The onlyName parameter only controls whether language flags are shown or not.
+    val mergedLabel = Injekt.get<Application>().stringResource(MR.strings.label_merged_entry)
+
+    return if (sourceNames.isBlank()) {
+        mergedLabel
+    } else {
+        "$mergedLabel ($sourceNames)"
+    }
+    // KMK <--
 }
 // SY <--
 

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -44,6 +44,7 @@
     <string name="label_started">Started</string>
     <string name="label_local">Local</string>
     <string name="label_downloaded">Downloaded</string>
+    <string name="label_merged_entry">Merged Entry</string>
 
     <string name="unlock_app_title">Unlock %s</string>
     <string name="confirm_lock_change">Authenticate to confirm change</string>


### PR DESCRIPTION
Improves how merged entries show their sources in the library and manga info screen.

**Before:**  
`SourceA, SourceB, MergedSource`

**After:**  
`Merged Entry (SourceA, SourceB)`

## Before
<img width="1200" height="867" alt="image" src="https://github.com/user-attachments/assets/14e97aae-5ba8-4f5a-8d99-b16bb3604985" />

## After
<img width="1200" height="874" alt="image" src="https://github.com/user-attachments/assets/6a0b8c36-ce97-4bf4-bad0-1f92358b16a8" />

## Notes

- Added new string resource `label_merged_entry`.
- Currently only translated to **English**.


Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc