### PR TITLE
chore: Use `currentCoroutineContext` instead of `coroutineContext`

### DIFF
--- a/app/src/main/java/exh/util/CoroutineUtil.kt
+++ b/app/src/main/java/exh/util/CoroutineUtil.kt
@@ -1,10 +1,10 @@
 package exh.util
 
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onEach
-import kotlin.coroutines.coroutineContext
 
 fun <T> Flow<T>.cancellable() = onEach {
-    coroutineContext.ensureActive()
+    currentCoroutineContext().ensureActive()
 }

--- a/data/src/main/java/tachiyomi/data/TransactionContext.kt
+++ b/data/src/main/java/tachiyomi/data/TransactionContext.kt
@@ -3,6 +3,7 @@ package tachiyomi.data
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -14,14 +15,13 @@ import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.coroutines.coroutineContext
 import kotlin.coroutines.resume
 
 /**
  * Returns the transaction dispatcher if we are on a transaction, or the database dispatchers.
  */
 internal suspend fun AndroidDatabaseHandler.getCurrentDatabaseContext(): CoroutineContext {
-    return coroutineContext[TransactionElement]?.transactionDispatcher ?: queryDispatcher
+    return currentCoroutineContext()[TransactionElement]?.transactionDispatcher ?: queryDispatcher
 }
 
 /**
@@ -41,7 +41,7 @@ internal suspend fun AndroidDatabaseHandler.getCurrentDatabaseContext(): Corouti
 internal suspend fun <T> AndroidDatabaseHandler.withTransaction(block: suspend () -> T): T {
     // Use inherited transaction context if available, this allows nested suspending transactions.
     val transactionContext =
-        coroutineContext[TransactionElement]?.transactionDispatcher ?: createTransactionContext()
+        currentCoroutineContext()[TransactionElement]?.transactionDispatcher ?: createTransactionContext()
     return withContext(transactionContext) {
         val transactionElement = coroutineContext[TransactionElement]!!
         transactionElement.acquire()
@@ -81,7 +81,7 @@ private suspend fun AndroidDatabaseHandler.createTransactionContext(): Coroutine
     // context get cancelled before we can even start using this job. Otherwise, the acquired
     // transaction thread will forever wait for the controlJob to be cancelled.
     // see b/148181325
-    coroutineContext[Job]?.invokeOnCompletion {
+    currentCoroutineContext()[Job]?.invokeOnCompletion {
         controlJob.cancel()
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Use `currentCoroutineContext` in suspending helpers to access coroutine context instead of `coroutineContext`.

Enhancements:
- Update database transaction helpers to use `currentCoroutineContext` when reading coroutine context elements.
- Update Flow.cancellable extension to use `currentCoroutineContext` for cancellation checks.