### PR TITLE
feat(logging): Allow disable verbose log in Debug build

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -64,6 +64,7 @@ import eu.kanade.tachiyomi.ui.more.OnboardingScreen
 import eu.kanade.tachiyomi.util.CrashLogUtil
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.system.GLUtil
+import eu.kanade.tachiyomi.util.system.isDebugBuildType
 import eu.kanade.tachiyomi.util.system.isReleaseBuildType
 import eu.kanade.tachiyomi.util.system.isShizukuInstalled
 import eu.kanade.tachiyomi.util.system.powerManager
@@ -799,7 +800,9 @@ object SettingsAdvancedScreen : SearchableSettings {
                     ),
                 ),
                 Preference.PreferenceItem.ListPreference(
-                    preference = exhPreferences.logLevel(),
+                    // KMK -->
+                    preference = exhPreferences.logLevel(isDebugBuildType),
+                    // KMK <--
                     entries = EHLogLevel.entries.mapIndexed { index, ehLogLevel ->
                         index to "${context.stringResource(ehLogLevel.nameRes)} (${
                             context.stringResource(ehLogLevel.description)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -136,7 +136,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                     }
                 },
             ),
-            Preference.PreferenceItem.SwitchPreference(
+            /* SY --> Preference.PreferenceItem.SwitchPreference(
                 preference = networkPreferences.verboseLogging(),
                 title = stringResource(MR.strings.pref_verbose_logging),
                 subtitle = stringResource(MR.strings.pref_verbose_logging_summary),
@@ -144,7 +144,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                     context.toast(MR.strings.requires_app_restart)
                     true
                 },
-            ),
+            ), SY <-- */
             Preference.PreferenceItem.TextPreference(
                 title = stringResource(MR.strings.pref_debug_info),
                 onClick = { navigator.push(DebugInfoScreen()) },

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -60,7 +60,6 @@ import eu.kanade.tachiyomi.di.AppModule
 import eu.kanade.tachiyomi.di.PreferenceModule
 import eu.kanade.tachiyomi.di.SYPreferenceModule
 import eu.kanade.tachiyomi.network.NetworkHelper
-import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.ui.base.delegate.SecureActivityDelegate
 import eu.kanade.tachiyomi.util.CrashLogUtil
 import eu.kanade.tachiyomi.util.system.DeviceUtil
@@ -107,7 +106,6 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
 
     private val basePreferences: BasePreferences by injectLazy()
     private val privacyPreferences: PrivacyPreferences by injectLazy()
-    private val networkPreferences: NetworkPreferences by injectLazy()
 
     private val disableIncognitoReceiver = DisableIncognitoReceiver()
 
@@ -152,7 +150,9 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         setupExhLogging() // EXH logging
         if (!LogcatLogger.isInstalled) {
             val minLogPriority = when {
-                networkPreferences.verboseLogging().get() -> LogPriority.VERBOSE
+                // KMK -->
+                EHLogLevel.isExtraLogging() -> LogPriority.VERBOSE
+                // KMK <--
                 BuildConfig.DEBUG -> LogPriority.DEBUG
                 else -> LogPriority.INFO
             }
@@ -290,7 +290,9 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
 
             crossfade((300 * this@App.animatorDurationScale).toInt())
             allowRgb565(DeviceUtil.isLowRamDevice(this@App))
-            if (networkPreferences.verboseLogging().get()) logger(DebugLogger())
+            // KMK -->
+            if (EHLogLevel.isExtraLogging()) logger(DebugLogger())
+            // KMK <--
 
             // Coil spawns a new thread for every image load by default
             fetcherCoroutineContext(Dispatchers.IO.limitedParallelism(8))
@@ -351,11 +353,18 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
 
     // EXH
     private fun setupExhLogging() {
-        EHLogLevel.init(this)
+        EHLogLevel.init(
+            this,
+            // KMK -->
+            isDebugBuildType = isDebugBuildType,
+            // KMK <--
+        )
 
         val logLevel = when {
-            EHLogLevel.shouldLog(EHLogLevel.EXTREME) -> LogLevel.ALL
-            EHLogLevel.shouldLog(EHLogLevel.EXTRA) || isDebugBuildType -> LogLevel.DEBUG
+            // KMK -->
+            EHLogLevel.isExtremeLogging() -> LogLevel.ALL
+            EHLogLevel.isExtraLogging() -> LogLevel.DEBUG
+            // KMK <--
             else -> LogLevel.WARN
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -156,7 +156,7 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { ChapterCache(app, get(), get()) }
         addSingletonFactory { CoverCache(app) }
 
-        addSingletonFactory { NetworkHelper(app, get(), isDebugBuildType) }
+        addSingletonFactory { NetworkHelper(app, get()) }
         addSingletonFactory { JavaScriptEngine(app) }
 
         addSingletonFactory<SourceManager> { AndroidSourceManager(app, get(), get()) }

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -11,7 +11,6 @@ import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
-import eu.kanade.tachiyomi.util.system.isDebugBuildType
 import tachiyomi.core.common.preference.AndroidPreferenceStore
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.storage.AndroidStorageFolderProvider
@@ -35,7 +34,6 @@ class PreferenceModule(val app: Application) : InjektModule {
         addSingletonFactory {
             NetworkPreferences(
                 preferenceStore = get(),
-                verboseLogging = isDebugBuildType,
             )
         }
         addSingletonFactory {

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import eu.kanade.tachiyomi.network.interceptor.CloudflareInterceptor
 import eu.kanade.tachiyomi.network.interceptor.UncaughtExceptionInterceptor
 import eu.kanade.tachiyomi.network.interceptor.UserAgentInterceptor
+import exh.log.EHLogLevel
 import logcat.LogPriority
 import okhttp3.Cache
 import okhttp3.Headers
@@ -21,9 +22,6 @@ import kotlin.random.Random
 /* SY --> */ open /* SY <-- */ class NetworkHelper(
     private val context: Context,
     private val preferences: NetworkPreferences,
-    // SY -->
-    val isDebugBuild: Boolean,
-    // SY <--
 ) {
 
     /* SY --> */ open /* SY <-- */val cookieJar = AndroidCookieJar()
@@ -54,7 +52,9 @@ import kotlin.random.Random
             .addInterceptor(UncaughtExceptionInterceptor())
             .addInterceptor(UserAgentInterceptor(::defaultUserAgentProvider))
 
-        if (isDebugBuild) {
+        // KMK -->
+        if (EHLogLevel.isExtraLogging()) {
+            // KMK <--
             val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.HEADERS
             }

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkPreferences.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkPreferences.kt
@@ -5,12 +5,11 @@ import tachiyomi.core.common.preference.PreferenceStore
 
 class NetworkPreferences(
     private val preferenceStore: PreferenceStore,
-    private val verboseLogging: Boolean = false,
 ) {
 
-    fun verboseLogging(): Preference<Boolean> {
+    /* KMK --> fun verboseLogging(): Preference<Boolean> {
         return preferenceStore.getBoolean("verbose_logging", verboseLogging)
-    }
+    } KMK <-- */
 
     fun dohProvider(): Preference<Int> {
         return preferenceStore.getInt("doh_provider", -1)

--- a/core/common/src/main/kotlin/exh/log/EHLogLevel.kt
+++ b/core/common/src/main/kotlin/exh/log/EHLogLevel.kt
@@ -12,17 +12,40 @@ enum class EHLogLevel(val nameRes: StringResource, val description: StringResour
     ;
 
     companion object {
-        private var curLogLevel: Int? = null
+        // KMK -->
+        private var _curLogLevel: Int = MINIMAL.ordinal
+        val curLogLevel: Int get() = _curLogLevel
 
-        val currentLogLevel get() = values()[curLogLevel!!]
+        const val EH_LOG_LEVEL_PREF = "eh_log_level"
+        // KMK <--
 
-        fun init(context: Context) {
-            curLogLevel = PreferenceManager.getDefaultSharedPreferences(context)
-                .getInt("eh_log_level", MINIMAL.ordinal) // todo
+        val currentLogLevel get() = entries[curLogLevel]
+
+        fun init(
+            context: Context,
+            // KMK -->
+            isDebugBuildType: Boolean = false,
+        ) {
+            val defaultLogLevel = if (isDebugBuildType) EXTRA.ordinal else MINIMAL.ordinal
+            _curLogLevel = PreferenceManager.getDefaultSharedPreferences(context)
+                .getInt(EH_LOG_LEVEL_PREF, defaultLogLevel)
         }
 
-        fun shouldLog(requiredLogLevel: EHLogLevel): Boolean {
-            return curLogLevel!! >= requiredLogLevel.ordinal
+        /**
+         * Same as Mihon's `verboseLogging`, which is:
+         * - Always follow [Companion.curLogLevel] value which user set
+         * - If user hasn't set it, default value is `EXTRA` for *Debug* build type, `MINIMAL` for *Release* build type
+         */
+        fun isExtraLogging() = shouldLog(EXTRA)
+
+        /**
+         * Enable extremely detail `||EH-NETWORK-JSON` log by [maybeInjectEHLogger]
+         */
+        fun isExtremeLogging() = shouldLog(EXTREME)
+        // KMK <--
+
+        private fun shouldLog(requiredLogLevel: EHLogLevel): Boolean {
+            return curLogLevel >= requiredLogLevel.ordinal
         }
     }
 }

--- a/core/common/src/main/kotlin/exh/log/EHLogLevel.kt
+++ b/core/common/src/main/kotlin/exh/log/EHLogLevel.kt
@@ -12,23 +12,21 @@ enum class EHLogLevel(val nameRes: StringResource, val description: StringResour
     ;
 
     companion object {
-        // KMK -->
         private var _curLogLevel: Int = MINIMAL.ordinal
         val curLogLevel: Int get() = _curLogLevel
 
         const val EH_LOG_LEVEL_PREF = "eh_log_level"
-        // KMK <--
 
-        val currentLogLevel get() = entries[curLogLevel]
+        fun defaultLogLevel(isDebugBuildType: Boolean) = if (isDebugBuildType) EXTRA.ordinal else MINIMAL.ordinal
+
+        val currentLogLevel get() = entries.getOrNull(curLogLevel) ?: MINIMAL
 
         fun init(
             context: Context,
-            // KMK -->
             isDebugBuildType: Boolean = false,
         ) {
-            val defaultLogLevel = if (isDebugBuildType) EXTRA.ordinal else MINIMAL.ordinal
             _curLogLevel = PreferenceManager.getDefaultSharedPreferences(context)
-                .getInt(EH_LOG_LEVEL_PREF, defaultLogLevel)
+                .getInt(EH_LOG_LEVEL_PREF, defaultLogLevel(isDebugBuildType))
         }
 
         /**
@@ -42,7 +40,6 @@ enum class EHLogLevel(val nameRes: StringResource, val description: StringResour
          * Enable extremely detail `||EH-NETWORK-JSON` log by [maybeInjectEHLogger]
          */
         fun isExtremeLogging() = shouldLog(EXTREME)
-        // KMK <--
 
         private fun shouldLog(requiredLogLevel: EHLogLevel): Boolean {
             return curLogLevel >= requiredLogLevel.ordinal

--- a/core/common/src/main/kotlin/exh/log/EHNetworkLogging.kt
+++ b/core/common/src/main/kotlin/exh/log/EHNetworkLogging.kt
@@ -1,13 +1,14 @@
 package exh.log
 
 import com.elvishew.xlog.XLog
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 
 fun OkHttpClient.Builder.maybeInjectEHLogger(): OkHttpClient.Builder {
-    if (EHLogLevel.shouldLog(EHLogLevel.EXTREME)) {
+    // KMK -->
+    if (EHLogLevel.isExtremeLogging()) {
+        // KMK <--
         val xlogBorder = XLog.tag("||EH-NETWORK-JSON").build()
         val xlogNoBorder = XLog.tag("||EH-NETWORK-JSON").disableBorder().build()
         val logger: HttpLoggingInterceptor.Logger = HttpLoggingInterceptor.Logger { message ->

--- a/domain/src/main/java/exh/source/ExhPreferences.kt
+++ b/domain/src/main/java/exh/source/ExhPreferences.kt
@@ -1,5 +1,7 @@
 package exh.source
 
+import exh.log.EHLogLevel
+import exh.log.EHLogLevel.Companion.EH_LOG_LEVEL_PREF
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.domain.release.service.AppUpdatePolicy
@@ -23,7 +25,7 @@ class ExhPreferences(
     fun ehIncognitoMode() = preferenceStore.getBoolean("eh_incognito_mode", false)
     // KMK <--
 
-    fun enableExhentai() = preferenceStore.getBoolean(Preference.Companion.privateKey("enable_exhentai"), false)
+    fun enableExhentai() = preferenceStore.getBoolean(Preference.privateKey("enable_exhentai"), false)
 
     fun imageQuality() = preferenceStore.getString("ehentai_quality", "auto")
 
@@ -38,15 +40,15 @@ class ExhPreferences(
     fun ehTagWatchingValue() = preferenceStore.getInt("eh_tag_watching_value", 0)
 
     // EH Cookies
-    fun memberIdVal() = preferenceStore.getString(Preference.Companion.privateKey("eh_ipb_member_id"), "")
+    fun memberIdVal() = preferenceStore.getString(Preference.privateKey("eh_ipb_member_id"), "")
 
-    fun passHashVal() = preferenceStore.getString(Preference.Companion.privateKey("eh_ipb_pass_hash"), "")
-    fun igneousVal() = preferenceStore.getString(Preference.Companion.privateKey("eh_igneous"), "")
-    fun ehSettingsProfile() = preferenceStore.getInt(Preference.Companion.privateKey("eh_ehSettingsProfile"), -1)
-    fun exhSettingsProfile() = preferenceStore.getInt(Preference.Companion.privateKey("eh_exhSettingsProfile"), -1)
-    fun exhSettingsKey() = preferenceStore.getString(Preference.Companion.privateKey("eh_settingsKey"), "")
-    fun exhSessionCookie() = preferenceStore.getString(Preference.Companion.privateKey("eh_sessionCookie"), "")
-    fun exhHathPerksCookies() = preferenceStore.getString(Preference.Companion.privateKey("eh_hathPerksCookie"), "")
+    fun passHashVal() = preferenceStore.getString(Preference.privateKey("eh_ipb_pass_hash"), "")
+    fun igneousVal() = preferenceStore.getString(Preference.privateKey("eh_igneous"), "")
+    fun ehSettingsProfile() = preferenceStore.getInt(Preference.privateKey("eh_ehSettingsProfile"), -1)
+    fun exhSettingsProfile() = preferenceStore.getInt(Preference.privateKey("eh_exhSettingsProfile"), -1)
+    fun exhSettingsKey() = preferenceStore.getString(Preference.privateKey("eh_settingsKey"), "")
+    fun exhSessionCookie() = preferenceStore.getString(Preference.privateKey("eh_sessionCookie"), "")
+    fun exhHathPerksCookies() = preferenceStore.getString(Preference.privateKey("eh_hathPerksCookie"), "")
 
     fun exhShowSyncIntro() = preferenceStore.getBoolean("eh_show_sync_intro", true)
 
@@ -56,13 +58,15 @@ class ExhPreferences(
 
     fun exhShowSettingsUploadWarning() = preferenceStore.getBoolean("eh_showSettingsUploadWarning2", true)
 
-    fun logLevel() = preferenceStore.getInt("eh_log_level", 0)
+    // KMK -->
+    fun logLevel() = preferenceStore.getInt(EH_LOG_LEVEL_PREF, EHLogLevel.curLogLevel)
+    // KMK <--
 
     fun exhAutoUpdateFrequency() = preferenceStore.getInt("eh_auto_update_frequency", 1)
 
     fun exhAutoUpdateRequirements() = preferenceStore.getStringSet("eh_auto_update_restrictions", emptySet())
 
-    fun exhAutoUpdateStats() = preferenceStore.getString(Preference.Companion.appStateKey("eh_auto_update_stats"), "")
+    fun exhAutoUpdateStats() = preferenceStore.getString(Preference.appStateKey("eh_auto_update_stats"), "")
 
     fun exhWatchedListDefaultState() = preferenceStore.getBoolean("eh_watched_list_default_state", false)
 

--- a/domain/src/main/java/exh/source/ExhPreferences.kt
+++ b/domain/src/main/java/exh/source/ExhPreferences.kt
@@ -59,7 +59,7 @@ class ExhPreferences(
     fun exhShowSettingsUploadWarning() = preferenceStore.getBoolean("eh_showSettingsUploadWarning2", true)
 
     // KMK -->
-    fun logLevel() = preferenceStore.getInt(EH_LOG_LEVEL_PREF, EHLogLevel.curLogLevel)
+    fun logLevel(isDebugBuildType: Boolean) = preferenceStore.getInt(EH_LOG_LEVEL_PREF, EHLogLevel.defaultLogLevel(isDebugBuildType))
     // KMK <--
 
     fun exhAutoUpdateFrequency() = preferenceStore.getInt("eh_auto_update_frequency", 1)

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -39,7 +39,7 @@ abstract class HttpSource : CatalogueSource {
     // SY -->
     protected val network: NetworkHelper by lazy {
         val network = Injekt.get<NetworkHelper>()
-        object : NetworkHelper(Injekt.get<Application>(), Injekt.get(), network.isDebugBuild) {
+        object : NetworkHelper(Injekt.get<Application>(), Injekt.get()) {
             override val client: OkHttpClient
                 get() = delegate?.networkHttpClient ?: network.client
                     .newBuilder()


### PR DESCRIPTION
## Summary by Sourcery

Unify logging configuration around EHLogLevel so that network and app logging honor the EH log level preference, allowing verbose logging to be disabled even in debug builds.

New Features:
- Support build-type-aware default EH log level, using EXTRA for debug builds and MINIMAL for release builds when no user preference is set.

Enhancements:
- Expose helper methods on EHLogLevel to query extra and extreme logging states and use them consistently across app, network, and EH network logging.
- Simplify NetworkHelper and NetworkPreferences by removing the verboseLogging flag and relying on EHLogLevel for log verbosity.
- Update ExhPreferences to use the shared EH log level preference key and current log level as default.

Chores:
- Clean up Preference.Companion usages and related DI wiring affected by the logging preference changes.
- Hide the previous verbose logging toggle from the advanced settings screen to avoid conflicting with EH log level controls.