### PR TITLE
chore(NetworkHelper): Allow disabling network handling for MangaDex cover images based on delegate source preferences

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -156,7 +156,7 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { ChapterCache(app, get(), get()) }
         addSingletonFactory { CoverCache(app) }
 
-        addSingletonFactory { NetworkHelper(app, get()) }
+        addSingletonFactory { NetworkHelper(app, get(), get()) }
         addSingletonFactory { JavaScriptEngine(app) }
 
         addSingletonFactory<SourceManager> { AndroidSourceManager(app, get(), get()) }

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.network.interceptor.CloudflareInterceptor
 import eu.kanade.tachiyomi.network.interceptor.UncaughtExceptionInterceptor
 import eu.kanade.tachiyomi.network.interceptor.UserAgentInterceptor
 import exh.log.EHLogLevel
+import exh.pref.DelegateSourcePreferences
 import logcat.LogPriority
 import okhttp3.Cache
 import okhttp3.Headers
@@ -22,9 +23,16 @@ import kotlin.random.Random
 /* SY --> */ open /* SY <-- */ class NetworkHelper(
     private val context: Context,
     private val preferences: NetworkPreferences,
+    // KMK -->
+    val delegateSourcePreferences: DelegateSourcePreferences,
+    // KMK <--
 ) {
 
     /* SY --> */ open /* SY <-- */val cookieJar = AndroidCookieJar()
+
+    // KMK -->
+    private val delegatedSourcesEnabled = delegateSourcePreferences.delegateSources().get()
+    // KMK <--
 
     /**
      * Timeout in unit of seconds.
@@ -88,18 +96,23 @@ import kotlin.random.Random
             .addInterceptor { chain ->
                 val originalRequest = chain.request()
                 val url = originalRequest.url
-                if (url.host == "uploads.mangadex.org" && url.encodedPath.startsWith("/covers/")) {
-                    val newRequest = originalRequest
-                        .newBuilder()
-                        .header("Referer", "https://mangadex.org/")
-                        .header("Origin", "https://mangadex.org")
-                        .header("sec-fetch-dest", "image")
-                        .header("sec-fetch-mode", "no-cors")
-                        .build()
-                    chain.proceed(newRequest)
-                } else {
-                    chain.proceed(originalRequest)
+
+                if (!delegatedSourcesEnabled ||
+                    url.host != "uploads.mangadex.org" ||
+                    !url.encodedPath.startsWith("/covers/")
+                ) {
+                    return@addInterceptor chain.proceed(originalRequest)
                 }
+
+                val newRequest = originalRequest
+                    .newBuilder()
+                    .header("Referer", "https://mangadex.org/")
+                    .header("Origin", "https://mangadex.org")
+                    .header("sec-fetch-dest", "image")
+                    .header("sec-fetch-mode", "no-cors")
+                    .build()
+
+                chain.proceed(newRequest)
             }
             // KMK <--
             .build()

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/online/HttpSource.kt
@@ -39,7 +39,7 @@ abstract class HttpSource : CatalogueSource {
     // SY -->
     protected val network: NetworkHelper by lazy {
         val network = Injekt.get<NetworkHelper>()
-        object : NetworkHelper(Injekt.get<Application>(), Injekt.get()) {
+        object : NetworkHelper(Injekt.get<Application>(), Injekt.get(), network.delegateSourcePreferences) {
             override val client: OkHttpClient
                 get() = delegate?.networkHttpClient ?: network.client
                     .newBuilder()


### PR DESCRIPTION
## Summary by Sourcery

Make MangaDex cover image network handling conditional on delegate source preferences.

Enhancements:
- Add delegate source preferences support to NetworkHelper to toggle MangaDex cover request headers based on delegated source enablement.
- Update DI wiring to provide DelegateSourcePreferences when constructing NetworkHelper.