### PR TITLE
fix(Anilist): handle GraphQL error responses on HTTP error status codes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -57,10 +57,10 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         }
         try {
             response.parseALError()
-        } catch (t: Throwable) {
+        } catch (e: Exception) {
             response.close()
-            t.stackTrace = callStack
-            throw t
+            e.stackTrace = callStack
+            throw e
         }
         if (!response.isSuccessful) {
             val code = response.code

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -18,7 +18,6 @@ import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.network.jsonMime
 import eu.kanade.tachiyomi.network.parseAs
-import okhttp3.Call
 import eu.kanade.tachiyomi.util.lang.htmlDecode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
@@ -26,6 +25,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import okhttp3.Call
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -54,6 +54,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             response.parseALError()
         } catch (t: Throwable) {
             response.close()
+            t.stackTrace = callStack
             throw t
         }
         if (!response.isSuccessful) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -49,7 +49,12 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
     // KMK -->
     private suspend fun Call.awaitALSuccess(): Response {
         val callStack = Exception().stackTrace.run { copyOfRange(1, size) }
-        val response = await()
+        val response = try {
+            await()
+        } catch (e: java.io.IOException) {
+            e.stackTrace = callStack
+            throw e
+        }
         try {
             response.parseALError()
         } catch (t: Throwable) {
@@ -159,7 +164,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 // KMK -->
                 .awaitALSuccess()
-                .use {}
+                .close()
             // KMK <--
             track
         }
@@ -184,7 +189,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
                 // KMK -->
                 .awaitALSuccess()
-                .use {}
+                .close()
             // KMK <--
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -14,10 +14,11 @@ import eu.kanade.tachiyomi.data.track.anilist.dto.ALUserListMangaQueryResult
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.network.jsonMime
 import eu.kanade.tachiyomi.network.parseAs
+import okhttp3.Call
 import eu.kanade.tachiyomi.util.lang.htmlDecode
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
@@ -46,6 +47,22 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         .build()
 
     // KMK -->
+    private suspend fun Call.awaitALSuccess(): Response {
+        val response = await()
+        try {
+            response.parseALError()
+        } catch (t: Throwable) {
+            response.close()
+            throw t
+        }
+        if (!response.isSuccessful) {
+            val code = response.code
+            response.close()
+            throw eu.kanade.tachiyomi.network.HttpException(code)
+        }
+        return response
+    }
+
     private fun Response.parseALError() {
         val bodyString = peekBody(1024 * 1024).string()
         val errorObj = try {
@@ -91,9 +108,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                         body = payload.toString().toRequestBody(jsonMime),
                     ),
                 )
-                    .awaitSuccess()
                     // KMK -->
-                    .also { it.parseALError() }
+                    .awaitALSuccess()
                     // KMK <--
                     .parseAs<ALAddMangaResult>()
                     .let {
@@ -135,9 +151,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 }
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
-                .awaitSuccess()
                 // KMK -->
-                .use { it.parseALError() }
+                .awaitALSuccess()
+                .use {}
             // KMK <--
             track
         }
@@ -160,9 +176,9 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                 }
             }
             authClient.newCall(POST(API_URL, body = payload.toString().toRequestBody(jsonMime)))
-                .awaitSuccess()
                 // KMK -->
-                .use { it.parseALError() }
+                .awaitALSuccess()
+                .use {}
             // KMK <--
         }
     }
@@ -221,9 +237,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                         body = payload.toString().toRequestBody(jsonMime),
                     ),
                 )
-                    .awaitSuccess()
                     // KMK -->
-                    .also { it.parseALError() }
+                    .awaitALSuccess()
                     // KMK <--
                     .parseAs<ALSearchResult>()
                     .data.page.media
@@ -303,9 +318,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                         body = payload.toString().toRequestBody(jsonMime),
                     ),
                 )
-                    .awaitSuccess()
                     // KMK -->
-                    .also { it.parseALError() }
+                    .awaitALSuccess()
                     // KMK <--
                     .parseAs<ALUserListMangaQueryResult>()
                     .data.page.mediaList
@@ -347,9 +361,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                         body = payload.toString().toRequestBody(jsonMime),
                     ),
                 )
-                    .awaitSuccess()
                     // KMK -->
-                    .also { it.parseALError() }
+                    .awaitALSuccess()
                     // KMK <--
                     .parseAs<ALCurrentUserResult>()
                     .let {
@@ -403,9 +416,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                         body = payload.toString().toRequestBody(jsonMime),
                     ),
                 )
-                    .awaitSuccess()
                     // KMK -->
-                    .also { it.parseALError() }
+                    .awaitALSuccess()
                     // KMK <--
                     .parseAs<ALMangaMetadata>()
                     .let { metadata ->
@@ -471,9 +483,8 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
                         body = payload.toString().toRequestBody(jsonMime),
                     ),
                 )
-                    .awaitSuccess()
                     // KMK -->
-                    .also { it.parseALError() }
+                    .awaitALSuccess()
                     // KMK <--
                     .parseAs<ALIdSearchResult>()
                     .data.media

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -48,6 +48,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     // KMK -->
     private suspend fun Call.awaitALSuccess(): Response {
+        val callStack = Exception().stackTrace.run { copyOfRange(1, size) }
         val response = await()
         try {
             response.parseALError()
@@ -58,13 +59,17 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
         if (!response.isSuccessful) {
             val code = response.code
             response.close()
-            throw eu.kanade.tachiyomi.network.HttpException(code)
+            throw eu.kanade.tachiyomi.network.HttpException(code).apply { stackTrace = callStack }
         }
         return response
     }
 
     private fun Response.parseALError() {
-        val bodyString = peekBody(1024 * 1024).string()
+        val bodyString = try {
+            peekBody(1024 * 1024).string()
+        } catch (_: Exception) {
+            return
+        }
         val errorObj = try {
             json.decodeFromString<ALError>(bodyString)
         } catch (_: Exception) {


### PR DESCRIPTION
Previously, network requests to the AniList API utilized the standard .awaitSuccess() extension function. When an HTTP status code is a non-success (such as 400 Bad Request or 401 Unauthorized), .awaitSuccess() immediately throws an HttpException (resulting in a generic "HTTP error 400" or "HTTP error 401" message) and closes the response body.

Because of this, the subsequent check .parseALError() was never executed for these errors, preventing the app from parsing and extracting the detailed GraphQL error messages (e.g., token expired, API downtime, validation/schema errors) from the response payload.

## Summary by Sourcery

Handle AniList GraphQL error responses before propagating HTTP errors and centralize response validation for AniList API calls.

Bug Fixes:
- Allow AniList GraphQL error payloads to be parsed even when the HTTP status code is non-success, ensuring detailed error messages are surfaced instead of generic HTTP errors.

Enhancements:
- Introduce a dedicated await helper for AniList calls that runs GraphQL error parsing, preserves calling stack traces, and normalizes HTTP error handling.