### PR TITLE
fix(database): Fix migrating default value of `memo` of existing database

### DIFF
--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -17,7 +17,7 @@ CREATE TABLE chapters(
     last_modified_at INTEGER NOT NULL DEFAULT 0,
     version INTEGER NOT NULL DEFAULT 0,
     is_syncing INTEGER NOT NULL DEFAULT 0,
-    memo BLOB AS JsonObject NOT NULL DEFAULT '{}',
+    memo BLOB AS JsonObject NOT NULL DEFAULT (CAST('{}' AS BLOB)),
     FOREIGN KEY(manga_id) REFERENCES mangas (_id)
     ON DELETE CASCADE
 );

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -31,7 +31,7 @@ CREATE TABLE mangas(
     version INTEGER NOT NULL DEFAULT 0,
     is_syncing INTEGER NOT NULL DEFAULT 0,
     notes TEXT NOT NULL DEFAULT "",
-    memo BLOB AS JsonObject NOT NULL DEFAULT '{}'
+    memo BLOB AS JsonObject NOT NULL DEFAULT (CAST('{}' AS BLOB))
 );
 
 CREATE INDEX library_favorite_index ON mangas(favorite) WHERE favorite = 1;

--- a/data/src/main/sqldelight/tachiyomi/migrations/46.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/46.sqm
@@ -1,4 +1,5 @@
 import kotlin.Boolean;
+import kotlinx.serialization.json.JsonObject;
 
 CREATE TABLE extension_store(
     index_url TEXT NOT NULL PRIMARY KEY,
@@ -15,5 +16,5 @@ SELECT base_url || '/repo.json', name, coalesce(short_name, name), signing_key_f
 
 DROP TABLE extension_repos;
 
-ALTER TABLE mangas ADD COLUMN memo BLOB NOT NULL DEFAULT '{}';
-ALTER TABLE chapters ADD COLUMN memo BLOB NOT NULL DEFAULT '{}';
+ALTER TABLE mangas ADD COLUMN memo BLOB AS JsonObject NOT NULL DEFAULT (CAST('{}' AS BLOB));
+ALTER TABLE chapters ADD COLUMN memo BLOB AS JsonObject NOT NULL DEFAULT (CAST('{}' AS BLOB));


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix migration logic so existing databases correctly set or preserve the memo column default value during schema upgrade.