### PR TITLE
fix(extension-store): Migrate to extension store during restore/sync legacy backup

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/ExtensionStoreRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/ExtensionStoreRestorer.kt
@@ -12,8 +12,15 @@ class ExtensionStoreRestorer(
     suspend operator fun invoke(
         backupStore: BackupExtensionStore,
     ) {
+        // KMK -->
+        val indexUrl = if (backupStore.isLegacy == null) {
+            backupStore.indexUrl.removeSuffix("/index.min.json").removeSuffix("/index.json") + "/repo.json"
+        } else {
+            backupStore.indexUrl
+        }
+        // KMK <--
         database.extension_storeQueries.upsert(
-            indexUrl = backupStore.indexUrl,
+            indexUrl = indexUrl,
             name = backupStore.name,
             badgeLabel = backupStore.badgeLabel ?: backupStore.name,
             signingKey = backupStore.signingKey,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix incorrect index URL used during restore/sync of extension store data from legacy backups, ensuring repo.json is targeted for non-legacy stores.