### PR TITLE
fix(MangaDex): Fix MangaDex tracker's covers

### DIFF
--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -87,6 +87,25 @@ import kotlin.random.Random
             .addInterceptor(
                 CloudflareInterceptor(context, cookieJar, ::defaultUserAgentProvider),
             )
+            // KMK -->
+            // FIXME (KMK): Dirty hack to fetch MangaDex covers
+            .addInterceptor { chain ->
+                val originalRequest = chain.request()
+                val url = originalRequest.url
+                if (url.host == "uploads.mangadex.org") {
+                    val newRequest = originalRequest
+                        .newBuilder()
+                        .header("Referer", "https://mangadex.org/")
+                        .header("Origin", "https://mangadex.org")
+                        .header("sec-fetch-dest", "document")
+                        .header("sec-fetch-mode", "navigate")
+                        .build()
+                    chain.proceed(newRequest)
+                } else {
+                    chain.proceed(originalRequest)
+                }
+            }
+            // KMK <--
             .build()
     }
 

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -92,13 +92,13 @@ import kotlin.random.Random
             .addInterceptor { chain ->
                 val originalRequest = chain.request()
                 val url = originalRequest.url
-                if (url.host == "uploads.mangadex.org") {
+                if (url.host == "uploads.mangadex.org" && url.encodedPath.startsWith("/covers/")) {
                     val newRequest = originalRequest
                         .newBuilder()
                         .header("Referer", "https://mangadex.org/")
                         .header("Origin", "https://mangadex.org")
-                        .header("sec-fetch-dest", "document")
-                        .header("sec-fetch-mode", "navigate")
+                        .header("sec-fetch-dest", "image")
+                        .header("sec-fetch-mode", "no-cors")
                         .build()
                     chain.proceed(newRequest)
                 } else {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix MangaDex cover retrieval by sending the appropriate referer and related headers on image requests.