### PR TITLE
ref(data): add composite index (source, url) on mangas table

### DIFF
--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -36,7 +36,7 @@ CREATE TABLE mangas(
 
 CREATE INDEX library_favorite_index ON mangas(favorite) WHERE favorite = 1;
 CREATE INDEX mangas_url_index ON mangas(url);
-CREATE INDEX idx_mangas_source ON mangas(source);
+CREATE INDEX idx_mangas_source_url ON mangas(source, url);
 
 CREATE TRIGGER update_last_favorited_at_mangas
 AFTER UPDATE OF favorite ON mangas

--- a/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
@@ -1,0 +1,5 @@
+-- Migration to add composite index on mangas(source, url) for faster source search lookups
+-- and drop the now-redundant single-column idx_mangas_source (covered by leftmost prefix).
+
+CREATE INDEX IF NOT EXISTS idx_mangas_source_url ON mangas(source, url);
+DROP INDEX IF EXISTS idx_mangas_source;


### PR DESCRIPTION
Covers the source+url WHERE clause in insertNetworkManga and getMangaByUrlAndSource, replacing single-column index + filter, which improves source search speed significantly on  libraries with 5k+ entries.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add a composite database index on the mangas table to optimize source and URL lookups and introduce the corresponding migration.

Enhancements:
- Add a composite (source, url) index for the mangas table to speed up queries that filter by both fields.
- Introduce a new database migration to create the composite index for existing installations.