### PR TITLE
Allow app to load TachiyomiX 1.6 extensions

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
@@ -57,7 +57,7 @@ internal object ExtensionLoader {
     private const val METADATA_SOURCE_FACTORY = "tachiyomi.extension.factory"
     private const val METADATA_NSFW = "tachiyomi.extension.nsfw"
     const val LIB_VERSION_MIN = 1.4
-    const val LIB_VERSION_MAX = 1.5
+    const val LIB_VERSION_MAX = 1.6
 
     @Suppress("DEPRECATION")
     private val PACKAGE_FLAGS = PackageManager.GET_CONFIGURATIONS or
@@ -266,13 +266,20 @@ internal object ExtensionLoader {
 
         // Validate lib version
         val libVersion = versionName.substringBeforeLast('.').toDoubleOrNull()
-        if (libVersion == null || libVersion < LIB_VERSION_MIN || libVersion > LIB_VERSION_MAX) {
+        if (libVersion == null || (libVersion != LIB_VERSION_MIN && libVersion != LIB_VERSION_MAX)) {
             logcat(LogPriority.WARN) {
                 "Lib version is $libVersion, while only versions " +
-                    "$LIB_VERSION_MIN to $LIB_VERSION_MAX are allowed"
+                    "$LIB_VERSION_MIN and $LIB_VERSION_MAX is allowed"
             }
             return LoadResult.Error
         }
+//        if (libVersion == null || libVersion < LIB_VERSION_MIN || libVersion > LIB_VERSION_MAX) {
+//            logcat(LogPriority.WARN) {
+//                "Lib version is $libVersion, while only versions " +
+//                    "$LIB_VERSION_MIN or $LIB_VERSION_MAX is allowed"
+//            }
+//            return LoadResult.Error
+//        }
 
         val signatures = getSignatures(pkgInfo)
         if (signatures.isNullOrEmpty()) {


### PR DESCRIPTION
## Summary by Sourcery

Allow the app to load and validate both Tachiyomi extension library versions 1.4 and 1.6 instead of only up to 1.5.

New Features:
- Support loading extensions built against library version 1.6.

Enhancements:
- Tighten extension lib version validation to only accept explicit supported versions instead of a version range.