### PR TITLE
feat(merge): mark already-read cross-source duplicates read on sync

### DIFF
--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -53,6 +53,12 @@ class SyncChaptersWithSource(
         source: Source,
         manualFetch: Boolean = false,
         fetchWindow: Pair<Long, Long> = Pair(0, 0),
+        // KMK -->
+        // Read chapter numbers from the sibling sources of a merged entry, so a chapter
+        // freshly fetched on one source can be marked read when the same number was
+        // already read on another source (honors the "mark duplicate read" / "new" pref).
+        siblingReadChapterNumbers: Set<Double> = emptySet(),
+        // KMK <--
     ): List<Chapter> {
         if (rawSourceChapters.isEmpty() && !source.isLocal()) {
             throw NoChaptersException()
@@ -171,6 +177,9 @@ class SyncChaptersWithSource(
             .filter { it.read && it.isRecognizedNumber }
             .map { it.chapterNumber }
             .toSet()
+            // KMK -->
+            .plus(siblingReadChapterNumbers)
+        // KMK <--
 
         removedChapters.forEach { chapter ->
             if (chapter.read) deletedReadChapterNumbers.add(chapter.chapterNumber)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MergedSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MergedSource.kt
@@ -20,7 +20,9 @@ import mihon.domain.chapter.interactor.FilterChaptersForDownload
 import mihon.domain.source.interactor.UpdateMangaFromRemote
 import okhttp3.Response
 import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.domain.chapter.interactor.GetMergedChaptersByMangaId
 import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.interactor.GetMergedReferencesById
 import tachiyomi.domain.manga.interactor.NetworkToLocalManga
@@ -37,6 +39,10 @@ class MergedSource : HttpSource() {
     private val sourceManager: SourceManager by injectLazy()
     private val downloadManager: DownloadManager by injectLazy()
     private val filterChaptersForDownload: FilterChaptersForDownload by injectLazy()
+    // KMK -->
+    private val getMergedChaptersByMangaId: GetMergedChaptersByMangaId by injectLazy()
+    private val libraryPreferences: LibraryPreferences by injectLazy()
+    // KMK <--
 
     override val id: Long = MERGED_SOURCE_ID
 
@@ -102,6 +108,24 @@ class MergedSource : HttpSource() {
             "Manga references are empty, chapters unavailable, merge is likely corrupted"
         }
 
+        // KMK -->
+        // Read chapter numbers across all sources of this merge, so a chapter newly fetched
+        // on one source can be marked read when the same number was already read on another.
+        // This only feeds the "mark duplicate read" / "new" pref (also enforced inside
+        // SyncChaptersWithSource), so skip the extra query entirely when that pref is off.
+        val siblingReadChapterNumbers = if (
+            libraryPreferences.markDuplicateReadChapterAsRead().get()
+                .contains(LibraryPreferences.MARK_DUPLICATE_CHAPTER_READ_NEW)
+        ) {
+            getMergedChaptersByMangaId.await(manga.id, dedupe = false, applyFilter = false)
+                .mapNotNullTo(mutableSetOf()) { chapter ->
+                    if (chapter.read && chapter.isRecognizedNumber) chapter.chapterNumber else null
+                }
+        } else {
+            emptySet()
+        }
+        // KMK <--
+
         val semaphore = Semaphore(5)
         var exception: Exception? = null
         return supervisorScope {
@@ -119,6 +143,9 @@ class MergedSource : HttpSource() {
                                             source = source,
                                             manga = loadedManga,
                                             fetchChapters = true,
+                                            // KMK -->
+                                            siblingReadChapterNumbers = siblingReadChapterNumbers,
+                                            // KMK <--
                                         ).getOrThrow().newChapters
 
                                         if (downloadChapters && reference.downloadChapters) {

--- a/app/src/main/java/mihon/domain/source/interactor/UpdateMangaFromRemote.kt
+++ b/app/src/main/java/mihon/domain/source/interactor/UpdateMangaFromRemote.kt
@@ -82,6 +82,9 @@ class UpdateMangaFromRemote(
         fetchChapters: Boolean = false,
         manualFetch: Boolean = false,
         fetchWindow: Pair<Long, Long> = Pair(0, 0),
+        // KMK -->
+        siblingReadChapterNumbers: Set<Double> = emptySet(),
+        // KMK <--
         // SY -->
         throttleFunc: suspend () -> Unit = {},
         // SY <--
@@ -124,6 +127,9 @@ class UpdateMangaFromRemote(
                         source = source,
                         manualFetch = manualFetch,
                         fetchWindow = fetchWindow,
+                        // KMK -->
+                        siblingReadChapterNumbers = siblingReadChapterNumbers,
+                        // KMK <--
                     )
                 }
                 val updatedManga = mangaRepository.getMangaById(manga.id)


### PR DESCRIPTION
Closes #1164 

Extends the "Mark duplicate read chapter as read -> After fetching new chapter" behavior to work across the sources of a merged entry.

Upstream, `SyncChaptersWithSource` computes its set of already-read chapter numbers from only the manga being synced. Merged entries sync each source as its own manga independently, so the check has only ever worked within a single source, a chapter freshly fetched on one source is never matched against an identical-numbered chapter already read on a sibling source of the same merge. As a result, a new chapter that's already been read elsewhere in the merge lands as an unread update (and notifies).

This change gathers read chapter numbers across all sources of the merge once per update and passes them into each source's sync, so the freshly-fetched duplicate is marked read just like the single-source case.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Extend merged manga synchronization to consider read chapters across all merged sources so cross-source duplicate chapters are marked read on sync.

Bug Fixes:
- Ensure newly fetched chapters on one source of a merged entry are marked read when the same chapter number was already read on a sibling source, preventing them from appearing as new unread updates.

Enhancements:
- Propagate the set of read chapter numbers from all sources in a merged entry into chapter synchronization for each individual source.