### PR TITLE
fix(updates): show chapters from all sources of merged entries

### DIFF
--- a/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
@@ -1,4 +1,9 @@
--- NOTE: must update MERGED_SOURCE_ID (6969) here
+-- Fix updatesView dropping chapters from all-but-one source of a merged entry.
+-- The merged branch grouped children by merge_id, collapsing every merged source
+-- down to a single arbitrary child, so newer chapters from other merged sources
+-- never appeared in the Updates tab. Recreate the view without the GROUP BY.
+DROP VIEW IF EXISTS updatesView;
+
 CREATE VIEW updatesView AS
 SELECT
     mangas._id AS mangaId,
@@ -56,33 +61,3 @@ AND chapters.scanlator = excluded_scanlators.scanlator
 WHERE favorite = 1 AND source = 6969
 AND date_fetch > date_added
 ORDER BY datefetch DESC;
-
-getRecentUpdates:
-SELECT *
-FROM updatesView
-WHERE dateUpload > :after
-LIMIT :limit;
-
-getRecentUpdatesWithFilters:
-SELECT *
-FROM updatesView
-WHERE dateUpload > :after
-AND (:read IS NULL OR read = :read)
--- Started means some progress but not finished, Read means finished chapter, thus:
-AND (
-    :started IS NULL
-    OR (:started = 1 AND last_page_read > 0 AND read = 0)
-    OR (:started = 0 AND last_page_read = 0 AND read = 0)
-)
-AND (:bookmarked IS NULL OR bookmark = :bookmarked)
-AND (
-    (excludedScanlator IS NULL OR :hideExcludedScanlators = 0)
-)
-LIMIT :limit;
-
-getUpdatesByReadStatus:
-SELECT *
-FROM updatesView
-WHERE read = :read
-AND dateUpload > :after
-LIMIT :limit;


### PR DESCRIPTION
## Problem
For a merged entry, the Updates tab only showed new chapters from one of its sources. A newer chapter released by another merged source never appeared in Updates even though it was fetched, synced, and showed in the chapter list (and could even trigger an update notification).

## Cause
The Updates list is backed by the `updatesView` SQL view. The view maps the merged parents to its children via a `LEFT JOIN`. That contains a `GROUP BY` on `merged.merge_id` which collapses every child of a merge down to a single, arbitrarily-chosen manga_id (whichever row SQLite keeps for the bare column). So only that one source's chapters could ever join, every other merged source's chapters were silently dropped from **Updates**. Which source "won" was non-deterministic; typically it was usually the info/first source, which is why the info source's chapters showed but newer ones from other sources didn't.

## Fix
The fix is to remove the `GROUP BY` so all child mangas join. Each chapter belongs to exactly one child, and the view's outer UNION dedupes identical rows, so no duplicate update rows are produced.

## Demo

### Before

M3 had an update from *SrcB*, but it does not appear in today's updates. Demo Single that it shows two chapter 10s available and a chevron to view them, but no chevron for M1 despite 2 chapters. M8 had three updates, but only updates from *SrcA* show despite there also being a ch11 update as well from *SrcB*

https://github.com/user-attachments/assets/55403e1c-1db1-43f8-a055-6a25714ad2a5

### After

The new chapter for M3 now shows up in today's updates. M1 shows the chevron and the option between the 2 chapter 10s. M8 now also shows the chevron, both chapter 10s and ch11.

https://github.com/user-attachments/assets/a0e12885-52eb-4e27-8f8d-dab75a5a2a97

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Bug Fixes:
- Ensure the updates list includes chapters from every source in a merged entry instead of only one non-deterministic source.