### PR TITLE
Fix migration dialog not showing for consecutive prompts from the same screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Fix crash when trying to install/update extensions while shizuku is not running ([@NGB-Was-Taken](https://github.com/NGB-Was-Taken)) ([#2837](https://github.com/mihonapp/mihon/pull/2837))
 - Fix Add Repo input not taking up the full dialog width ([@cuong-tran](https://github.com/cuong-tran)) ([#2816](https://github.com/mihonapp/mihon/pull/2816))
 - Fix migration's selected sources order not preserved ([@AntsyLich](https://github.com/AntsyLich)) ([#2773](https://github.com/mihonapp/mihon/pull/2993))
+- Fix migration dialog not showing for consecutive prompts from the same screen ([@AntsyLich](https://github.com/AntsyLich)) ([#2773](https://github.com/mihonapp/mihon/pull/2994))
 
 ### Other
 - Enable logcat logging on stable and debug builds without enabling verbose logging ([@NGB-Was-Taken](https://github.com/NGB-Was-Taken)) ([#2836](https://github.com/mihonapp/mihon/pull/2836))

--- a/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
+++ b/app/src/main/java/mihon/feature/migration/dialog/MigrateMangaDialog.kt
@@ -154,12 +154,11 @@ private class MigrateDialogScreenModel(
         }
         val selectedFlags = sourcePreference.migrationFlags().get()
         mutableState.update {
-            it.copy(
+            State(
                 current = current,
                 target = target,
                 applicableFlags = applicableFlags,
                 selectedFlags = selectedFlags,
-                isMigrated = false,
             )
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Reset migration dialog state when initializing a new migration so that the dialog reliably appears for consecutive prompts from the same screen.

Bug Fixes:
- Resolve an issue where the migration dialog would not show again when triggered multiple times from the same screen.

Documentation:
- Document the migration dialog fix in the changelog.