### PR TITLE
Clean up build warnings and enhance migration

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -307,3 +307,5 @@
 -dontwarn org.ietf.jgss.GSSManager
 -dontwarn org.ietf.jgss.GSSName
 -dontwarn org.ietf.jgss.Oid
+-dontwarn com.google.re2j.Matcher
+-dontwarn com.google.re2j.Pattern

--- a/app/src/main/java/eu/kanade/presentation/webview/EhLoginWebViewScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/EhLoginWebViewScreen.kt
@@ -80,7 +80,7 @@ fun EhLoginWebViewScreen(
                     )
                     is LoadingState.Loading -> {
                         val animatedProgress by animateFloatAsState(
-                            (loadingState as? LoadingState.Loading)?.progress ?: 1f,
+                            loadingState.progress,
                             animationSpec = ProgressIndicatorDefaults.ProgressAnimationSpec,
                             label = "webview_loading",
                         )

--- a/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
+++ b/app/src/main/java/mihon/domain/migration/usecases/MigrateMangaUseCase.kt
@@ -99,6 +99,7 @@ class MigrateMangaUseCase(
                                 // SY <--
                                 dateFetch = prevChapter.dateFetch,
                                 bookmark = prevChapter.bookmark,
+                                lastPageRead = prevChapter.lastPageRead,
                             )
                             // SY -->
                             // KMK -->


### PR DESCRIPTION
## Summary by Sourcery

Clean up build warnings and improve manga migration behavior.

Bug Fixes:
- Preserve the last page read when migrating manga chapters to the new source.

Enhancements:
- Simplify WebView loading progress animation state handling.
- Suppress additional ProGuard warnings for RE2J regex classes to reduce build noise.

Build:
- Add ProGuard dontwarn rules for RE2J Matcher and Pattern classes.