### PR TITLE
feat(smart-update): Allow manually set periodic smart update period

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaDialogs.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import dev.icerock.moko.resources.StringResource
-import eu.kanade.tachiyomi.util.system.isReleaseBuildType
 import kotlinx.collections.immutable.toImmutableList
 import tachiyomi.core.common.preference.CheckboxState
 import tachiyomi.domain.manga.interactor.FetchInterval
@@ -170,7 +169,7 @@ fun SetIntervalDialog(
                 }
                 Spacer(Modifier.height(MaterialTheme.padding.small))
 
-                if (onValueChanged != null && (!isReleaseBuildType)) {
+                if (onValueChanged != null) {
                     Text(stringResource(MR.strings.manga_interval_custom_amount))
 
                     BoxWithConstraints(


### PR DESCRIPTION
## Summary by Sourcery

Allow configuring a custom manga update interval in the SetIntervalDialog for all build types.

New Features:
- Enable manual configuration of a custom periodic update interval when a value change handler is provided.

Enhancements:
- Remove build-type restriction so the custom interval input is available outside non-release builds.