### PR TITLE
Add all pages of adjacent chapters in the UI instead of only the first or last three

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Changed
 - Update tracker icons ([@AntsyLich](https://github.com/AntsyLich)) ([#2773](https://github.com/mihonapp/mihon/pull/2773))
 - Add a small increment to chapter number before comparison to fix progress sync issues for Suwayomi ([@cpiber](https://github.com/cpiber)) ([#2657](https://github.com/mihonapp/mihon/pull/2675))
+- Add all pages of adjacent chapters in the UI instead of only the first or last three ([@AntsyLich](https://github.com/AntsyLich)) ([#2995](https://github.com/mihonapp/mihon/pull/2995))
 
 ### Fixed
 - Fix reader tap zones triggering after scrolling is stopped by tapping ([@NGB-Was-Taken](https://github.com/NGB-Was-Taken)) ([#2680](https://github.com/mihonapp/mihon/pull/2680))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -74,15 +74,8 @@ class PagerViewerAdapter(
         val prevHasMissingChapters = calculateChapterGap(chapters.currChapter, chapters.prevChapter) > 0
         val nextHasMissingChapters = calculateChapterGap(chapters.nextChapter, chapters.currChapter) > 0
 
-        // Add previous chapter pages and transition.
-        if (chapters.prevChapter != null) {
-            // We only need to add the last few pages of the previous chapter, because it'll be
-            // selected as the current chapter when one of those pages is selected.
-            val prevPages = chapters.prevChapter.pages
-            if (prevPages != null) {
-                newItems.addAll(prevPages.takeLast(2))
-            }
-        }
+        // Add previous chapter pages and transition
+        chapters.prevChapter?.pages?.let(newItems::addAll)
 
         // Skip transition page if the chapter is loaded & current page is not a transition page
         if (prevHasMissingChapters || forceTransition || chapters.prevChapter?.state !is ReaderChapter.State.Loaded) {
@@ -124,14 +117,7 @@ class PagerViewerAdapter(
                 }
             }
 
-        if (chapters.nextChapter != null) {
-            // Add at most two pages, because this chapter will be selected before the user can
-            // swap more pages.
-            val nextPages = chapters.nextChapter.pages
-            if (nextPages != null) {
-                newItems.addAll(nextPages.take(2))
-            }
-        }
+        chapters.nextChapter?.pages?.let(newItems::addAll)
 
         // Resets double-page splits, else insert pages get misplaced
         subItems.filterIsInstance<InsertPage>().also { subItems.removeAll(it) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -49,14 +49,7 @@ class WebtoonAdapter(
         val nextHasMissingChapters = calculateChapterGap(chapters.nextChapter, chapters.currChapter) > 0
 
         // Add previous chapter pages and transition.
-        if (chapters.prevChapter != null) {
-            // We only need to add the last few pages of the previous chapter, because it'll be
-            // selected as the current chapter when one of those pages is selected.
-            val prevPages = chapters.prevChapter.pages
-            if (prevPages != null) {
-                newItems.addAll(prevPages.takeLast(2))
-            }
-        }
+        chapters.prevChapter?.pages?.let(newItems::addAll)
 
         // Skip transition page if the chapter is loaded & current page is not a transition page
         if (prevHasMissingChapters || forceTransition || chapters.prevChapter?.state !is ReaderChapter.State.Loaded) {
@@ -76,14 +69,7 @@ class WebtoonAdapter(
             newItems.add(ChapterTransition.Next(chapters.currChapter, chapters.nextChapter))
         }
 
-        if (chapters.nextChapter != null) {
-            // Add at most two pages, because this chapter will be selected before the user can
-            // swap more pages.
-            val nextPages = chapters.nextChapter.pages
-            if (nextPages != null) {
-                newItems.addAll(nextPages.take(2))
-            }
-        }
+        chapters.nextChapter?.pages?.let(newItems::addAll)
 
         updateItems(newItems)
     }


### PR DESCRIPTION
## Summary by Sourcery

Show full page lists for adjacent chapters in the reader instead of limiting to a few pages, for both pager and webtoon viewers, and document the change in the changelog.

New Features:
- Display all pages from previous and next chapters in the reader UI when adjacent chapters are loaded.

Enhancements:
- Unify adjacent chapter page handling in pager and webtoon adapters to always append the full page list instead of partial subsets.

Documentation:
- Document the updated adjacent chapter page behavior in the changelog.