### PR TITLE
fix(merged-chapters): Fix sorting merged-manga's chapters by source order

### DIFF
--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -122,7 +122,10 @@ AND (
         AND ((MA.chapter_flags & :bookmarkMask) = 0 OR C.bookmark = 1)
     )
     -- KMK <--
-);
+)
+-- KMK -->
+ORDER BY C.manga_id, C.source_order;
+-- KMK <--
 
 getScanlatorsByMergeId:
 SELECT scanlator


### PR DESCRIPTION
Fix #1680

## Summary by Sourcery

Bug Fixes:
- Correct merged manga chapter ordering when displaying chapters from multiple sources.