### PR TITLE
Remove redundant call to `updateMangaFromRemote` in manga screen

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -502,11 +502,15 @@ class MangaScreenModel(
 
             // Fetch info-chapters when needed
             if (screenModelScope.isActive) {
-                fetchAllFromSource(
-                    manualFetch = false,
-                    fetchDetails = needRefreshInfo,
-                    fetchChapters = needRefreshChapter,
-                )
+                // KMK -->
+                if (needRefreshInfo || needRefreshChapter) {
+                    // KMK <--
+                    fetchAllFromSource(
+                        manualFetch = false,
+                        fetchDetails = needRefreshInfo,
+                        fetchChapters = needRefreshChapter,
+                    )
+                }
                 // KMK -->
                 launch { syncTrackers() }
                 launch { fetchRelatedMangasFromSource() }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Skip calling the remote fetch pipeline when neither manga info nor chapters require refresh in the manga screen.