### PR TITLE
Address bundleOf deprecation

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/SourcePreferencesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/details/SourcePreferencesScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.FragmentManager
@@ -182,7 +181,9 @@ class SourcePreferencesFragment : PreferenceFragmentCompat() {
 
         fun getInstance(sourceId: Long): SourcePreferencesFragment {
             return SourcePreferencesFragment().apply {
-                arguments = bundleOf(SOURCE_ID to sourceId)
+                arguments = Bundle().apply {
+                    putLong(SOURCE_ID, sourceId)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Use explicit Bundle with putLong for passing source ID to SourcePreferencesFragment to avoid deprecated bundleOf API