### PR TITLE
Enhance source display name for merged entries

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -1,11 +1,15 @@
 package eu.kanade.tachiyomi.source
 
+import android.app.Application
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import exh.source.EH_PACKAGE
 import exh.source.LOCAL_SOURCE_PACKAGE
+import exh.source.MERGED_SOURCE_ID
 import exh.source.isEhBasedSource
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.source.model.StubSource
+import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.icons.FlagEmoji
 import tachiyomi.source.local.isLocal
 import uy.kohesive.injekt.Injekt
@@ -52,8 +56,11 @@ private fun getMergedSourcesString(
     enabledLangs: List<String>,
     onlyName: Boolean,
 ): String {
-    return if (onlyName) {
-        mergeSources.joinToString { source ->
+    // KMK --> Filter out MergedSource itself so it's not displayed in the list
+    val realSources = mergeSources.filterNot { it.id == MERGED_SOURCE_ID }
+    // KMK <--
+    val sourceNames = if (onlyName) {
+        realSources.joinToString { source ->
             when {
                 // KMK -->
                 source.isLocalOrStub() -> source.toString()
@@ -67,7 +74,7 @@ private fun getMergedSourcesString(
             }
         }
     } else {
-        mergeSources.joinToString { source ->
+        realSources.joinToString { source ->
             // KMK -->
             if (source.isLocalOrStub()) {
                 source.toString()
@@ -77,6 +84,17 @@ private fun getMergedSourcesString(
             // KMK <--
         }
     }
+
+    // KMK --> Always show "Merged Entry" prefix for merged entries.
+    // The onlyName parameter only controls whether language flags are shown or not.
+    val mergedLabel = Injekt.get<Application>().stringResource(MR.strings.label_merged_entry)
+
+    return if (sourceNames.isBlank()) {
+        mergedLabel
+    } else {
+        "$mergedLabel ($sourceNames)"
+    }
+    // KMK <--
 }
 // SY <--
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -20,6 +20,10 @@ fun Source.getNameForMangaInfo(
     mergeSources: List<Source>? = null,
     // SY <--
 ): String {
+    // KMK --> Resolve the merged label once at the top level and pass it down
+    // instead of looking it up inside the helper.
+    val mergedLabel = Injekt.get<Application>().stringResource(MR.strings.label_merged_entry)
+    // KMK <--
     val preferences = Injekt.get<SourcePreferences>()
     val enabledLanguages = preferences.enabledLanguages().get()
         .filterNot { it in listOf("all", "other") }
@@ -31,6 +35,7 @@ fun Source.getNameForMangaInfo(
             mergeSources,
             enabledLanguages,
             hasOneActiveLanguages,
+            mergedLabel,
         )
         // SY <--
         // KMK -->
@@ -55,6 +60,7 @@ private fun getMergedSourcesString(
     mergeSources: List<Source>,
     enabledLangs: List<String>,
     onlyName: Boolean,
+    mergedLabel: String,
 ): String {
     // KMK --> Filter out MergedSource itself so it's not displayed in the list
     val realSources = mergeSources.filterNot { it.id == MERGED_SOURCE_ID }
@@ -84,10 +90,6 @@ private fun getMergedSourcesString(
             // KMK <--
         }
     }
-
-    // KMK --> Always show "Merged Entry" prefix for merged entries.
-    // The onlyName parameter only controls whether language flags are shown or not.
-    val mergedLabel = Injekt.get<Application>().stringResource(MR.strings.label_merged_entry)
 
     return if (sourceNames.isBlank()) {
         mergedLabel

--- a/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/SourceExtensions.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.source
 
 import android.app.Application
+import android.content.Context
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.extension.ExtensionManager
 import exh.source.EH_PACKAGE
@@ -20,10 +21,7 @@ fun Source.getNameForMangaInfo(
     mergeSources: List<Source>? = null,
     // SY <--
 ): String {
-    // KMK --> Resolve the merged label once at the top level and pass it down
-    // instead of looking it up inside the helper.
-    val mergedLabel = Injekt.get<Application>().stringResource(MR.strings.label_merged_entry)
-    // KMK <--
+    val application = Injekt.get<Application>()
     val preferences = Injekt.get<SourcePreferences>()
     val enabledLanguages = preferences.enabledLanguages().get()
         .filterNot { it in listOf("all", "other") }
@@ -32,10 +30,10 @@ fun Source.getNameForMangaInfo(
     return when {
         // SY -->
         !mergeSources.isNullOrEmpty() -> getMergedSourcesString(
+            application,
             mergeSources,
             enabledLanguages,
             hasOneActiveLanguages,
-            mergedLabel,
         )
         // SY <--
         // KMK -->
@@ -57,10 +55,10 @@ fun Source.getNameForMangaInfo(
 
 // SY -->
 private fun getMergedSourcesString(
+    context: Context,
     mergeSources: List<Source>,
     enabledLangs: List<String>,
     onlyName: Boolean,
-    mergedLabel: String,
 ): String {
     // KMK --> Filter out MergedSource itself so it's not displayed in the list
     val realSources = mergeSources.filterNot { it.id == MERGED_SOURCE_ID }
@@ -91,10 +89,13 @@ private fun getMergedSourcesString(
         }
     }
 
+    // KMK --> Use the empty-state label when filtering removes every real source,
+    // otherwise use the localized format string so RTL languages can reorder the
+    // label and the sources as needed.
     return if (sourceNames.isBlank()) {
-        mergedLabel
+        context.stringResource(MR.strings.label_merged_entry)
     } else {
-        "$mergedLabel ($sourceNames)"
+        context.stringResource(MR.strings.label_merged_entry_with_sources, sourceNames)
     }
     // KMK <--
 }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -44,6 +44,7 @@
     <string name="label_started">Started</string>
     <string name="label_local">Local</string>
     <string name="label_downloaded">Downloaded</string>
+    <string name="label_merged_entry">Merged Entry</string>
 
     <string name="unlock_app_title">Unlock %s</string>
     <string name="confirm_lock_change">Authenticate to confirm change</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -45,6 +45,7 @@
     <string name="label_local">Local</string>
     <string name="label_downloaded">Downloaded</string>
     <string name="label_merged_entry">Merged Entry</string>
+    <string name="label_merged_entry_with_sources">Merged Entry (%1$s)</string>
 
     <string name="unlock_app_title">Unlock %s</string>
     <string name="confirm_lock_change">Authenticate to confirm change</string>


### PR DESCRIPTION
Improves how merged entries show their sources in the library and manga info screen.

**Before:**  
`SourceA, SourceB, MergedSource`

**After:**  
`Merged Entry (SourceA, SourceB)`

## Before
<img width="1200" height="867" alt="image" src="https://github.com/user-attachments/assets/14e97aae-5ba8-4f5a-8d99-b16bb3604985" />

## After
<img width="1200" height="874" alt="image" src="https://github.com/user-attachments/assets/6a0b8c36-ce97-4bf4-bad0-1f92358b16a8" />

## Notes

- Added new string resource `label_merged_entry`.
- Currently only translated to **English**.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve merged-entry source display by presenting a localized merged-entry label with only its real contributing sources.

New Features:
- Display merged entries with a localized “Merged Entry” label and their contributing source names.

Enhancements:
- Exclude the synthetic merged source from displayed source lists and support an empty-source merged entry label.