### PR TITLE
feat(mangadex): auto-renew authentication without browser re-login

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALOAuth.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALOAuth.kt
@@ -14,6 +14,13 @@ data class MALOAuth(
     val accessToken: String,
     @SerialName("expires_in")
     val expiresIn: Long,
+    // KMK -->
+    // Lifetime (in seconds) of the refresh token, when known. A value of 0 means
+    // "unknown / never" (e.g. offline tokens) and is treated as not expiring.
+    @SerialName("refresh_expires_in")
+    @EncodeDefault
+    val refreshExpiresIn: Long = 0,
+    // KMK <--
     @SerialName("created_at")
     @EncodeDefault
     val createdAt: Long = System.currentTimeMillis() / 1000,
@@ -22,4 +29,15 @@ data class MALOAuth(
     private val adjustedExpiresIn: Long = (expiresIn - 60)
 
     fun isExpired() = createdAt + adjustedExpiresIn < System.currentTimeMillis() / 1000
+
+    // KMK -->
+    /**
+     * Whether the refresh token itself is known to be expired. Returns false when
+     * [refreshExpiresIn] is 0 (unknown or offline token that does not expire by idle).
+     */
+    fun isRefreshTokenExpired(): Boolean {
+        if (refreshExpiresIn <= 0) return false
+        return createdAt + refreshExpiresIn < System.currentTimeMillis() / 1000
+    }
+    // KMK <--
 }

--- a/app/src/main/java/exh/md/network/MangaDexAuthInterceptor.kt
+++ b/app/src/main/java/exh/md/network/MangaDexAuthInterceptor.kt
@@ -29,14 +29,29 @@ class MangaDexAuthInterceptor(
         if (oauth == null) {
             oauth = MdUtil.loadOAuth(trackPreferences, mdList)
         }
-        // Refresh access token if expired
-        if (oauth != null && oauth!!.isExpired()) {
-            setAuth(refreshToken(chain))
-        }
 
         if (oauth == null) {
             throw IOException("No authentication token")
         }
+
+        // KMK -->
+        // Refresh access token if expired. Only clear the stored credentials when the
+        // refresh token is genuinely rejected by the server; transient failures (no
+        // network, server errors, ...) must keep the credentials so the app can keep
+        // renewing on its own instead of forcing a browser re-login.
+        if (oauth!!.isExpired()) {
+            when (val result = refreshToken(chain)) {
+                is RefreshResult.Success -> setAuth(result.oauth)
+                is RefreshResult.InvalidGrant -> {
+                    setAuth(null)
+                    throw IOException("MangaDex session expired, please log in again")
+                }
+                is RefreshResult.TransientError -> {
+                    throw IOException("Could not refresh MangaDex token", result.cause)
+                }
+            }
+        }
+        // KMK <--
 
         // Add the authorization header to the original request
         val authRequest = originalRequest.newBuilder()
@@ -50,10 +65,18 @@ class MangaDexAuthInterceptor(
         // Retry the request once with a new token in case it was not already refreshed
         // by the is expired check before.
         if (response.code == 401 && tokenIsExpired) {
-            val newToken = refreshToken(chain)
-            setAuth(newToken)
+            // KMK -->
+            val newToken = when (val result = refreshToken(chain)) {
+                is RefreshResult.Success -> result.oauth.also { setAuth(it) }
+                is RefreshResult.InvalidGrant -> {
+                    setAuth(null)
+                    return response
+                }
+                // Keep credentials on transient errors and return the original response.
+                is RefreshResult.TransientError -> return response
+            }
+            // KMK <--
 
-            newToken ?: return response
             response.close()
 
             val newRequest = originalRequest.newBuilder()
@@ -76,20 +99,51 @@ class MangaDexAuthInterceptor(
         MdUtil.saveOAuth(trackPreferences, mdList, oauth)
     }
 
-    private fun refreshToken(chain: Interceptor.Chain): MALOAuth? {
-        val newOauth = runCatching {
-            val oauthResponse = chain.proceed(MdUtil.refreshTokenRequest(oauth!!))
+    // KMK -->
+    /**
+     * Attempts to refresh the access token using the stored refresh token.
+     *
+     * Distinguishes a definitive rejection of the refresh token ([RefreshResult.InvalidGrant]),
+     * which requires the user to log in again, from transient failures
+     * ([RefreshResult.TransientError]) that must not clear the stored credentials.
+     */
+    private fun refreshToken(chain: Interceptor.Chain): RefreshResult {
+        val currentOauth = oauth ?: return RefreshResult.InvalidGrant
 
-            if (oauthResponse.isSuccessful) {
-                with(MdUtil.jsonParser) { oauthResponse.parseAs<MALOAuth>() }
-            } else {
-                oauthResponse.close()
-                null
-            }
+        // If the refresh token is known to be expired there is no point in trying.
+        if (currentOauth.isRefreshTokenExpired()) {
+            return RefreshResult.InvalidGrant
         }
 
-        logcat(throwable = newOauth.exceptionOrNull()) { "Fetched new mangadex oauth" }
-
-        return newOauth.getOrNull()
+        return runCatching {
+            chain.proceed(MdUtil.refreshTokenRequest(currentOauth)).use { oauthResponse ->
+                when {
+                    oauthResponse.isSuccessful -> {
+                        val newOauth = with(MdUtil.jsonParser) { oauthResponse.parseAs<MALOAuth>() }
+                        RefreshResult.Success(newOauth)
+                    }
+                    // 400/401 with an invalid_grant error means the refresh token is dead.
+                    oauthResponse.code in 400..401 &&
+                        oauthResponse.peekBody(Long.MAX_VALUE).string().contains("invalid_grant") -> {
+                        RefreshResult.InvalidGrant
+                    }
+                    else -> RefreshResult.TransientError(
+                        IOException("Unexpected refresh response: HTTP ${oauthResponse.code}"),
+                    )
+                }
+            }
+        }.getOrElse { e ->
+            logcat(throwable = e) { "Failed to refresh mangadex oauth" }
+            RefreshResult.TransientError(e)
+        }
     }
+
+    private sealed interface RefreshResult {
+        data class Success(val oauth: MALOAuth) : RefreshResult
+
+        data object InvalidGrant : RefreshResult
+
+        data class TransientError(val cause: Throwable) : RefreshResult
+    }
+    // KMK <--
 }

--- a/app/src/main/java/exh/md/network/MangaDexLoginHelper.kt
+++ b/app/src/main/java/exh/md/network/MangaDexLoginHelper.kt
@@ -32,6 +32,11 @@ class MangaDexLoginHelper(
             .add("code", authorizationCode)
             .add("code_verifier", MdUtil.getPkceChallengeCode())
             .add("redirect_uri", MdConstants.Login.redirectUri)
+            // KMK -->
+            // Match the scope requested in the authorization URL so the exchanged token
+            // pair includes an offline refresh token.
+            .add("scope", MdConstants.Login.scope)
+            // KMK <--
             .build()
 
         val error = kotlin.runCatching {

--- a/app/src/main/java/exh/md/utils/MdConstants.kt
+++ b/app/src/main/java/exh/md/utils/MdConstants.kt
@@ -28,6 +28,12 @@ object MdConstants {
         const val authorizationCode = "authorization_code"
         const val refreshToken = "refresh_token"
 
+        // KMK -->
+        // Request an offline refresh token so the app can keep renewing the session on its
+        // own (offline tokens survive the browser SSO session) without forcing a re-login.
+        const val scope = "openid offline_access"
+        // KMK <--
+
         fun authUrl(codeVerifier: String): String {
             val bytes = codeVerifier.toByteArray()
             val messageDigest = MessageDigest.getInstance("SHA-256")
@@ -42,6 +48,9 @@ object MdConstants {
                 .appendQueryParameter("redirect_uri", redirectUri)
                 .appendQueryParameter("code_challenge", codeChallenge)
                 .appendQueryParameter("code_challenge_method", "S256")
+                // KMK -->
+                .appendQueryParameter("scope", scope)
+                // KMK <--
                 .build().toString()
         }
     }

--- a/app/src/main/java/exh/md/utils/MdUtil.kt
+++ b/app/src/main/java/exh/md/utils/MdUtil.kt
@@ -177,6 +177,11 @@ class MdUtil {
                 .add("refresh_token", oauth.refreshToken)
                 .add("code_verifier", getPkceChallengeCode())
                 .add("redirect_uri", MdConstants.Login.redirectUri)
+                // KMK -->
+                // Keep refreshing as an offline token so renewal does not depend on the
+                // browser SSO session lifetime.
+                .add("scope", MdConstants.Login.scope)
+                // KMK <--
                 .build()
 
             // Add the Authorization header manually as this particular

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALOAuthTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/myanimelist/dto/MALOAuthTest.kt
@@ -1,0 +1,49 @@
+package eu.kanade.tachiyomi.data.track.myanimelist.dto
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MALOAuthTest {
+
+    private val now get() = System.currentTimeMillis() / 1000
+
+    private fun oauth(
+        expiresIn: Long = 3600,
+        refreshExpiresIn: Long = 0,
+        createdAt: Long = now,
+    ) = MALOAuth(
+        tokenType = "Bearer",
+        refreshToken = "refresh",
+        accessToken = "access",
+        expiresIn = expiresIn,
+        refreshExpiresIn = refreshExpiresIn,
+        createdAt = createdAt,
+    )
+
+    @Test
+    fun `access token freshly issued is not expired`() {
+        assertFalse(oauth(expiresIn = 3600).isExpired())
+    }
+
+    @Test
+    fun `access token issued long ago is expired`() {
+        assertTrue(oauth(expiresIn = 3600, createdAt = now - 7200).isExpired())
+    }
+
+    @Test
+    fun `refresh token with unknown lifetime never expires`() {
+        // refreshExpiresIn == 0 represents an offline token / unknown lifetime.
+        assertFalse(oauth(refreshExpiresIn = 0, createdAt = now - 1_000_000).isRefreshTokenExpired())
+    }
+
+    @Test
+    fun `refresh token within its lifetime is not expired`() {
+        assertFalse(oauth(refreshExpiresIn = 86_400, createdAt = now).isRefreshTokenExpired())
+    }
+
+    @Test
+    fun `refresh token past its lifetime is expired`() {
+        assertTrue(oauth(refreshExpiresIn = 3600, createdAt = now - 7200).isRefreshTokenExpired())
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lets the app renew its MangaDex (Keycloak) authentication on its own, instead of forcing the user to reopen the browser once the session "expires".

Two root causes were addressed:

1. **Credentials were wiped on transient refresh failures.** `MangaDexAuthInterceptor.refreshToken()` returned `null` on *any* failure (no network, server 5xx, parse error), and the caller then ran `setAuth(null)`, which deletes the stored token via `MdUtil.saveOAuth(..., null)`. A single network hiccup during a token refresh logged the user out and required a full browser re-login.
2. **The renewal window was short.** The browser auth-code + PKCE flow yields an *online* refresh token bound to the Keycloak SSO session (the `KEYCLOAK_IDENTITY` cookie lives only in the browser). Once it lapses, the app can't re-auth silently.

## Changes

- `MangaDexAuthInterceptor`: `refreshToken()` now returns a sealed `RefreshResult` (`Success` / `InvalidGrant` / `TransientError`). Credentials are cleared **only** on a definitive `invalid_grant` (HTTP 400/401 with `invalid_grant` in the body). Transient errors keep the stored credentials and just fail the current request, so the app keeps renewing itself. Applies to both the proactive expiry check and the `401 + www-authenticate` retry path.
- `MdConstants.Login.authUrl`, `MdUtil.refreshTokenRequest`, `MangaDexLoginHelper.login`: request the `openid offline_access` scope so the refresh token is an offline token that survives the browser SSO session, enabling indefinite self-renewal.
- `MALOAuth`: capture `refresh_expires_in` and add `isRefreshTokenExpired()` (treating `0` as unknown/never), used by the interceptor to skip futile refresh attempts when the refresh token is conclusively dead.
- Added `MALOAuthTest` covering access/refresh token expiry logic.

## Testing

- `./gradlew spotlessApply spotlessCheck` — passes (CI gate).
- `./gradlew :app:compileDebugKotlin` — passes.
- `./gradlew :app:testReleaseUnitTest --tests MALOAuthTest` — 5/5 pass.

End-to-end refresh against the live MangaDex server requires a real account, and the Cloud VM has no emulator/device, so token exchange was verified via the build + unit tests rather than on-device manual testing.

> Note on the `offline_access` scope: it is a Keycloak built-in default client scope, so it is expected to be allowed for the `tachiyomisy` client. If MangaDex has removed it, the scope would need to be dropped — the credential-wipe fix is independent and is itself a major self-renewal improvement.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7200fdcf-9c1f-48bc-9f01-12e0a3c55fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7200fdcf-9c1f-48bc-9f01-12e0a3c55fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Improve MangaDex authentication renewal to avoid unnecessary browser re-logins by distinguishing invalid refresh tokens from transient failures and supporting long-lived offline tokens.

New Features:
- Request and use offline refresh tokens for MangaDex so sessions can self-renew independently of the browser SSO lifetime.

Bug Fixes:
- Prevent stored MangaDex credentials from being wiped on transient refresh failures by only clearing them when the refresh token is definitively invalid.
- Skip futile refresh attempts when the refresh token lifetime is known to have expired.

Enhancements:
- Extend MALOAuth with refresh token lifetime tracking and helpers for access and refresh token expiry evaluation.

Tests:
- Add unit tests for MALOAuth access and refresh token expiry behavior.