### PR TITLE
Implement Data Saver for manga covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Add bookmarked chapters to chapter download options ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#2891](https://github.com/mihonapp/mihon/pull/2891))
 - Add `src:` prefix to search the library by source ID ([@MajorTanya](https://github.com/MajorTanya)) ([#2927](https://github.com/mihonapp/mihon/pull/2927))
   - Add `src:local` as a way to search for Local Source entries ([@MajorTanya](https://github.com/MajorTanya)) ([#2928](https://github.com/mihonapp/mihon/pull/2928))
+- Implement Data Saver for manga covers ([@MuhamadSyabitHidayattulloh](https://github.com/MuhamadSyabitHidayattulloh)) ([#1644](https://github.com/komikku-app/komikku/pull/1644))
 
 ### Improved
 - Minimize memory usage by reducing in-memory cover cache size ([@Lolle2000la](https://github.com/Lolle2000la)) ([#2266](https://github.com/mihonapp/mihon/pull/2266))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Add bookmarked chapters to chapter download options ([@NarwhalHorns](https://github.com/NarwhalHorns)) ([#2891](https://github.com/mihonapp/mihon/pull/2891))
 - Add `src:` prefix to search the library by source ID ([@MajorTanya](https://github.com/MajorTanya)) ([#2927](https://github.com/mihonapp/mihon/pull/2927))
   - Add `src:local` as a way to search for Local Source entries ([@MajorTanya](https://github.com/MajorTanya)) ([#2928](https://github.com/mihonapp/mihon/pull/2928))
-- Implement Data Saver for manga covers ([@MuhamadSyabitHidayattulloh](https://github.com/MuhamadSyabitHidayattulloh)) ([#1644](https://github.com/komikku-app/komikku/pull/1644))
 
 ### Improved
 - Minimize memory usage by reducing in-memory cover cache size ([@Lolle2000la](https://github.com/Lolle2000la)) ([#2266](https://github.com/mihonapp/mihon/pull/2266))

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -126,6 +126,29 @@ class SourcePreferences(
 
     fun dataSaverCovers() = preferenceStore.getBoolean("data_saver_covers", false)
 
+    fun getCoverDataSaverKey(sourceId: Long): String {
+        val dataSaver = dataSaver().get()
+        val dataSaverCovers = dataSaverCovers().get()
+        val excludedSources = dataSaverExcludedSources().get()
+
+        val useDataSaver = dataSaverCovers &&
+            dataSaver != DataSaver.NONE &&
+            sourceId.toString() !in excludedSources
+
+        return if (useDataSaver) {
+            val server = dataSaverServer().get()
+            val quality = dataSaverImageQuality().get()
+            val format = dataSaverImageFormatJpeg().get()
+            val colorBW = dataSaverColorBW().get()
+            val ignoreJpeg = dataSaverIgnoreJpeg().get()
+            val ignoreGif = dataSaverIgnoreGif().get()
+
+            "$dataSaver;$server;$quality;$format;$colorBW;$ignoreJpeg;$ignoreGif"
+        } else {
+            "no-data-saver"
+        }
+    }
+
     enum class DataSaver {
         NONE,
         BANDWIDTH_HERO,

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -126,29 +126,6 @@ class SourcePreferences(
 
     fun dataSaverCovers() = preferenceStore.getBoolean("data_saver_covers", false)
 
-    fun getCoverDataSaverKey(sourceId: Long): String {
-        val dataSaver = dataSaver().get()
-        val dataSaverCovers = dataSaverCovers().get()
-        val excludedSources = dataSaverExcludedSources().get()
-
-        val useDataSaver = dataSaverCovers &&
-            dataSaver != DataSaver.NONE &&
-            sourceId.toString() !in excludedSources
-
-        return if (useDataSaver) {
-            val server = dataSaverServer().get()
-            val quality = dataSaverImageQuality().get()
-            val format = dataSaverImageFormatJpeg().get()
-            val colorBW = dataSaverColorBW().get()
-            val ignoreJpeg = dataSaverIgnoreJpeg().get()
-            val ignoreGif = dataSaverIgnoreGif().get()
-
-            "$dataSaver;$server;$quality;$format;$colorBW;$ignoreJpeg;$ignoreGif"
-        } else {
-            "no-data-saver"
-        }
-    }
-
     enum class DataSaver {
         NONE,
         BANDWIDTH_HERO,

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -124,6 +124,8 @@ class SourcePreferences(
 
     fun dataSaverDownloader() = preferenceStore.getBoolean("data_saver_downloader", true)
 
+    fun dataSaverCovers() = preferenceStore.getBoolean("data_saver_covers", false)
+
     enum class DataSaver {
         NONE,
         BANDWIDTH_HERO,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -713,6 +713,11 @@ object SettingsAdvancedScreen : SearchableSettings {
                     enabled = dataSaver != DataSaver.NONE,
                 ),
                 Preference.PreferenceItem.SwitchPreference(
+                    preference = sourcePreferences.dataSaverCovers(),
+                    title = stringResource(SYMR.strings.data_saver_covers),
+                    enabled = dataSaver != DataSaver.NONE,
+                ),
+                Preference.PreferenceItem.SwitchPreference(
                     preference = sourcePreferences.dataSaverIgnoreJpeg(),
                     title = stringResource(SYMR.strings.data_saver_ignore_jpeg),
                     enabled = dataSaver != DataSaver.NONE,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -227,7 +227,9 @@ class MangaCoverFetcher(
 
     private fun newRequest(): Request {
         val request = Request.Builder().apply {
-            val dataSaver = if (sourcePreferences.dataSaverCovers().get()) {
+            val dataSaver = if (sourcePreferences.dataSaverCovers().get() &&
+                sourcePreferences.dataSaver().get() != SourcePreferences.DataSaver.NONE
+            ) {
                 sourceLazy.value?.let { DataSaver(it, sourcePreferences) } ?: DataSaver.NoOp
             } else {
                 DataSaver.NoOp

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -12,11 +12,13 @@ import coil3.fetch.SourceFetchResult
 import coil3.getOrDefault
 import coil3.request.Options
 import com.hippo.unifile.UniFile
+import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.coil.MangaCoverFetcher.Companion.USE_CUSTOM_COVER_KEY
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.source.online.HttpSource
+import exh.util.DataSaver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -72,6 +74,7 @@ class MangaCoverFetcher(
     // KMK -->
     private val scope by lazy { CoroutineScope(Dispatchers.IO) }
     private val uiPreferences = Injekt.get<UiPreferences>()
+    private val sourcePreferences = Injekt.get<SourcePreferences>()
     private val themeCoverBased = uiPreferences.themeCoverBased().get()
     private val preloadLibraryColor = uiPreferences.preloadLibraryColor().get()
     // KMK <--
@@ -224,7 +227,12 @@ class MangaCoverFetcher(
 
     private fun newRequest(): Request {
         val request = Request.Builder().apply {
-            url(url!!)
+            val dataSaver = if (sourcePreferences.dataSaverCovers().get()) {
+                sourceLazy.value?.let { DataSaver(it, sourcePreferences) } ?: DataSaver.NoOp
+            } else {
+                DataSaver.NoOp
+            }
+            url(dataSaver.compress(url!!))
 
             val sourceHeaders = sourceLazy.value?.headers
             if (sourceHeaders != null) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -227,10 +227,7 @@ class MangaCoverFetcher(
 
     private fun newRequest(): Request {
         val request = Request.Builder().apply {
-            val dataSaver = if (sourcePreferences.dataSaverCovers().get() &&
-                sourcePreferences.dataSaver().get() != SourcePreferences.DataSaver.NONE &&
-                sourceLazy.value?.id?.toString() !in sourcePreferences.dataSaverExcludedSources().get()
-            ) {
+            val dataSaver = if (sourcePreferences.dataSaverCovers().get()) {
                 sourceLazy.value?.let { DataSaver(it, sourcePreferences) } ?: DataSaver.NoOp
             } else {
                 DataSaver.NoOp

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -228,7 +228,8 @@ class MangaCoverFetcher(
     private fun newRequest(): Request {
         val request = Request.Builder().apply {
             val dataSaver = if (sourcePreferences.dataSaverCovers().get() &&
-                sourcePreferences.dataSaver().get() != SourcePreferences.DataSaver.NONE
+                sourcePreferences.dataSaver().get() != SourcePreferences.DataSaver.NONE &&
+                sourceLazy.value?.id?.toString() !in sourcePreferences.dataSaverExcludedSources().get()
             ) {
                 sourceLazy.value?.let { DataSaver(it, sourcePreferences) } ?: DataSaver.NoOp
             } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
@@ -3,30 +3,48 @@ package eu.kanade.tachiyomi.data.coil
 import coil3.key.Keyer
 import coil3.request.Options
 import eu.kanade.domain.manga.model.hasCustomCover
+import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import tachiyomi.domain.manga.model.MangaCover
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import tachiyomi.domain.manga.model.Manga as DomainManga
 
-class MangaKeyer : Keyer<DomainManga> {
+class MangaKeyer(
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
+) : Keyer<DomainManga> {
     override fun key(data: DomainManga, options: Options): String {
+        val useDataSaver = sourcePreferences.dataSaverCovers().get() &&
+            sourcePreferences.dataSaver().get() != SourcePreferences.DataSaver.NONE
+        val dataSaverKey = if (useDataSaver) {
+            "${sourcePreferences.dataSaver().get()};${sourcePreferences.dataSaverImageQuality().get()};${sourcePreferences.dataSaverImageFormatJpeg().get()}"
+        } else {
+            "no-data-saver"
+        }
         return if (data.hasCustomCover()) {
             "${data.id};${data.coverLastModified}"
         } else {
-            "${data.thumbnailUrl};${data.coverLastModified}"
+            "${data.thumbnailUrl};${data.coverLastModified};$dataSaverKey"
         }
     }
 }
 
 class MangaCoverKeyer(
     private val coverCache: CoverCache = Injekt.get(),
+    private val sourcePreferences: SourcePreferences = Injekt.get(),
 ) : Keyer<MangaCover> {
     override fun key(data: MangaCover, options: Options): String {
+        val useDataSaver = sourcePreferences.dataSaverCovers().get() &&
+            sourcePreferences.dataSaver().get() != SourcePreferences.DataSaver.NONE
+        val dataSaverKey = if (useDataSaver) {
+            "${sourcePreferences.dataSaver().get()};${sourcePreferences.dataSaverImageQuality().get()};${sourcePreferences.dataSaverImageFormatJpeg().get()}"
+        } else {
+            "no-data-saver"
+        }
         return if (coverCache.getCustomCoverFile(data.mangaId).exists()) {
             "${data.mangaId};${data.lastModified}"
         } else {
-            "${data.url};${data.lastModified}"
+            "${data.url};${data.lastModified};$dataSaverKey"
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
@@ -14,7 +14,7 @@ class MangaKeyer(
     private val sourcePreferences: SourcePreferences = Injekt.get(),
 ) : Keyer<DomainManga> {
     override fun key(data: DomainManga, options: Options): String {
-        val dataSaverKey = sourcePreferences.getCoverDataSaverKey(data.source)
+        val dataSaverKey = getCoverDataSaverKey(sourcePreferences, data.source)
         return if (data.hasCustomCover()) {
             "${data.id};${data.coverLastModified}"
         } else {
@@ -28,11 +28,34 @@ class MangaCoverKeyer(
     private val sourcePreferences: SourcePreferences = Injekt.get(),
 ) : Keyer<MangaCover> {
     override fun key(data: MangaCover, options: Options): String {
-        val dataSaverKey = sourcePreferences.getCoverDataSaverKey(data.sourceId)
+        val dataSaverKey = getCoverDataSaverKey(sourcePreferences, data.sourceId)
         return if (coverCache.getCustomCoverFile(data.mangaId).exists()) {
             "${data.mangaId};${data.lastModified}"
         } else {
             "${data.url};${data.lastModified};$dataSaverKey"
         }
+    }
+}
+
+private fun getCoverDataSaverKey(sourcePreferences: SourcePreferences, sourceId: Long): String {
+    val dataSaver = sourcePreferences.dataSaver().get()
+    val dataSaverCovers = sourcePreferences.dataSaverCovers().get()
+    val excludedSources = sourcePreferences.dataSaverExcludedSources().get()
+
+    val useDataSaver = dataSaverCovers &&
+        dataSaver != SourcePreferences.DataSaver.NONE &&
+        sourceId.toString() !in excludedSources
+
+    return if (useDataSaver) {
+        val server = sourcePreferences.dataSaverServer().get()
+        val quality = sourcePreferences.dataSaverImageQuality().get()
+        val format = sourcePreferences.dataSaverImageFormatJpeg().get()
+        val colorBW = sourcePreferences.dataSaverColorBW().get()
+        val ignoreJpeg = sourcePreferences.dataSaverIgnoreJpeg().get()
+        val ignoreGif = sourcePreferences.dataSaverIgnoreGif().get()
+
+        "$dataSaver;$server;$quality;$format;$colorBW;$ignoreJpeg;$ignoreGif"
+    } else {
+        "no-data-saver"
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
@@ -14,13 +14,7 @@ class MangaKeyer(
     private val sourcePreferences: SourcePreferences = Injekt.get(),
 ) : Keyer<DomainManga> {
     override fun key(data: DomainManga, options: Options): String {
-        val useDataSaver = sourcePreferences.dataSaverCovers().get() &&
-            sourcePreferences.dataSaver().get() != SourcePreferences.DataSaver.NONE
-        val dataSaverKey = if (useDataSaver) {
-            "${sourcePreferences.dataSaver().get()};${sourcePreferences.dataSaverImageQuality().get()};${sourcePreferences.dataSaverImageFormatJpeg().get()}"
-        } else {
-            "no-data-saver"
-        }
+        val dataSaverKey = sourcePreferences.getCoverDataSaverKey(data.source)
         return if (data.hasCustomCover()) {
             "${data.id};${data.coverLastModified}"
         } else {
@@ -34,17 +28,22 @@ class MangaCoverKeyer(
     private val sourcePreferences: SourcePreferences = Injekt.get(),
 ) : Keyer<MangaCover> {
     override fun key(data: MangaCover, options: Options): String {
-        val useDataSaver = sourcePreferences.dataSaverCovers().get() &&
-            sourcePreferences.dataSaver().get() != SourcePreferences.DataSaver.NONE
-        val dataSaverKey = if (useDataSaver) {
-            "${sourcePreferences.dataSaver().get()};${sourcePreferences.dataSaverImageQuality().get()};${sourcePreferences.dataSaverImageFormatJpeg().get()}"
-        } else {
-            "no-data-saver"
-        }
+        val dataSaverKey = sourcePreferences.getCoverDataSaverKey(data.sourceId)
         return if (coverCache.getCustomCoverFile(data.mangaId).exists()) {
             "${data.mangaId};${data.lastModified}"
         } else {
             "${data.url};${data.lastModified};$dataSaverKey"
         }
+    }
+}
+
+private fun SourcePreferences.getCoverDataSaverKey(sourceId: Long): String {
+    val useDataSaver = dataSaverCovers().get() &&
+        dataSaver().get() != SourcePreferences.DataSaver.NONE &&
+        sourceId.toString() !in dataSaverExcludedSources().get()
+    return if (useDataSaver) {
+        "${dataSaver().get()};${dataSaverServer().get()};${dataSaverImageQuality().get()};${dataSaverImageFormatJpeg().get()};${dataSaverColorBW().get()};${dataSaverIgnoreJpeg().get()};${dataSaverIgnoreGif().get()}"
+    } else {
+        "no-data-saver"
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverKeyer.kt
@@ -36,14 +36,3 @@ class MangaCoverKeyer(
         }
     }
 }
-
-private fun SourcePreferences.getCoverDataSaverKey(sourceId: Long): String {
-    val useDataSaver = dataSaverCovers().get() &&
-        dataSaver().get() != SourcePreferences.DataSaver.NONE &&
-        sourceId.toString() !in dataSaverExcludedSources().get()
-    return if (useDataSaver) {
-        "${dataSaver().get()};${dataSaverServer().get()};${dataSaverImageQuality().get()};${dataSaverImageFormatJpeg().get()};${dataSaverColorBW().get()};${dataSaverIgnoreJpeg().get()};${dataSaverIgnoreGif().get()}"
-    } else {
-        "no-data-saver"
-    }
-}

--- a/i18n-sy/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/base/strings.xml
@@ -140,6 +140,7 @@
     <string name="data_saver">Data Saver</string>
     <string name="data_saver_summary">Compress images before downloading or loading in reader</string>
     <string name="data_saver_downloader">Use data saver in the downloader</string>
+    <string name="data_saver_covers">Use data saver for manga covers</string>
     <string name="data_saver_ignore_jpeg">Ignore Jpeg Images</string>
     <string name="data_saver_ignore_gif">Ignore Gif Animations</string>
     <string name="data_saver_image_quality">Image Quality</string>

--- a/i18n-sy/src/commonMain/moko-resources/in/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/in/strings.xml
@@ -125,6 +125,7 @@
     <string name="data_saver">Penghemat Data</string>
     <string name="data_saver_summary">Kompres gambar sebelum mengunduh atau memuat di pembaca, membutuhkan server Bandwidth Hero Proxy</string>
     <string name="data_saver_downloader">Gunakan penghemat data saat mengunduh</string>
+    <string name="data_saver_covers">Gunakan penghemat data untuk sampul manga</string>
     <string name="data_saver_ignore_jpeg">Abaikan Gambar Jpeg</string>
     <string name="data_saver_ignore_gif">Abaikan Animasi Gif</string>
     <string name="data_saver_image_quality">Kualitas Gambar</string>


### PR DESCRIPTION
- Added `dataSaverCovers` preference to `SourcePreferences`.
- Added string resources for the new preference in base and Indonesian translations.
- Updated `SettingsAdvancedScreen` to include the Data Saver covers toggle.
- Modified `MangaCoverFetcher` to apply image compression to cover URLs if enabled.
- Updated `MangaKeyer` and `MangaCoverKeyer` to include Data Saver settings in cache keys to ensure proper cache invalidation.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add an optional data saver mode for manga cover images and ensure cover caching respects data saver configuration.

New Features:
- Introduce a Data Saver covers preference to control whether cover images are compressed.
- Apply data saver compression to manga cover requests when the feature is enabled.

Enhancements:
- Include data saver configuration in manga cover cache keys to properly invalidate and separate cached covers based on compression settings.
- Expose the Data Saver covers toggle in the advanced settings UI.
- Extend localized strings to describe the new Data Saver covers option in supported languages.