### PR TITLE
Fix hide missing chapter indicator feature

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -777,7 +777,7 @@ private fun MangaScreenSmallImpl(
                         contentType = MangaScreenItem.CHAPTER_HEADER,
                     ) {
                         // KMK -->
-                        val missingChapterCount = remember(chapters, state.hideMissingChapters) {
+                        val missingChapterCount = remember(chapters) {
                             if (state.hideMissingChapters) {
                                 0
                             } else {
@@ -1222,7 +1222,7 @@ private fun MangaScreenLargeImpl(
                                 contentType = MangaScreenItem.CHAPTER_HEADER,
                             ) {
                                 // KMK -->
-                                val missingChapterCount = remember(chapters, state.hideMissingChapters) {
+                                val missingChapterCount = remember(chapters) {
                                     if (state.hideMissingChapters) {
                                         0
                                     } else {

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -776,9 +776,15 @@ private fun MangaScreenSmallImpl(
                         key = MangaScreenItem.CHAPTER_HEADER,
                         contentType = MangaScreenItem.CHAPTER_HEADER,
                     ) {
-                        val missingChapterCount = remember(chapters) {
-                            chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+                        // KMK -->
+                        val missingChapterCount = remember(chapters, state.hideMissingChapters) {
+                            if (state.hideMissingChapters) {
+                                0
+                            } else {
+                                chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+                            }
                         }
+                        // KMK <--
                         ChapterHeader(
                             enabled = !isAnySelected,
                             chapterCount = chapters.size,
@@ -1215,9 +1221,15 @@ private fun MangaScreenLargeImpl(
                                 key = MangaScreenItem.CHAPTER_HEADER,
                                 contentType = MangaScreenItem.CHAPTER_HEADER,
                             ) {
-                                val missingChapterCount = remember(chapters) {
-                                    chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+                                // KMK -->
+                                val missingChapterCount = remember(chapters, state.hideMissingChapters) {
+                                    if (state.hideMissingChapters) {
+                                        0
+                                    } else {
+                                        chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+                                    }
                                 }
+                                // KMK <--
                                 ChapterHeader(
                                     enabled = !isAnySelected,
                                     chapterCount = chapters.size,

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -781,7 +781,7 @@ private fun MangaScreenSmallImpl(
                             if (state.hideMissingChapters) {
                                 0
                             } else {
-                                chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+                                chapters.fastMap { it.chapter.chapterNumber }.missingChaptersCount()
                             }
                         }
                         // KMK <--
@@ -1226,7 +1226,7 @@ private fun MangaScreenLargeImpl(
                                     if (state.hideMissingChapters) {
                                         0
                                     } else {
-                                        chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+                                        chapters.fastMap { it.chapter.chapterNumber }.missingChaptersCount()
                                     }
                                 }
                                 // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -394,6 +394,19 @@ class MangaScreenModel(
                 }
         }
 
+        // KMK -->
+        screenModelScope.launchIO {
+            libraryPreferences.hideMissingChapters().changes()
+                .flowWithLifecycle(lifecycle)
+                .distinctUntilChanged()
+                .collectLatest { hideMissingChapters ->
+                    updateSuccessState {
+                        it.copy(hideMissingChapters = hideMissingChapters)
+                    }
+                }
+        }
+        // KMK <--
+
         screenModelScope.launchIO {
             getExcludedScanlators.subscribe(mangaId)
                 .flowWithLifecycle(lifecycle)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -394,19 +394,6 @@ class MangaScreenModel(
                 }
         }
 
-        // KMK -->
-        screenModelScope.launchIO {
-            libraryPreferences.hideMissingChapters().changes()
-                .flowWithLifecycle(lifecycle)
-                .distinctUntilChanged()
-                .collectLatest { hideMissingChapters ->
-                    updateSuccessState {
-                        it.copy(hideMissingChapters = hideMissingChapters)
-                    }
-                }
-        }
-        // KMK <--
-
         screenModelScope.launchIO {
             getExcludedScanlators.subscribe(mangaId)
                 .flowWithLifecycle(lifecycle)


### PR DESCRIPTION
- Added observer for `hideMissingChapters` preference in `MangaScreenModel` to ensure reactive UI updates.
- Updated `MangaScreen` to hide the missing chapter count in the header when `hideMissingChapters` is enabled.
- Wrapped custom changes with KMK comment tags for consistency.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Ensure the manga screen reacts to the `hideMissingChapters` preference and hides the missing chapter indicator when enabled.

Bug Fixes:
- Hide the missing chapter count in manga chapter headers when the `hideMissingChapters` preference is enabled.

Enhancements:
- Make the manga screen state observe `hideMissingChapters` preference changes so the UI updates reactively without reloads.