### PR TITLE
fix: add sourceOrder tiebreaker when chapter numbers are equal

### DIFF
--- a/domain/src/main/java/tachiyomi/domain/chapter/service/ChapterSort.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/service/ChapterSort.kt
@@ -17,8 +17,16 @@ fun getChapterSort(
             false -> { c1, c2 -> c2.sourceOrder.compareTo(c1.sourceOrder) }
         }
         Manga.CHAPTER_SORTING_NUMBER -> when (sortDescending) {
-            true -> { c1, c2 -> c2.chapterNumber.compareTo(c1.chapterNumber) }
-            false -> { c1, c2 -> c1.chapterNumber.compareTo(c2.chapterNumber) }
+            true -> { c1, c2 ->
+                c2.chapterNumber.compareTo(c1.chapterNumber)
+                    .takeIf { it != 0 }
+                    ?: c1.sourceOrder.compareTo(c2.sourceOrder)
+            }
+            false -> { c1, c2 ->
+                c1.chapterNumber.compareTo(c2.chapterNumber)
+                    .takeIf { it != 0 }
+                    ?: c1.sourceOrder.compareTo(c2.sourceOrder)
+            }
         }
         Manga.CHAPTER_SORTING_UPLOAD_DATE -> when (sortDescending) {
             true -> { c1, c2 -> c2.dateUpload.compareTo(c1.dateUpload) }


### PR DESCRIPTION
## 问题
章节按章节号排序时，同号或无号章节（如纯文字章节名"番外篇"、"预告"等）之间顺序不稳定。

## 改动
`ChapterSort.kt` 的 `CHAPTER_SORTING_NUMBER` 分支：当两个章节的 `chapterNumber` 相等时，fallback 到 `sourceOrder` 作为 tiebreaker。

## 效果
- 同号章节之间按来源顺序稳定排序
- 无号章节（chapterNumber = -1.0）之间不再随机排列
- 其他排序方式不受影响

## Summary by Sourcery

Bug Fixes:
- Ensure chapters with identical or missing chapter numbers are sorted deterministically using their source order as a tiebreaker when sorting by chapter number.