### PR TITLE
Fix horizontal ChapterNavigator overlapping system nav buttons in landscape

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/appbars/ReaderAppBars.kt
@@ -15,9 +15,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
@@ -248,6 +250,11 @@ fun ReaderAppBars(
                         isVerticalSlider = false,
                         currentPageText = currentPageText,
                         // SY <--
+                        // KMK -->
+                        modifier = Modifier.windowInsetsPadding(
+                            WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal),
+                        ),
+                        // KMK <--
                     )
                 }
                 ReaderBottomBar(

--- a/app/src/main/java/eu/kanade/presentation/reader/components/ChapterNavigator.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/components/ChapterNavigator.kt
@@ -63,6 +63,9 @@ fun ChapterNavigator(
     // SY <--
     totalPages: Int,
     onPageIndexChange: (Int) -> Unit,
+    // KMK -->
+    modifier: Modifier = Modifier,
+    // KMK <--
 ) {
     // SY -->
     if (isVerticalSlider) {
@@ -75,6 +78,9 @@ fun ChapterNavigator(
             currentPageText = currentPageText,
             totalPages = totalPages,
             onPageIndexChange = onPageIndexChange,
+            // KMK -->
+            modifier = modifier,
+            // KMK <--
         )
         return
     }
@@ -100,7 +106,7 @@ fun ChapterNavigator(
     // We explicitly handle direction based on the reader viewer rather than the system direction
     CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
         Row(
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxWidth()
                 .padding(horizontal = horizontalPadding),
             verticalAlignment = Alignment.CenterVertically,
@@ -201,6 +207,9 @@ fun ChapterNavigatorVert(
     // SY <--
     totalPages: Int,
     onPageIndexChange: (Int) -> Unit,
+    // KMK -->
+    modifier: Modifier = Modifier,
+    // KMK <--
 ) {
     val isTabletUi = isTabletUi()
     val verticalPadding = if (isTabletUi) 24.dp else 8.dp
@@ -208,7 +217,7 @@ fun ChapterNavigatorVert(
     val haptic = LocalHapticFeedback.current
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxHeight()
             .padding(vertical = verticalPadding, horizontal = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
In landscape mode with floating system navigation buttons, the horizontal `ChapterNavigator` (`NavBarType.Bottom`) spans the full screen width without accounting for system navigation bar insets, causing it to overlap with the floating nav buttons.

### Changes
- Add `modifier` parameter to `ChapterNavigator` and `ChapterNavigatorVert` (standard Compose convention, defaults to `Modifier`)
- In `ReaderAppBars`, pass `WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)` to the horizontal `ChapterNavigator` so it respects system navigation bar padding on the left/right edges
- The `ReaderBottomBar` already handles its own `windowInsetsPadding(WindowInsets.navigationBars)` independently

### Files changed
- `ChapterNavigator.kt` — added `modifier` parameter to both `ChapterNavigator` and `ChapterNavigatorVert`, applied to root layout elements
- `ReaderAppBars.kt` — added `WindowInsetsSides`/`only` imports, passed horizontal navigation bar insets modifier to the bottom `ChapterNavigator`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd094ac8-5162-4566-93bd-e6cefbf853da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd094ac8-5162-4566-93bd-e6cefbf853da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Ensure the reader chapter navigator respects system navigation insets in landscape mode to avoid overlapping system navigation buttons.

New Features:
- Allow ChapterNavigator and ChapterNavigatorVert composables to accept an optional Modifier parameter for external layout and insets control.

Bug Fixes:
- Apply horizontal navigation bar window insets to the bottom ChapterNavigator in ReaderAppBars to prevent overlap with floating system navigation buttons in landscape.