### PR TITLE
Use RECEIVER_NOT_EXPORTED for ShizukuInstaller broadcast receiver

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/installer/ShizukuInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/installer/ShizukuInstaller.kt
@@ -164,7 +164,7 @@ class ShizukuInstaller(private val service: Service) : Installer(service) {
             service,
             receiver,
             IntentFilter(ACTION_INSTALL_RESULT),
-            ContextCompat.RECEIVER_EXPORTED,
+            ContextCompat.RECEIVER_NOT_EXPORTED,
         )
 
         initShizuku()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent the Shizuku installer broadcast receiver from being exported when registering the install result listener.