### PR TITLE
Ensure chapter order is retained when passed to `source.getMangaUpdate`

### DIFF
--- a/app/src/main/java/mihon/domain/source/interactor/UpdateMangaFromRemote.kt
+++ b/app/src/main/java/mihon/domain/source/interactor/UpdateMangaFromRemote.kt
@@ -88,6 +88,7 @@ class UpdateMangaFromRemote(
     ): Result<RemoteMangaUpdate> {
         return try {
             val chapters = chapterRepository.getChapterByMangaId(manga.id)
+                .sortedBy { it.sourceOrder }
             val update = withIOContext {
                 // SY -->
                 if (source is EHentai) {


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Sort locally retrieved manga chapters by source order prior to invoking the remote update call to preserve chapter ordering semantics.