### PR TITLE
fix(UpdateMangaFromRemote): Correct `manualFetch` to former code

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -589,6 +589,10 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
 
                 updateMangaFromRemote(
                     manga = dbManga,
+                    // KMK -->
+                    // Update cover & fetchInterval
+                    manualFetch = true,
+                    // KMK <--
                 )
 
                 metadata.mangaId = dbManga.id

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/MetadataUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/MetadataUpdateJob.kt
@@ -118,6 +118,10 @@ class MetadataUpdateJob(private val context: Context, workerParams: WorkerParame
                                             source = source,
                                             manga = manga,
                                             fetchDetails = true,
+                                            // KMK -->
+                                            // Refresh same Url
+                                            manualFetch = true,
+                                            // KMK <--
                                         ).getOrThrow()
                                     } catch (e: Throwable) {
                                         // Ignore errors and continue

--- a/app/src/main/java/exh/debug/DebugFunctions.kt
+++ b/app/src/main/java/exh/debug/DebugFunctions.kt
@@ -100,6 +100,9 @@ object DebugFunctions {
                     },
                     manga = manga,
                     fetchDetails = true,
+                    // KMK -->
+                    manualFetch = true,
+                    // KMK <--
                 )
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

Ensure library and metadata update operations perform a manual fetch when updating manga from remote sources.

Bug Fixes:
- Restore manual fetch behavior for library manga updates to correctly refresh covers and fetch intervals.
- Enable manual fetch during metadata updates to ensure details are refreshed even for unchanged URLs.
- Ensure debug update functions trigger a manual fetch when requesting manga details.