### PR TITLE
chore(download): disable download URL hash inclusion by default

### DIFF
--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -42,7 +42,7 @@ class DownloadPreferences(
     fun parallelPageLimit() = preferenceStore.getInt("download_parallel_page_limit", 5)
 
     // SY -->
-    fun includeChapterUrlHash() = preferenceStore.getBoolean("download_include_chapter_url_hash", true)
+    fun includeChapterUrlHash() = preferenceStore.getBoolean("download_include_chapter_url_hash", false)
     // SY <--
 
     // KMK -->


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Change the default for the chapter URL hash download preference to be disabled instead of enabled.