### PR TITLE
Display category name instead of text In library

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -658,6 +658,7 @@ private fun MangaScreenSmallImpl(
                             // KMK -->
                             status = state.manga.status,
                             interval = state.manga.fetchInterval,
+                            categories = state.categories,
                             // KMK <--
                         )
                     }
@@ -1108,6 +1109,7 @@ private fun MangaScreenLargeImpl(
                             // KMK -->
                             status = state.manga.status,
                             interval = state.manga.fetchInterval,
+                            categories = state.categories,
                             // KMK <--
                         )
                         // SY -->

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -1048,6 +1048,8 @@ private fun RowScope.MangaActionButton(
                 color = color,
                 fontSize = 12.sp,
                 textAlign = TextAlign.Center,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 2,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -279,22 +279,8 @@ fun MangaActionRow(
     }
 
     Row(modifier = modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp)) {
-        val favoriteTitle = if (favorite) {
-            if (categories.isNotEmpty()) {
-                val categoryNames = categories.take(3).joinToString { it.name }
-                if (categories.size > 3) {
-                    "$categoryNames (+${categories.size - 3})"
-                } else {
-                    categoryNames
-                }
-            } else {
-                stringResource(MR.strings.in_library)
-            }
-        } else {
-            stringResource(MR.strings.add_to_library)
-        }
         MangaActionButton(
-            title = favoriteTitle,
+            title = getFavoriteTitle(favorite, categories),
             icon = if (favorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
             color = if (favorite) MaterialTheme.colorScheme.primary else defaultActionButtonColor,
             onClick = onAddToLibraryClicked,
@@ -1021,6 +1007,24 @@ private fun MangaSummary(
 }
 
 private val DefaultTagChipModifier = Modifier.padding(vertical = 4.dp)
+
+@Composable
+private fun getFavoriteTitle(favorite: Boolean, categories: List<Category>): String {
+    return if (favorite) {
+        if (categories.isNotEmpty()) {
+            val categoryNames = categories.take(3).joinToString { it.name }
+            if (categories.size > 3) {
+                "$categoryNames (+${categories.size - 3})"
+            } else {
+                categoryNames
+            }
+        } else {
+            stringResource(MR.strings.in_library)
+        }
+    } else {
+        stringResource(MR.strings.add_to_library)
+    }
+}
 
 @Composable
 private fun RowScope.MangaActionButton(

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -97,6 +97,7 @@ import eu.kanade.tachiyomi.util.system.copyToClipboard
 import org.intellij.markdown.MarkdownElementTypes
 import org.intellij.markdown.MarkdownTokenTypes
 import org.intellij.markdown.ast.findChildOfType
+import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_NON_COMPLETED
 import tachiyomi.domain.manga.interactor.FetchInterval
@@ -247,6 +248,7 @@ fun MangaActionRow(
     // KMK -->
     status: Long,
     interval: Int,
+    categories: List<Category>,
     // KMK <--
     modifier: Modifier = Modifier,
 ) {
@@ -277,12 +279,22 @@ fun MangaActionRow(
     }
 
     Row(modifier = modifier.padding(start = 16.dp, top = 8.dp, end = 16.dp)) {
-        MangaActionButton(
-            title = if (favorite) {
-                stringResource(MR.strings.in_library)
+        val favoriteTitle = if (favorite) {
+            if (categories.isNotEmpty()) {
+                val categoryNames = categories.take(3).joinToString { it.name }
+                if (categories.size > 3) {
+                    "$categoryNames (+${categories.size - 3})"
+                } else {
+                    categoryNames
+                }
             } else {
-                stringResource(MR.strings.add_to_library)
-            },
+                stringResource(MR.strings.in_library)
+            }
+        } else {
+            stringResource(MR.strings.add_to_library)
+        }
+        MangaActionButton(
+            title = favoriteTitle,
             icon = if (favorite) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
             color = if (favorite) MaterialTheme.colorScheme.primary else defaultActionButtonColor,
             onClick = onAddToLibraryClicked,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -87,11 +87,13 @@ import exh.util.nullIfEmpty
 import exh.util.trimOrNull
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -99,10 +101,12 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -239,6 +243,10 @@ class MangaScreenModel(
 
     private val successState: State.Success?
         get() = state.value as? State.Success
+
+    private val mangaCategoriesFlow = getCategories.subscribe(mangaId)
+        .distinctUntilChanged()
+        .shareIn(screenModelScope, SharingStarted.Lazily, 1)
 
     // KMK -->
     val useNewSourceNavigation by uiPreferences.useNewSourceNavigation().asState(screenModelScope)
@@ -431,9 +439,8 @@ class MangaScreenModel(
         }
 
         screenModelScope.launchIO {
-            getCategories.subscribe(mangaId)
+            mangaCategoriesFlow
                 .flowWithLifecycle(lifecycle)
-                .distinctUntilChanged()
                 .collectLatest { categories ->
                     updateSuccessState {
                         it.copy(categories = categories.toImmutableList())
@@ -489,7 +496,7 @@ class MangaScreenModel(
                     }.toImmutableSet(),
                     // SY <--
                     excludedScanlators = getExcludedScanlators.await(mangaId).toImmutableSet(),
-                    categories = getCategories.await(mangaId).toImmutableList(),
+                    categories = mangaCategoriesFlow.first().toImmutableList(),
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
                     dialog = null,
                     hideMissingChapters = libraryPreferences.hideMissingChapters().get(),
@@ -978,7 +985,7 @@ class MangaScreenModel(
      * @return Array of category ids the manga is in, if none returns default id
      */
     private suspend fun getMangaCategoryIds(manga: Manga): List<Long> {
-        return getCategories.await(manga.id)
+        return mangaCategoriesFlow.first()
             .map { it.id }
     }
 
@@ -2025,7 +2032,7 @@ class MangaScreenModel(
             val chapters: List<ChapterList.Item>,
             val availableScanlators: ImmutableSet<String>,
             val excludedScanlators: ImmutableSet<String>,
-            val categories: ImmutableList<Category> = emptyList<Category>().toImmutableList(),
+            val categories: ImmutableList<Category> = persistentListOf(),
             val trackingCount: Int = 0,
             val hasLoggedInTrackers: Boolean = false,
             val isRefreshingData: Boolean = false,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -430,6 +430,17 @@ class MangaScreenModel(
                 }
         }
 
+        screenModelScope.launchIO {
+            getCategories.subscribe(mangaId)
+                .flowWithLifecycle(lifecycle)
+                .distinctUntilChanged()
+                .collectLatest { categories ->
+                    updateSuccessState {
+                        it.copy(categories = categories.toImmutableList())
+                    }
+                }
+        }
+
         observeDownloads()
 
         screenModelScope.launchIO {
@@ -478,6 +489,7 @@ class MangaScreenModel(
                     }.toImmutableSet(),
                     // SY <--
                     excludedScanlators = getExcludedScanlators.await(mangaId).toImmutableSet(),
+                    categories = getCategories.await(mangaId).toImmutableList(),
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
                     dialog = null,
                     hideMissingChapters = libraryPreferences.hideMissingChapters().get(),
@@ -2013,6 +2025,7 @@ class MangaScreenModel(
             val chapters: List<ChapterList.Item>,
             val availableScanlators: ImmutableSet<String>,
             val excludedScanlators: ImmutableSet<String>,
+            val categories: ImmutableList<Category> = emptyList<Category>().toImmutableList(),
             val trackingCount: Int = 0,
             val hasLoggedInTrackers: Boolean = false,
             val isRefreshingData: Boolean = false,


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Display manga library categories on the manga info action row when the title is in the user’s library.

New Features:
- Show the manga’s library category names on the library action button when the manga is marked as a favorite.

Enhancements:
- Load and store manga categories in the manga screen state for use by the UI.
- Truncate long library button titles across up to two lines with ellipsis to keep the action row layout stable.