### PR TITLE
Add auto migration support from legacy extension store index

### DIFF
--- a/data/src/main/java/mihon/data/extension/model/NetworkLegacyExtensionRepo.kt
+++ b/data/src/main/java/mihon/data/extension/model/NetworkLegacyExtensionRepo.kt
@@ -1,12 +1,15 @@
 package mihon.data.extension.model
 
 import android.annotation.SuppressLint
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import mihon.domain.extension.model.ExtensionStore
 
 @SuppressLint("UnsafeOptInUsageError")
 @Serializable
 data class NetworkLegacyExtensionRepo(
+    @SerialName("index_v2")
+    val indexV2: String?,
     val meta: Meta,
 ) : BaseNetworkExtensionStore {
     @Serializable

--- a/data/src/main/java/mihon/data/extension/service/ExtensionStoreService.kt
+++ b/data/src/main/java/mihon/data/extension/service/ExtensionStoreService.kt
@@ -22,6 +22,10 @@ class ExtensionStoreService(
     private val protoBuf: ProtoBuf,
 ) {
     suspend fun fetch(indexUrl: String): Result<ExtensionStore> {
+        return fetch(indexUrl, forceV2 = false)
+    }
+
+    private suspend fun fetch(indexUrl: String, forceV2: Boolean): Result<ExtensionStore> {
         var updatedIndexUrl: String = indexUrl
         return try {
             val store = network.client.newCall(GET(indexUrl)).awaitSuccess().body.source().use { source ->
@@ -40,10 +44,11 @@ class ExtensionStoreService(
                     } catch (e: Exception) {
                         if (e is CancellationException) throw e
                         // KMK <--
+                        if (forceV2) throw e
                         logcat(LogPriority.ERROR, e) {
                             "Failed to add extension store '$updatedIndexUrl'"
                         }
-                        try {
+                        val legacyIndex = try {
                             json.decodeFromBufferedSource<NetworkLegacyExtensionRepo>(source.peek())
                         } catch (e: IllegalArgumentException) {
                             if (!indexUrl.endsWith("/index.min.json")) {
@@ -56,6 +61,12 @@ class ExtensionStoreService(
                             network.client.newCall(GET(updatedIndexUrl)).awaitSuccess().use {
                                 json.decodeFromBufferedSource<NetworkLegacyExtensionRepo>(it.body.source())
                             }
+                        }
+
+                        if (legacyIndex.indexV2 != null) {
+                            return fetch(legacyIndex.indexV2, forceV2 = true)
+                        } else {
+                            legacyIndex
                         }
                     }
                 }


### PR DESCRIPTION
## Summary by Sourcery

Add automatic migration from legacy extension store indexes to the new v2 index when available while preserving existing protobuf-based loading.

New Features:
- Introduce automatic fallback from protobuf index loading to legacy JSON extension repo when protobuf parsing fails.
- Support discovering and following an `index_v2` URL from the legacy extension repo to transparently load the new index format.

Bug Fixes:
- Avoid failing extension store loading when a legacy index includes a pointer to a newer v2 index by retrying against the v2 URL instead of erroring.

Enhancements:
- Extend the legacy extension repo model to include an optional `index_v2` field for compatibility with updated store metadata.