### PR TITLE
feat(source-api): Check if extension supports related manga before making request

### DIFF
--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -317,32 +317,31 @@ abstract class HttpSource : CatalogueSource {
      *
      * @since komikku/extensions-lib 1.6
      * @param manga the current manga to get related mangas.
-     * @return the related mangas for the current manga.
-     * @throws UnsupportedOperationException if a source doesn't support related mangas.
+     * @return the related mangas for the current manga, or empty if a source doesn't support related mangas.
      */
     override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
-        val isOverridden = try {
-            var clazz: Class<*>? = javaClass
-            var found = false
-            while (clazz != null && clazz != HttpSource::class.java) {
-                if (clazz.declaredMethods.any { it.name == "relatedMangaListParse" || it.name == "popularMangaParse" }) {
-                    found = true
-                    break
-                }
-                clazz = clazz.superclass
-            }
-            found
-        } catch (_: Exception) {
-            false
-        }
-
-        if (!isOverridden) return emptyList()
+        if (!isRelatedMangaListParseAvailable) return emptyList()
 
         return client.newCall(relatedMangaListRequest(manga))
             .awaitSuccess()
             .use { response ->
                 relatedMangaListParse(response)
             }
+    }
+
+    private val isRelatedMangaListParseAvailable by lazy(LazyThreadSafetyMode.NONE) {
+        try {
+            var clazz: Class<*>? = javaClass
+            while (clazz != null && clazz != HttpSource::class.java) {
+                if (clazz.declaredMethods.any { it.name == "relatedMangaListParse" || it.name == "popularMangaParse" }) {
+                    return@lazy true
+                }
+                clazz = clazz.superclass
+            }
+            false
+        } catch (_: Exception) {
+            false
+        }
     }
 
     /**

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -16,8 +16,6 @@ import eu.kanade.tachiyomi.source.model.SManga
 import exh.log.maybeInjectEHLogger
 import exh.pref.DelegateSourcePreferences
 import exh.source.DelegatedHttpSource
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -322,14 +320,29 @@ abstract class HttpSource : CatalogueSource {
      * @return the related mangas for the current manga.
      * @throws UnsupportedOperationException if a source doesn't support related mangas.
      */
-    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> = coroutineScope {
-        async {
-            client.newCall(relatedMangaListRequest(manga))
-                .execute()
-                .let { response ->
-                    relatedMangaListParse(response)
+    override suspend fun fetchRelatedMangaList(manga: SManga): List<SManga> {
+        val isOverridden = try {
+            var clazz: Class<*>? = javaClass
+            var found = false
+            while (clazz != null && clazz != HttpSource::class.java) {
+                if (clazz.declaredMethods.any { it.name == "relatedMangaListParse" || it.name == "popularMangaParse" }) {
+                    found = true
+                    break
                 }
-        }.await()
+                clazz = clazz.superclass
+            }
+            found
+        } catch (_: Exception) {
+            false
+        }
+
+        if (!isOverridden) return emptyList()
+
+        return client.newCall(relatedMangaListRequest(manga))
+            .awaitSuccess()
+            .use { response ->
+                relatedMangaListParse(response)
+            }
     }
 
     /**


### PR DESCRIPTION
## Summary by Sourcery

Guard related manga fetching to only run for sources that implement related or popular manga parsing, returning an empty list otherwise.

Enhancements:
- Add a runtime check to skip related manga requests for sources that do not override related or popular manga parsing methods.
- Simplify related manga fetching by removing unnecessary coroutine scaffolding and using the existing awaitSuccess helper for HTTP calls.