### PR TITLE
Fix ANR during extension installation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -241,7 +241,7 @@
         <service
             android:name=".extension.util.ExtensionInstallService"
             android:exported="false"
-            android:foregroundServiceType="shortService" />
+            android:foregroundServiceType="dataSync" />
 
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionInstallService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionInstallService.kt
@@ -3,8 +3,10 @@ package eu.kanade.tachiyomi.extension.util
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.os.Build
 import android.os.IBinder
 import androidx.core.content.ContextCompat
 import eu.kanade.domain.base.BasePreferences
@@ -21,6 +23,11 @@ import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
 
+/**
+ * Foreground service that stages and installs extension APKs via [PackageInstallerInstaller] or
+ * [ShizukuInstaller]. Uses [ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC] because installs can
+ * wait on multiple system confirmation dialogs; `shortService` times out after ~3 minutes.
+ */
 class ExtensionInstallService : Service() {
 
     private var installer: Installer? = null
@@ -36,7 +43,17 @@ class ExtensionInstallService : Service() {
             setContentTitle(stringResource(MR.strings.ext_install_service_notif))
             setProgress(100, 100, true)
         }.build()
-        startForeground(Notifications.ID_EXTENSION_INSTALLER, notification)
+        // KMK -->
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                Notifications.ID_EXTENSION_INSTALLER,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            // KMK <--
+            startForeground(Notifications.ID_EXTENSION_INSTALLER, notification)
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {


### PR DESCRIPTION
Address an ANR issue that occurred while installing extensions by updating the foreground service type for the ExtensionInstallService to dataSync. This change ensures that the service can handle multiple system confirmation dialogs without timing out.

## Summary by Sourcery

Update extension installation foreground service configuration to prevent ANR during long-running installs that require user confirmations.

Bug Fixes:
- Prevent ANR when installing extensions by running the install service as a data sync foreground service on supported Android versions.

Enhancements:
- Document the behavior and purpose of the ExtensionInstallService, including its use of a data sync foreground service type for long-running installs.