### PR TITLE
Ensure extension installer's download IDs are non-negative

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/installer/PackageInstallerInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/installer/PackageInstallerInstaller.kt
@@ -106,8 +106,13 @@ class PackageInstallerInstaller(private val service: Service) : Installer(servic
     override fun cancelEntry(entry: Entry): Boolean {
         activeSession?.let { (activeEntry, sessionId) ->
             if (activeEntry == entry) {
-                packageInstaller.abandonSession(sessionId)
-                return false
+                return try {
+                    packageInstaller.abandonSession(sessionId)
+                    false
+                } catch (_: SecurityException) {
+                    // Highly likely the session has succeeded
+                    true
+                }
             }
         }
         return true

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionInstaller.kt
@@ -58,8 +58,8 @@ internal class ExtensionInstaller(
         val pkgName = extension.pkgName +
             // KMK -->
             "_${extension.signatureHash}"
+        val downloadId = pkgName.toDownloadId()
         // KMK <--
-        val downloadId = pkgName.hashCode().toLong()
         cancelInstall(pkgName)
 
         val step = MutableStateFlow(InstallStep.Pending)
@@ -158,7 +158,7 @@ internal class ExtensionInstaller(
      */
     fun cancelInstall(pkgName: String) {
         activeJobs.remove(pkgName)?.cancel()
-        Installer.cancelInstallQueue(context, pkgName.hashCode().toLong())
+        Installer.cancelInstallQueue(context, /* KMK --> */ pkgName.toDownloadId() /* KMK <-- */)
     }
 
     /**
@@ -191,5 +191,10 @@ internal class ExtensionInstaller(
     companion object {
         const val APK_MIME = "application/vnd.android.package-archive"
         const val EXTRA_DOWNLOAD_ID = "ExtensionInstaller.extra.DOWNLOAD_ID"
+
+        // KMK -->
+        /** Convert packageName to download ID avoiding negative number */
+        private fun String.toDownloadId(): Long = hashCode().toLong() and 0xFFFFFFFFL
+        // KMK <--
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/ExtensionsScreenModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import tachiyomi.core.common.util.lang.launchIO
@@ -228,6 +229,7 @@ class ExtensionsScreenModel(
     private suspend fun Flow<InstallStep>.collectToInstallUpdate(extension: Extension) =
         this
             .onEach { installStep -> addDownloadState(extension, installStep) }
+            .takeWhile { installStep -> installStep != InstallStep.Installed }
             .onCompletion { removeDownloadState(extension) }
             .collect()
 


### PR DESCRIPTION
## Summary by Sourcery

Ensure extension installation download identifiers and lifecycle handling are more robust and consistent.

Bug Fixes:
- Prevent negative download IDs for extension installs by deriving a non-negative identifier from the package name.
- Align install cancellation to use the same stable, non-negative download ID as install scheduling.
- Avoid crashing when abandoning an install session that has already completed by handling SecurityException in the installer.
- Stop tracking extension install progress once the install is marked as completed to ensure proper cleanup of UI state.