### PR TITLE
Ensure old extension store is removed if index url changes

### DIFF
--- a/data/src/main/java/mihon/data/extension/repository/ExtensionStoreRepositoryImpl.kt
+++ b/data/src/main/java/mihon/data/extension/repository/ExtensionStoreRepositoryImpl.kt
@@ -40,7 +40,14 @@ class ExtensionStoreRepositoryImpl(
                 extension_storeQueries.getAll()
             }.forEach { store ->
                 service.fetch(store.index_url)
-                    .mapCatching { upsert(it) }
+                    .mapCatching {
+                        handler.await {
+                            upsert(it)
+                            if (store.index_url != it.indexUrl) {
+                                extension_storeQueries.delete(store.index_url)
+                            }
+                        }
+                    }
                     .onFailure {
                         logcat(LogPriority.ERROR, it) {
                             "Failed to refresh extension store '${store.name} (${store.index_url})'"


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove outdated extension store records when a fetched store reports a different index URL than the existing one.