### PR TITLE
Fix migration's selected sources order not preserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix pre-1970 upload date display in chapter list ([@MajorTanya](https://github.com/MajorTanya)) ([#2779](https://github.com/mihonapp/mihon/pull/2779))
 - Fix crash when trying to install/update extensions while shizuku is not running ([@NGB-Was-Taken](https://github.com/NGB-Was-Taken)) ([#2837](https://github.com/mihonapp/mihon/pull/2837))
 - Fix Add Repo input not taking up the full dialog width ([@cuong-tran](https://github.com/cuong-tran)) ([#2816](https://github.com/mihonapp/mihon/pull/2816))
+- Fix migration's selected sources order not preserved ([@AntsyLich](https://github.com/AntsyLich)) ([#2773](https://github.com/mihonapp/mihon/pull/2993))
 
 ### Other
 - Enable logcat logging on stable and debug builds without enabling verbose logging ([@NGB-Was-Taken](https://github.com/NGB-Was-Taken)) ([#2836](https://github.com/mihonapp/mihon/pull/2836))

--- a/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreen.kt
+++ b/app/src/main/java/mihon/feature/migration/config/MigrationConfigScreen.kt
@@ -426,7 +426,7 @@ class MigrationConfigScreen(private val mangaIds: Collection<Long>) : Screen() {
             }
         }
 
-        private fun updateSources(save: Boolean = true, action: (List<MigrationSource>) -> List<MigrationSource>) {
+        private fun updateSources(action: (List<MigrationSource>) -> List<MigrationSource>) {
             mutableState.update { state ->
                 val updatedSources = action(state.sources)
                 val includedSources = updatedSources.mapNotNull { if (!it.isSelected) null else it.id }
@@ -435,7 +435,7 @@ class MigrationConfigScreen(private val mangaIds: Collection<Long>) : Screen() {
                 // KMK <--
                 state.copy(sources = updatedSources.sortedWith(sourcesComparator(includedSources)))
             }
-            if (save) saveSources()
+            saveSources()
         }
 
         private fun initSources() {
@@ -451,9 +451,6 @@ class MigrationConfigScreen(private val mangaIds: Collection<Long>) : Screen() {
                 .asSequence()
                 .filterIsInstance<HttpSource>()
                 .filter { it.lang in languages }
-                // KMK -->
-                .sortedWith(compareBy { includedSources[it.id] ?: Int.MAX_VALUE })
-                // KMK <--
                 .map {
                     val source = Source(
                         id = it.id,
@@ -473,7 +470,9 @@ class MigrationConfigScreen(private val mangaIds: Collection<Long>) : Screen() {
                 }
                 .toList()
 
-            updateSources(save = false) { sources }
+            mutableState.update { state ->
+                state.copy(sources = sources.sortedWith(sourcesComparator(includedSources)))
+            }
         }
 
         fun toggleSelection(id: Long) {


### PR DESCRIPTION
## Summary by Sourcery

Preserve the user-defined order of selected migration sources when displaying and updating the migration source list.

Bug Fixes:
- Ensure the migration configuration screen respects the saved ordering of selected sources when listing and sorting migration sources.

Documentation:
- Document the migration selected sources ordering fix in the changelog.