### PR TITLE
fix(logging): Prevent app crashes from logging before XLog initialization

### DIFF
--- a/app/src/main/java/exh/GalleryAdder.kt
+++ b/app/src/main/java/exh/GalleryAdder.kt
@@ -2,11 +2,11 @@ package exh
 
 import android.content.Context
 import androidx.core.net.toUri
-import com.elvishew.xlog.Logger
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.source.online.UrlImportableSource
 import eu.kanade.tachiyomi.source.online.all.EHentai
+import exh.log.ResettableLogger
 import exh.log.safeXLogStackTag
 import exh.source.getMainSource
 import mihon.domain.source.interactor.UpdateMangaFromRemote
@@ -38,13 +38,7 @@ class GalleryAdder(
         get() = second
 
     // KMK -->
-    private var logger: Logger? = safeXLogStackTag()
-    private fun logger(): Logger? {
-        return logger ?: run {
-            logger = safeXLogStackTag()
-            logger
-        }
-    }
+    private val logger = ResettableLogger { safeXLogStackTag() }
     // KMK <--
 
     fun pickSource(url: String): List<UrlImportableSource> {

--- a/app/src/main/java/exh/GalleryAdder.kt
+++ b/app/src/main/java/exh/GalleryAdder.kt
@@ -2,11 +2,12 @@ package exh
 
 import android.content.Context
 import androidx.core.net.toUri
+import com.elvishew.xlog.Logger
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.source.online.UrlImportableSource
 import eu.kanade.tachiyomi.source.online.all.EHentai
-import exh.log.xLogStack
+import exh.log.safeXLogStackTag
 import exh.source.getMainSource
 import mihon.domain.source.interactor.UpdateMangaFromRemote
 import tachiyomi.core.common.i18n.stringResource
@@ -36,7 +37,15 @@ class GalleryAdder(
     private val Pair<Set<String>, Set<Long>>.disabledSources
         get() = second
 
-    private val logger = xLogStack()
+    // KMK -->
+    private var logger: Logger? = safeXLogStackTag()
+    private fun logger(): Logger? {
+        return logger ?: run {
+            logger = safeXLogStackTag()
+            logger
+        }
+    }
+    // KMK <--
 
     fun pickSource(url: String): List<UrlImportableSource> {
         val uri = url.toUri()
@@ -61,7 +70,7 @@ class GalleryAdder(
         throttleFunc: suspend () -> Unit = {},
         retry: Int = 1,
     ): GalleryAddEvent {
-        logger.d(context.stringResource(SYMR.strings.gallery_adder_importing_gallery, url, fav.toString(), forceSource?.toString().orEmpty()))
+        logger()?.d(context.stringResource(SYMR.strings.gallery_adder_importing_gallery, url, fav.toString(), forceSource?.toString().orEmpty()))
         try {
             val uri = url.toUri()
 
@@ -74,7 +83,7 @@ class GalleryAdder(
                         return GalleryAddEvent.Fail.UnknownSource(url, context)
                     }
                 } catch (e: Exception) {
-                    logger.e(context.stringResource(SYMR.strings.gallery_adder_source_uri_must_match), e)
+                    logger()?.e(context.stringResource(SYMR.strings.gallery_adder_source_uri_must_match), e)
                     return GalleryAddEvent.Fail.UnknownType(url, context)
                 }
             } else {
@@ -94,7 +103,7 @@ class GalleryAdder(
             val realChapterUrl = try {
                 source.mapUrlToChapterUrl(uri)
             } catch (e: Exception) {
-                logger.e(context.stringResource(SYMR.strings.gallery_adder_uri_map_to_chapter_error), e)
+                logger()?.e(context.stringResource(SYMR.strings.gallery_adder_uri_map_to_chapter_error), e)
                 null
             }
 
@@ -102,7 +111,7 @@ class GalleryAdder(
                 try {
                     source.cleanChapterUrl(realChapterUrl)
                 } catch (e: Exception) {
-                    logger.e(context.stringResource(SYMR.strings.gallery_adder_uri_clean_error), e)
+                    logger()?.e(context.stringResource(SYMR.strings.gallery_adder_uri_clean_error), e)
                     null
                 }
             } else {
@@ -119,7 +128,7 @@ class GalleryAdder(
             val realMangaUrl = try {
                 chapterMangaUrl ?: source.mapUrlToMangaUrl(uri)
             } catch (e: Exception) {
-                logger.e(context.stringResource(SYMR.strings.gallery_adder_uri_map_to_gallery_error), e)
+                logger()?.e(context.stringResource(SYMR.strings.gallery_adder_uri_map_to_gallery_error), e)
                 null
             } ?: return GalleryAddEvent.Fail.UnknownType(url, context)
 
@@ -127,7 +136,7 @@ class GalleryAdder(
             val cleanedMangaUrl = try {
                 source.cleanMangaUrl(realMangaUrl)
             } catch (e: Exception) {
-                logger.e(context.stringResource(SYMR.strings.gallery_adder_uri_clean_error), e)
+                logger()?.e(context.stringResource(SYMR.strings.gallery_adder_uri_clean_error), e)
                 null
             } ?: return GalleryAddEvent.Fail.UnknownType(url, context)
 
@@ -165,7 +174,7 @@ class GalleryAdder(
                 GalleryAddEvent.Success(url, manga, context)
             }
         } catch (e: Exception) {
-            logger.w(context.stringResource(SYMR.strings.gallery_adder_could_not_add_gallery, url), e)
+            logger()?.w(context.stringResource(SYMR.strings.gallery_adder_could_not_add_gallery, url), e)
 
             if (e is EHentai.GalleryNotFoundException) {
                 return GalleryAddEvent.Fail.NotFound(url, context)

--- a/app/src/main/java/exh/eh/EHentaiUpdateWorker.kt
+++ b/app/src/main/java/exh/eh/EHentaiUpdateWorker.kt
@@ -14,7 +14,6 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkerParameters
-import com.elvishew.xlog.Logger
 import eu.kanade.tachiyomi.data.library.LibraryUpdateNotifier
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.source.online.all.EHentai
@@ -23,6 +22,7 @@ import eu.kanade.tachiyomi.util.system.setForegroundSafely
 import eu.kanade.tachiyomi.util.system.workManager
 import exh.debug.DebugToggles
 import exh.eh.EHentaiUpdateWorkerConstants.UPDATES_PER_ITERATION
+import exh.log.ResettableLogger
 import exh.log.safeXLogTag
 import exh.metadata.metadata.EHentaiSearchMetadata
 import exh.source.ExhPreferences
@@ -270,13 +270,7 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
         private const val TAG = "EHBackgroundUpdater"
 
         // KMK -->
-        private var logger: Logger? = safeXLogTag()
-        private fun logger(): Logger? {
-            return logger ?: run {
-                logger = safeXLogTag()
-                logger
-            }
-        }
+        private val logger = ResettableLogger { safeXLogTag() }
         // KMK <--
 
         fun launchBackgroundTest(context: Context) {

--- a/app/src/main/java/exh/eh/EHentaiUpdateWorker.kt
+++ b/app/src/main/java/exh/eh/EHentaiUpdateWorker.kt
@@ -15,7 +15,6 @@ import androidx.work.OutOfQuotaPolicy
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkerParameters
 import com.elvishew.xlog.Logger
-import com.elvishew.xlog.XLog
 import eu.kanade.tachiyomi.data.library.LibraryUpdateNotifier
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.source.online.all.EHentai
@@ -24,7 +23,7 @@ import eu.kanade.tachiyomi.util.system.setForegroundSafely
 import eu.kanade.tachiyomi.util.system.workManager
 import exh.debug.DebugToggles
 import exh.eh.EHentaiUpdateWorkerConstants.UPDATES_PER_ITERATION
-import exh.log.xLog
+import exh.log.safeXLogTag
 import exh.metadata.metadata.EHentaiSearchMetadata
 import exh.source.ExhPreferences
 import exh.util.cancellable
@@ -57,7 +56,6 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
     private val libraryPreferences: LibraryPreferences by injectLazy()
     private val sourceManager: SourceManager by injectLazy()
     private val updateHelper: EHentaiUpdateHelper by injectLazy()
-    private val logger: Logger by lazy { xLog() }
     private val updateMangaFromRemote: UpdateMangaFromRemote by injectLazy()
     private val getChaptersByMangaId: GetChaptersByMangaId by injectLazy()
     private val getFlatMetadataById: GetFlatMetadataById by injectLazy()
@@ -73,16 +71,16 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
                 requiresWifiConnection(exhPreferences) &&
                 !context.isConnectedToWifi()
             ) {
-                logger.d("Retry again later in next periodic run due to missing Wi-Fi connection...")
+                logger()?.d("Retry again later in next periodic run due to missing Wi-Fi connection...")
                 Result.success() // retry again later in next periodic run
             } else {
                 setForegroundSafely()
                 startUpdating()
-                logger.d("Update job completed!")
+                logger()?.d("Update job completed!")
                 Result.success()
             }
         } catch (e: Exception) {
-            logger.d("Retry again later in next periodic run!", e)
+            logger()?.d("Retry again later in next periodic run!", e)
             Result.success() // retry again later in next periodic run
         } finally {
             updateNotifier.cancelProgressNotification()
@@ -102,13 +100,13 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
     }
 
     private suspend fun startUpdating() {
-        logger.d("Update job started!")
+        logger()?.d("Update job started!")
         val startTime = System.currentTimeMillis()
 
-        logger.d("Finding manga with metadata...")
+        logger()?.d("Finding manga with metadata...")
         val metadataManga = getExhFavoriteMangaWithMetadata.await()
 
-        logger.d("Filtering manga and raising metadata...")
+        logger()?.d("Filtering manga and raising metadata...")
         val curTime = System.currentTimeMillis()
         val allMeta = metadataManga.asFlow().cancellable().mapNotNull { manga ->
             val meta = getFlatMetadataById.await(manga.id)
@@ -133,7 +131,7 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
             UpdateEntry(manga, raisedMeta, chapter)
         }.toList().sortedBy { it.meta.lastUpdateCheck }
 
-        logger.d("Found %s manga to update, starting updates!", allMeta.size)
+        logger()?.d("Found %s manga to update, starting updates!", allMeta.size)
         val mangaMetaToUpdateThisIter = allMeta.take(UPDATES_PER_ITERATION)
 
         var failuresThisIteration = 0
@@ -145,11 +143,11 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
             for ((index, entry) in mangaMetaToUpdateThisIter.withIndex()) {
                 val (manga, meta) = entry
                 if (failuresThisIteration > MAX_UPDATE_FAILURES) {
-                    logger.w("Too many update failures, aborting...")
+                    logger()?.w("Too many update failures, aborting...")
                     break
                 }
 
-                logger.d(
+                logger()?.d(
                     "Updating gallery (index: %s, manga.id: %s, meta.gId: %s, meta.gToken: %s, failures-so-far: %s, modifiedThisIteration.size: %s)...",
                     index,
                     manga.id,
@@ -161,7 +159,7 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
 
                 if (manga.id in modifiedThisIteration) {
                     // We already processed this manga!
-                    logger.w("Gallery already updated this iteration, skipping...")
+                    logger()?.w("Gallery already updated this iteration, skipping...")
                     updatedThisIteration++
                     continue
                 }
@@ -177,8 +175,8 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
                     if (e.network) {
                         failuresThisIteration++
 
-                        logger.e("> Network error while updating gallery!", e)
-                        logger.e(
+                        logger()?.e("> Network error while updating gallery!", e)
+                        logger()?.e(
                             "> (manga.id: %s, meta.gId: %s, meta.gToken: %s, failures-so-far: %s)",
                             manga.id,
                             meta.gId,
@@ -191,7 +189,7 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
                 }
 
                 if (chapters.isEmpty()) {
-                    logger.e(
+                    logger()?.e(
                         "No chapters found for gallery (manga.id: %s, meta.gId: %s, meta.gToken: %s, failures-so-far: %s)!",
                         manga.id,
                         meta.gId,
@@ -254,7 +252,7 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
                 val meta = getFlatMetadataById.await(manga.id)?.raise<EHentaiSearchMetadata>()
                 if (meta != null) {
                     // Age dead galleries
-                    logger.d("Aged %s - notfound", manga.id)
+                    logger()?.d("Aged %s - notfound", manga.id)
                     meta.aged = true
                     insertFlatMetadata.await(meta)
                 }
@@ -271,7 +269,15 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
 
         private const val TAG = "EHBackgroundUpdater"
 
-        private val logger by lazy { XLog.tag("EHUpdaterScheduler") }
+        // KMK -->
+        private var logger: Logger? = safeXLogTag()
+        private fun logger(): Logger? {
+            return logger ?: run {
+                logger = safeXLogTag()
+                logger
+            }
+        }
+        // KMK <--
 
         fun launchBackgroundTest(context: Context) {
             context.workManager.enqueue(
@@ -321,7 +327,7 @@ class EHentaiUpdateWorker(private val context: Context, workerParams: WorkerPara
                     .build()
 
                 context.workManager.enqueueUniquePeriodicWork(TAG, ExistingPeriodicWorkPolicy.UPDATE, request)
-                logger.d("Successfully scheduled background update job!")
+                logger()?.d("Successfully scheduled background update job!")
             } else {
                 cancelBackground(context)
             }

--- a/app/src/main/java/exh/favorites/FavoritesSyncHelper.kt
+++ b/app/src/main/java/exh/favorites/FavoritesSyncHelper.kt
@@ -3,7 +3,6 @@ package exh.favorites
 import android.content.Context
 import android.net.wifi.WifiManager
 import android.os.PowerManager
-import com.elvishew.xlog.Logger
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
@@ -12,6 +11,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import exh.GalleryAddEvent
 import exh.GalleryAdder
 import exh.eh.EHentaiUpdateWorker
+import exh.log.ResettableLogger
 import exh.log.safeXLogTag
 import exh.source.EH_SOURCE_ID
 import exh.source.EXH_SOURCE_ID
@@ -75,13 +75,7 @@ class FavoritesSyncHelper(val context: Context) {
     private var wakeLock: PowerManager.WakeLock? = null
 
     // KMK -->
-    private var logger: Logger? = safeXLogTag()
-    private fun logger(): Logger? {
-        return logger ?: run {
-            logger = safeXLogTag()
-            logger
-        }
-    }
+    private val logger = ResettableLogger { safeXLogTag() }
     // KMK <--
 
     val status: MutableStateFlow<FavoritesSyncStatus> = MutableStateFlow(FavoritesSyncStatus.Idle)

--- a/app/src/main/java/exh/favorites/FavoritesSyncHelper.kt
+++ b/app/src/main/java/exh/favorites/FavoritesSyncHelper.kt
@@ -3,6 +3,7 @@ package exh.favorites
 import android.content.Context
 import android.net.wifi.WifiManager
 import android.os.PowerManager
+import com.elvishew.xlog.Logger
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.await
@@ -11,7 +12,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import exh.GalleryAddEvent
 import exh.GalleryAdder
 import exh.eh.EHentaiUpdateWorker
-import exh.log.xLog
+import exh.log.safeXLogTag
 import exh.source.EH_SOURCE_ID
 import exh.source.EXH_SOURCE_ID
 import exh.source.ExhPreferences
@@ -73,7 +74,15 @@ class FavoritesSyncHelper(val context: Context) {
     private var wifiLock: WifiManager.WifiLock? = null
     private var wakeLock: PowerManager.WakeLock? = null
 
-    private val logger by lazy { xLog() }
+    // KMK -->
+    private var logger: Logger? = safeXLogTag()
+    private fun logger(): Logger? {
+        return logger ?: run {
+            logger = safeXLogTag()
+            logger
+        }
+    }
+    // KMK <--
 
     val status: MutableStateFlow<FavoritesSyncStatus> = MutableStateFlow(FavoritesSyncStatus.Idle)
 
@@ -107,7 +116,7 @@ class FavoritesSyncHelper(val context: Context) {
                 status.value = FavoritesSyncStatus.BadLibraryState
                     .MangaInMultipleCategories(manga.id, manga.title, inCategories.map { it.name })
 
-                logger.w(context.stringResource(SYMR.strings.favorites_sync_gallery_multiple_categories_error, manga.id))
+                logger()?.w(context.stringResource(SYMR.strings.favorites_sync_gallery_multiple_categories_error, manga.id))
                 return
             } else {
                 seenManga += manga.id
@@ -120,7 +129,7 @@ class FavoritesSyncHelper(val context: Context) {
             exh.fetchFavorites()
         } catch (e: Exception) {
             status.value = FavoritesSyncStatus.SyncError.FailedToFetchFavorites
-            logger.e(context.stringResource(SYMR.strings.favorites_sync_could_not_fetch), e)
+            logger()?.e(context.stringResource(SYMR.strings.favorites_sync_could_not_fetch), e)
             return
         }
 
@@ -163,11 +172,11 @@ class FavoritesSyncHelper(val context: Context) {
             }
         } catch (e: IgnoredException) {
             // Do not display error as this error has already been reported
-            logger.w(context.stringResource(SYMR.strings.favorites_sync_ignoring_exception), e)
+            logger()?.w(context.stringResource(SYMR.strings.favorites_sync_ignoring_exception), e)
             return
         } catch (e: Exception) {
             status.value = FavoritesSyncStatus.SyncError.UnknownSyncError(e.message.orEmpty())
-            logger.e(context.stringResource(SYMR.strings.favorites_sync_sync_error), e)
+            logger()?.e(context.stringResource(SYMR.strings.favorites_sync_sync_error), e)
             return
         } finally {
             // Release wake + wifi locks
@@ -259,7 +268,7 @@ class FavoritesSyncHelper(val context: Context) {
                     break
                 }
             } catch (e: Exception) {
-                logger.w(context.stringResource(SYMR.strings.favorites_sync_network_error), e)
+                logger()?.w(context.stringResource(SYMR.strings.favorites_sync_network_error), e)
             }
         }
 
@@ -375,7 +384,7 @@ class FavoritesSyncHelper(val context: Context) {
 
             if (result is GalleryAddEvent.Fail) {
                 if (result is GalleryAddEvent.Fail.NotFound) {
-                    logger.e(context.stringResource(SYMR.strings.favorites_sync_remote_not_exist, it.getUrl()))
+                    logger()?.e(context.stringResource(SYMR.strings.favorites_sync_remote_not_exist, it.getUrl()))
                     // Skip this gallery, it no longer exists
                     return@forEachIndexed
                 }

--- a/app/src/main/java/exh/recs/batch/RecommendationSearchHelper.kt
+++ b/app/src/main/java/exh/recs/batch/RecommendationSearchHelper.kt
@@ -5,10 +5,11 @@ import android.net.wifi.WifiManager
 import android.os.PowerManager
 import androidx.annotation.StringRes
 import androidx.core.net.toUri
+import com.elvishew.xlog.Logger
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.source.model.SManga
-import exh.log.xLog
+import exh.log.safeXLogTag
 import exh.recs.sources.RecommendationPagingSource
 import exh.recs.sources.RecommendationSource
 import exh.recs.sources.TrackerRecommendationPagingSource
@@ -52,7 +53,15 @@ class RecommendationSearchHelper(val context: Context) {
 
     private val smartSearchEngine by lazy { SmartLibrarySearchEngine() }
 
-    private val logger by lazy { xLog() }
+    // KMK -->
+    private var logger: Logger? = safeXLogTag()
+    private fun logger(): Logger? {
+        return logger ?: run {
+            logger = safeXLogTag()
+            logger
+        }
+    }
+    // KMK <--
 
     val status: MutableStateFlow<SearchStatus> = MutableStateFlow(SearchStatus.Idle)
 
@@ -135,7 +144,7 @@ class RecommendationSearchHelper(val context: Context) {
                             }.results.addAll(mangas)
                         } catch (_: NoResultsException) {
                         } catch (e: Exception) {
-                            logger.e("Error while fetching recommendations for $recSourceId", e)
+                            logger()?.e("Error while fetching recommendations for $recSourceId", e)
                         }
                     }
                 }
@@ -172,7 +181,7 @@ class RecommendationSearchHelper(val context: Context) {
         } catch (_: CancellationException) {
         } catch (e: Exception) {
             status.value = SearchStatus.Error(e.message.orEmpty())
-            logger.e("Error during recommendation search", e)
+            logger()?.e("Error during recommendation search", e)
             return
         } finally {
             // Release wake + wifi locks

--- a/app/src/main/java/exh/recs/batch/RecommendationSearchHelper.kt
+++ b/app/src/main/java/exh/recs/batch/RecommendationSearchHelper.kt
@@ -5,10 +5,10 @@ import android.net.wifi.WifiManager
 import android.os.PowerManager
 import androidx.annotation.StringRes
 import androidx.core.net.toUri
-import com.elvishew.xlog.Logger
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.tachiyomi.source.model.SManga
+import exh.log.ResettableLogger
 import exh.log.safeXLogTag
 import exh.recs.sources.RecommendationPagingSource
 import exh.recs.sources.RecommendationSource
@@ -54,13 +54,7 @@ class RecommendationSearchHelper(val context: Context) {
     private val smartSearchEngine by lazy { SmartLibrarySearchEngine() }
 
     // KMK -->
-    private var logger: Logger? = safeXLogTag()
-    private fun logger(): Logger? {
-        return logger ?: run {
-            logger = safeXLogTag()
-            logger
-        }
-    }
+    private val logger = ResettableLogger { safeXLogTag() }
     // KMK <--
 
     val status: MutableStateFlow<SearchStatus> = MutableStateFlow(SearchStatus.Idle)

--- a/core/common/src/main/kotlin/exh/log/Logging.kt
+++ b/core/common/src/main/kotlin/exh/log/Logging.kt
@@ -5,9 +5,9 @@ import com.elvishew.xlog.Logger
 import com.elvishew.xlog.XLog
 import com.elvishew.xlog.LogLevel as XLogLevel
 
-fun Any.xLog(): Logger = XLog.tag(this::class.java.simpleName).build()
+private fun Any.xLog(): Logger = XLog.tag(this::class.java.simpleName).build()
 
-fun Any.xLogStack(): Logger = XLog.tag(this::class.java.simpleName).enableStackTrace(0).build()
+private fun Any.xLogStack(): Logger = XLog.tag(this::class.java.simpleName).enableStackTrace(0).build()
 
 // KMK -->
 /**
@@ -35,6 +35,24 @@ private inline fun Any.safeXLog(androidLevel: Int, log: Any?, e: Throwable, bloc
 
 private fun formatSafely(format: String, args: Array<out Any?>): String =
     runCatching { String.format(format, *args) }.getOrDefault(format)
+
+/**
+ * Safe variant of `XLog.tag(tag).build()`, for callers that need to cache a [Logger] instance
+ * (e.g. a lazy property on a singleton/worker) instead of using the [xLogE]/[xLogW]/[xLogD]/[xLogI]
+ * convenience functions above. Returns null instead of throwing if accessed before [XLog.init],
+ * so callers should use `logger?.d(...)` rather than assuming a non-null [Logger].
+ */
+fun Any.safeXLogTag(tag: String = this::class.java.simpleName): Logger? = try {
+    XLog.tag(tag).build()
+} catch (_: IllegalStateException) {
+    null
+}
+
+fun Any.safeXLogStackTag(tag: String = this::class.java.simpleName): Logger? = try {
+    XLog.tag(tag).enableStackTrace(0).build()
+} catch (_: IllegalStateException) {
+    null
+}
 // KMK <--
 
 fun Any.xLogE(log: String) = safeXLog(Log.ERROR, log) { xLog().e(log) }

--- a/core/common/src/main/kotlin/exh/log/Logging.kt
+++ b/core/common/src/main/kotlin/exh/log/Logging.kt
@@ -41,7 +41,10 @@ fun Any.xLogE(log: String) = safeXLog(Log.ERROR, log) { xLog().e(log) }
 fun Any.xLogW(log: String) = safeXLog(Log.WARN, log) { xLog().w(log) }
 fun Any.xLogD(log: String) = safeXLog(Log.DEBUG, log) { xLog().d(log) }
 fun Any.xLogI(log: String) = safeXLog(Log.INFO, log) { xLog().i(log) }
-fun Any.xLog(logLevel: LogLevel, log: String) = safeXLog(logLevel.androidLevel, log) { xLog().log(logLevel.int, log) }
+fun Any.xLog(logLevel: LogLevel, log: String) {
+    if (logLevel is LogLevel.None) return
+    safeXLog(logLevel.androidLevel, log) { xLog().log(logLevel.int, log) }
+}
 fun Any.xLogJson(log: String) = safeXLog(Log.DEBUG, log) { xLog().json(log) }
 fun Any.xLogXML(log: String) = safeXLog(Log.DEBUG, log) { xLog().xml(log) }
 
@@ -132,5 +135,7 @@ fun Any.xLogD(log: Throwable) = safeXLog(Log.DEBUG, log.toString(), log) { xLogS
 fun Any.xLogI(log: Throwable) = safeXLog(Log.INFO, log.toString(), log) { xLogStack().i(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLog(logLevel, "", log)"""))
-fun Any.xLog(logLevel: LogLevel, log: Throwable) =
+fun Any.xLog(logLevel: LogLevel, log: Throwable) {
+    if (logLevel is LogLevel.None) return
     safeXLog(logLevel.androidLevel, log.toString(), log) { xLogStack().log(logLevel.int, log) }
+}

--- a/core/common/src/main/kotlin/exh/log/Logging.kt
+++ b/core/common/src/main/kotlin/exh/log/Logging.kt
@@ -42,13 +42,13 @@ private fun formatSafely(format: String, args: Array<out Any?>): String =
  * convenience functions above. Returns null instead of throwing if accessed before [XLog.init],
  * so callers should use `logger?.d(...)` rather than assuming a non-null [Logger].
  */
-fun Any.safeXLogTag(tag: String = this::class.java.simpleName): Logger? = try {
+fun Any.safeXLogTag(tag: String = (this::class.java.enclosingClass?.simpleName ?: this::class.java.simpleName)): Logger? = try {
     XLog.tag(tag).build()
 } catch (_: IllegalStateException) {
     null
 }
 
-fun Any.safeXLogStackTag(tag: String = this::class.java.simpleName): Logger? = try {
+fun Any.safeXLogStackTag(tag: String = (this::class.java.enclosingClass?.simpleName ?: this::class.java.simpleName)): Logger? = try {
     XLog.tag(tag).enableStackTrace(0).build()
 } catch (_: IllegalStateException) {
     null
@@ -70,8 +70,10 @@ fun Any.xLogE(log: String, e: Throwable) = safeXLog(Log.ERROR, log, e) { xLogSta
 fun Any.xLogW(log: String, e: Throwable) = safeXLog(Log.WARN, log, e) { xLogStack().w(log, e) }
 fun Any.xLogD(log: String, e: Throwable) = safeXLog(Log.DEBUG, log, e) { xLogStack().d(log, e) }
 fun Any.xLogI(log: String, e: Throwable) = safeXLog(Log.INFO, log, e) { xLogStack().i(log, e) }
-fun Any.xLog(logLevel: LogLevel, log: String, e: Throwable) =
+fun Any.xLog(logLevel: LogLevel, log: String, e: Throwable) {
+    if (logLevel is LogLevel.None) return
     safeXLog(logLevel.androidLevel, log, e) { xLogStack().log(logLevel.int, log, e) }
+}
 
 fun Any.xLogE(log: Any?) = safeXLog(Log.ERROR, log) { xLog().let { if (log == null) it.e("null") else it.e(log) } }
 fun Any.xLogW(log: Any?) = safeXLog(Log.WARN, log) { xLog().let { if (log == null) it.w("null") else it.w(log) } }

--- a/core/common/src/main/kotlin/exh/log/Logging.kt
+++ b/core/common/src/main/kotlin/exh/log/Logging.kt
@@ -14,38 +14,54 @@ fun Any.xLogStack(): Logger = XLog.tag(this::class.java.simpleName).enableStackT
  * XLog.init() runs during App#onCreate, but DI can eagerly construct components (e.g.
  * AndroidSourceManager) whose async init blocks log before that point, or before it re-runs after
  * an early startup crash. XLog throws IllegalStateException from any tag()/build() call made
- * before init() — swallow that here instead of crashing the app over a debug log line.
+ * before init() — swallow that here instead of crashing the app over a debug log line, but still
+ * surface the message via android.util.Log so it isn't lost entirely.
  */
-private inline fun safeXLog(block: () -> Unit) {
+private inline fun Any.safeXLog(androidLevel: Int, log: Any?, block: () -> Unit) {
     try {
         block()
     } catch (_: IllegalStateException) {
+        Log.println(androidLevel, this::class.java.simpleName, log.toString())
     }
 }
+
+private inline fun Any.safeXLog(androidLevel: Int, log: Any?, e: Throwable, block: () -> Unit) {
+    try {
+        block()
+    } catch (_: IllegalStateException) {
+        Log.println(androidLevel, this::class.java.simpleName, log.toString() + "\n" + Log.getStackTraceString(e))
+    }
+}
+
+private fun formatSafely(format: String, args: Array<out Any?>): String =
+    runCatching { String.format(format, *args) }.getOrDefault(format)
 // KMK <--
 
-fun Any.xLogE(log: String) = safeXLog { xLog().e(log) }
-fun Any.xLogW(log: String) = safeXLog { xLog().w(log) }
-fun Any.xLogD(log: String) = safeXLog { xLog().d(log) }
-fun Any.xLogI(log: String) = safeXLog { xLog().i(log) }
-fun Any.xLog(logLevel: LogLevel, log: String) = safeXLog { xLog().log(logLevel.int, log) }
-fun Any.xLogJson(log: String) = safeXLog { xLog().json(log) }
-fun Any.xLogXML(log: String) = safeXLog { xLog().xml(log) }
+fun Any.xLogE(log: String) = safeXLog(Log.ERROR, log) { xLog().e(log) }
+fun Any.xLogW(log: String) = safeXLog(Log.WARN, log) { xLog().w(log) }
+fun Any.xLogD(log: String) = safeXLog(Log.DEBUG, log) { xLog().d(log) }
+fun Any.xLogI(log: String) = safeXLog(Log.INFO, log) { xLog().i(log) }
+fun Any.xLog(logLevel: LogLevel, log: String) = safeXLog(logLevel.androidLevel, log) { xLog().log(logLevel.int, log) }
+fun Any.xLogJson(log: String) = safeXLog(Log.DEBUG, log) { xLog().json(log) }
+fun Any.xLogXML(log: String) = safeXLog(Log.DEBUG, log) { xLog().xml(log) }
 
-fun Any.xLogE(log: String, e: Throwable) = safeXLog { xLogStack().e(log, e) }
-fun Any.xLogW(log: String, e: Throwable) = safeXLog { xLogStack().w(log, e) }
-fun Any.xLogD(log: String, e: Throwable) = safeXLog { xLogStack().d(log, e) }
-fun Any.xLogI(log: String, e: Throwable) = safeXLog { xLogStack().i(log, e) }
-fun Any.xLog(logLevel: LogLevel, log: String, e: Throwable) = safeXLog { xLogStack().log(logLevel.int, log, e) }
+fun Any.xLogE(log: String, e: Throwable) = safeXLog(Log.ERROR, log, e) { xLogStack().e(log, e) }
+fun Any.xLogW(log: String, e: Throwable) = safeXLog(Log.WARN, log, e) { xLogStack().w(log, e) }
+fun Any.xLogD(log: String, e: Throwable) = safeXLog(Log.DEBUG, log, e) { xLogStack().d(log, e) }
+fun Any.xLogI(log: String, e: Throwable) = safeXLog(Log.INFO, log, e) { xLogStack().i(log, e) }
+fun Any.xLog(logLevel: LogLevel, log: String, e: Throwable) =
+    safeXLog(logLevel.androidLevel, log, e) { xLogStack().log(logLevel.int, log, e) }
 
-fun Any.xLogE(log: Any?) = safeXLog { xLog().let { if (log == null) it.e("null") else it.e(log) } }
-fun Any.xLogW(log: Any?) = safeXLog { xLog().let { if (log == null) it.w("null") else it.w(log) } }
-fun Any.xLogD(log: Any?) = safeXLog { xLog().let { if (log == null) it.d("null") else it.d(log) } }
-fun Any.xLogI(log: Any?) = safeXLog { xLog().let { if (log == null) it.i("null") else it.i(log) } }
+fun Any.xLogE(log: Any?) = safeXLog(Log.ERROR, log) { xLog().let { if (log == null) it.e("null") else it.e(log) } }
+fun Any.xLogW(log: Any?) = safeXLog(Log.WARN, log) { xLog().let { if (log == null) it.w("null") else it.w(log) } }
+fun Any.xLogD(log: Any?) = safeXLog(Log.DEBUG, log) { xLog().let { if (log == null) it.d("null") else it.d(log) } }
+fun Any.xLogI(log: Any?) = safeXLog(Log.INFO, log) { xLog().let { if (log == null) it.i("null") else it.i(log) } }
 fun Any.xLog(
     logLevel: LogLevel,
     log: Any?,
-) = safeXLog { xLog().let { if (log == null) it.log(logLevel.int, "null") else it.log(logLevel.int, log) } }
+) = safeXLog(logLevel.androidLevel, log) {
+    xLog().let { if (log == null) it.log(logLevel.int, "null") else it.log(logLevel.int, log) }
+}
 
 /*fun Any.xLogE(vararg logs: Any) = xLog().e(logs)
 fun Any.xLogW(vararg logs: Any) = xLog().w(logs)
@@ -53,11 +69,16 @@ fun Any.xLogD(vararg logs: Any) = xLog().d(logs)
 fun Any.xLogI(vararg logs: Any) = xLog().i(logs)
 fun Any.xLog(logLevel: LogLevel, vararg logs: Any) = xLog().log(logLevel.int, logs)*/
 
-fun Any.xLogE(format: String, vararg args: Any?) = safeXLog { xLog().e(format, *args) }
-fun Any.xLogW(format: String, vararg args: Any?) = safeXLog { xLog().w(format, *args) }
-fun Any.xLogD(format: String, vararg args: Any?) = safeXLog { xLog().d(format, *args) }
-fun Any.xLogI(format: String, vararg args: Any?) = safeXLog { xLog().i(format, *args) }
-fun Any.xLog(logLevel: LogLevel, format: String, vararg args: Any) = safeXLog { xLog().log(logLevel.int, format, *args) }
+fun Any.xLogE(format: String, vararg args: Any?) =
+    safeXLog(Log.ERROR, formatSafely(format, args)) { xLog().e(format, *args) }
+fun Any.xLogW(format: String, vararg args: Any?) =
+    safeXLog(Log.WARN, formatSafely(format, args)) { xLog().w(format, *args) }
+fun Any.xLogD(format: String, vararg args: Any?) =
+    safeXLog(Log.DEBUG, formatSafely(format, args)) { xLog().d(format, *args) }
+fun Any.xLogI(format: String, vararg args: Any?) =
+    safeXLog(Log.INFO, formatSafely(format, args)) { xLog().i(format, *args) }
+fun Any.xLog(logLevel: LogLevel, format: String, vararg args: Any) =
+    safeXLog(logLevel.androidLevel, formatSafely(format, args)) { xLog().log(logLevel.int, format, *args) }
 
 sealed class LogLevel(val int: Int, val androidLevel: Int) {
     object None : LogLevel(XLogLevel.NONE, Log.ASSERT)
@@ -88,16 +109,17 @@ sealed class LogLevel(val int: Int, val androidLevel: Int) {
 }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLogE("", log)"""))
-fun Any.xLogE(log: Throwable) = safeXLog { xLogStack().e(log) }
+fun Any.xLogE(log: Throwable) = safeXLog(Log.ERROR, log.toString(), log) { xLogStack().e(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLogW("", log)"""))
-fun Any.xLogW(log: Throwable) = safeXLog { xLogStack().w(log) }
+fun Any.xLogW(log: Throwable) = safeXLog(Log.WARN, log.toString(), log) { xLogStack().w(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLogD("", log)"""))
-fun Any.xLogD(log: Throwable) = safeXLog { xLogStack().d(log) }
+fun Any.xLogD(log: Throwable) = safeXLog(Log.DEBUG, log.toString(), log) { xLogStack().d(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLogI("", log)"""))
-fun Any.xLogI(log: Throwable) = safeXLog { xLogStack().i(log) }
+fun Any.xLogI(log: Throwable) = safeXLog(Log.INFO, log.toString(), log) { xLogStack().i(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLog(logLevel, "", log)"""))
-fun Any.xLog(logLevel: LogLevel, log: Throwable) = safeXLog { xLogStack().log(logLevel.int, log) }
+fun Any.xLog(logLevel: LogLevel, log: Throwable) =
+    safeXLog(logLevel.androidLevel, log.toString(), log) { xLogStack().log(logLevel.int, log) }

--- a/core/common/src/main/kotlin/exh/log/Logging.kt
+++ b/core/common/src/main/kotlin/exh/log/Logging.kt
@@ -69,16 +69,27 @@ fun Any.xLogD(vararg logs: Any) = xLog().d(logs)
 fun Any.xLogI(vararg logs: Any) = xLog().i(logs)
 fun Any.xLog(logLevel: LogLevel, vararg logs: Any) = xLog().log(logLevel.int, logs)*/
 
-fun Any.xLogE(format: String, vararg args: Any?) =
-    safeXLog(Log.ERROR, formatSafely(format, args)) { xLog().e(format, *args) }
-fun Any.xLogW(format: String, vararg args: Any?) =
-    safeXLog(Log.WARN, formatSafely(format, args)) { xLog().w(format, *args) }
-fun Any.xLogD(format: String, vararg args: Any?) =
-    safeXLog(Log.DEBUG, formatSafely(format, args)) { xLog().d(format, *args) }
-fun Any.xLogI(format: String, vararg args: Any?) =
-    safeXLog(Log.INFO, formatSafely(format, args)) { xLog().i(format, *args) }
-fun Any.xLog(logLevel: LogLevel, format: String, vararg args: Any) =
-    safeXLog(logLevel.androidLevel, formatSafely(format, args)) { xLog().log(logLevel.int, format, *args) }
+fun Any.xLogE(format: String, vararg args: Any?) {
+    val msg = formatSafely(format, args)
+    safeXLog(Log.ERROR, msg) { xLog().e(msg) }
+}
+fun Any.xLogW(format: String, vararg args: Any?) {
+    val msg = formatSafely(format, args)
+    safeXLog(Log.WARN, msg) { xLog().w(msg) }
+}
+fun Any.xLogD(format: String, vararg args: Any?) {
+    val msg = formatSafely(format, args)
+    safeXLog(Log.DEBUG, msg) { xLog().d(msg) }
+}
+fun Any.xLogI(format: String, vararg args: Any?) {
+    val msg = formatSafely(format, args)
+    safeXLog(Log.INFO, msg) { xLog().i(msg) }
+}
+fun Any.xLog(logLevel: LogLevel, format: String, vararg args: Any) {
+    if (logLevel is LogLevel.None) return
+    val msg = formatSafely(format, args)
+    safeXLog(logLevel.androidLevel, msg) { xLog().log(logLevel.int, msg) }
+}
 
 sealed class LogLevel(val int: Int, val androidLevel: Int) {
     object None : LogLevel(XLogLevel.NONE, Log.ASSERT)

--- a/core/common/src/main/kotlin/exh/log/Logging.kt
+++ b/core/common/src/main/kotlin/exh/log/Logging.kt
@@ -62,8 +62,11 @@ fun Any.xLogI(log: Any?) = safeXLog(Log.INFO, log) { xLog().let { if (log == nul
 fun Any.xLog(
     logLevel: LogLevel,
     log: Any?,
-) = safeXLog(logLevel.androidLevel, log) {
-    xLog().let { if (log == null) it.log(logLevel.int, "null") else it.log(logLevel.int, log) }
+) {
+    if (logLevel is LogLevel.None) return
+    safeXLog(logLevel.androidLevel, log) {
+        xLog().let { if (log == null) it.log(logLevel.int, "null") else it.log(logLevel.int, log) }
+    }
 }
 
 /*fun Any.xLogE(vararg logs: Any) = xLog().e(logs)

--- a/core/common/src/main/kotlin/exh/log/Logging.kt
+++ b/core/common/src/main/kotlin/exh/log/Logging.kt
@@ -9,28 +9,43 @@ fun Any.xLog(): Logger = XLog.tag(this::class.java.simpleName).build()
 
 fun Any.xLogStack(): Logger = XLog.tag(this::class.java.simpleName).enableStackTrace(0).build()
 
-fun Any.xLogE(log: String) = xLog().e(log)
-fun Any.xLogW(log: String) = xLog().w(log)
-fun Any.xLogD(log: String) = xLog().d(log)
-fun Any.xLogI(log: String) = xLog().i(log)
-fun Any.xLog(logLevel: LogLevel, log: String) = xLog().log(logLevel.int, log)
-fun Any.xLogJson(log: String) = xLog().json(log)
-fun Any.xLogXML(log: String) = xLog().xml(log)
+// KMK -->
+/**
+ * XLog.init() runs during App#onCreate, but DI can eagerly construct components (e.g.
+ * AndroidSourceManager) whose async init blocks log before that point, or before it re-runs after
+ * an early startup crash. XLog throws IllegalStateException from any tag()/build() call made
+ * before init() — swallow that here instead of crashing the app over a debug log line.
+ */
+private inline fun safeXLog(block: () -> Unit) {
+    try {
+        block()
+    } catch (_: IllegalStateException) {
+    }
+}
+// KMK <--
 
-fun Any.xLogE(log: String, e: Throwable) = xLogStack().e(log, e)
-fun Any.xLogW(log: String, e: Throwable) = xLogStack().w(log, e)
-fun Any.xLogD(log: String, e: Throwable) = xLogStack().d(log, e)
-fun Any.xLogI(log: String, e: Throwable) = xLogStack().i(log, e)
-fun Any.xLog(logLevel: LogLevel, log: String, e: Throwable) = xLogStack().log(logLevel.int, log, e)
+fun Any.xLogE(log: String) = safeXLog { xLog().e(log) }
+fun Any.xLogW(log: String) = safeXLog { xLog().w(log) }
+fun Any.xLogD(log: String) = safeXLog { xLog().d(log) }
+fun Any.xLogI(log: String) = safeXLog { xLog().i(log) }
+fun Any.xLog(logLevel: LogLevel, log: String) = safeXLog { xLog().log(logLevel.int, log) }
+fun Any.xLogJson(log: String) = safeXLog { xLog().json(log) }
+fun Any.xLogXML(log: String) = safeXLog { xLog().xml(log) }
 
-fun Any.xLogE(log: Any?) = xLog().let { if (log == null) it.e("null") else it.e(log) }
-fun Any.xLogW(log: Any?) = xLog().let { if (log == null) it.w("null") else it.w(log) }
-fun Any.xLogD(log: Any?) = xLog().let { if (log == null) it.d("null") else it.d(log) }
-fun Any.xLogI(log: Any?) = xLog().let { if (log == null) it.i("null") else it.i(log) }
+fun Any.xLogE(log: String, e: Throwable) = safeXLog { xLogStack().e(log, e) }
+fun Any.xLogW(log: String, e: Throwable) = safeXLog { xLogStack().w(log, e) }
+fun Any.xLogD(log: String, e: Throwable) = safeXLog { xLogStack().d(log, e) }
+fun Any.xLogI(log: String, e: Throwable) = safeXLog { xLogStack().i(log, e) }
+fun Any.xLog(logLevel: LogLevel, log: String, e: Throwable) = safeXLog { xLogStack().log(logLevel.int, log, e) }
+
+fun Any.xLogE(log: Any?) = safeXLog { xLog().let { if (log == null) it.e("null") else it.e(log) } }
+fun Any.xLogW(log: Any?) = safeXLog { xLog().let { if (log == null) it.w("null") else it.w(log) } }
+fun Any.xLogD(log: Any?) = safeXLog { xLog().let { if (log == null) it.d("null") else it.d(log) } }
+fun Any.xLogI(log: Any?) = safeXLog { xLog().let { if (log == null) it.i("null") else it.i(log) } }
 fun Any.xLog(
     logLevel: LogLevel,
     log: Any?,
-) = xLog().let { if (log == null) it.log(logLevel.int, "null") else it.log(logLevel.int, log) }
+) = safeXLog { xLog().let { if (log == null) it.log(logLevel.int, "null") else it.log(logLevel.int, log) } }
 
 /*fun Any.xLogE(vararg logs: Any) = xLog().e(logs)
 fun Any.xLogW(vararg logs: Any) = xLog().w(logs)
@@ -38,11 +53,11 @@ fun Any.xLogD(vararg logs: Any) = xLog().d(logs)
 fun Any.xLogI(vararg logs: Any) = xLog().i(logs)
 fun Any.xLog(logLevel: LogLevel, vararg logs: Any) = xLog().log(logLevel.int, logs)*/
 
-fun Any.xLogE(format: String, vararg args: Any?) = xLog().e(format, *args)
-fun Any.xLogW(format: String, vararg args: Any?) = xLog().w(format, *args)
-fun Any.xLogD(format: String, vararg args: Any?) = xLog().d(format, *args)
-fun Any.xLogI(format: String, vararg args: Any?) = xLog().i(format, *args)
-fun Any.xLog(logLevel: LogLevel, format: String, vararg args: Any) = xLog().log(logLevel.int, format, *args)
+fun Any.xLogE(format: String, vararg args: Any?) = safeXLog { xLog().e(format, *args) }
+fun Any.xLogW(format: String, vararg args: Any?) = safeXLog { xLog().w(format, *args) }
+fun Any.xLogD(format: String, vararg args: Any?) = safeXLog { xLog().d(format, *args) }
+fun Any.xLogI(format: String, vararg args: Any?) = safeXLog { xLog().i(format, *args) }
+fun Any.xLog(logLevel: LogLevel, format: String, vararg args: Any) = safeXLog { xLog().log(logLevel.int, format, *args) }
 
 sealed class LogLevel(val int: Int, val androidLevel: Int) {
     object None : LogLevel(XLogLevel.NONE, Log.ASSERT)
@@ -73,16 +88,16 @@ sealed class LogLevel(val int: Int, val androidLevel: Int) {
 }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLogE("", log)"""))
-fun Any.xLogE(log: Throwable) = xLogStack().e(log)
+fun Any.xLogE(log: Throwable) = safeXLog { xLogStack().e(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLogW("", log)"""))
-fun Any.xLogW(log: Throwable) = xLogStack().w(log)
+fun Any.xLogW(log: Throwable) = safeXLog { xLogStack().w(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLogD("", log)"""))
-fun Any.xLogD(log: Throwable) = xLogStack().d(log)
+fun Any.xLogD(log: Throwable) = safeXLog { xLogStack().d(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLogI("", log)"""))
-fun Any.xLogI(log: Throwable) = xLogStack().i(log)
+fun Any.xLogI(log: Throwable) = safeXLog { xLogStack().i(log) }
 
 @Deprecated("Use proper throwable function", ReplaceWith("""xLog(logLevel, "", log)"""))
-fun Any.xLog(logLevel: LogLevel, log: Throwable) = xLogStack().log(logLevel.int, log)
+fun Any.xLog(logLevel: LogLevel, log: Throwable) = safeXLog { xLogStack().log(logLevel.int, log) }

--- a/core/common/src/main/kotlin/exh/log/ResettableLogger.kt
+++ b/core/common/src/main/kotlin/exh/log/ResettableLogger.kt
@@ -1,0 +1,20 @@
+package exh.log
+
+import com.elvishew.xlog.Logger
+
+class ResettableLogger(private val resolver: () -> Logger?) {
+    private var logger: Logger? = null
+
+    @Synchronized
+    operator fun invoke(): Logger? {
+        return logger ?: run {
+            logger = resolver()
+            logger
+        }
+    }
+
+    @Synchronized
+    fun reset() {
+        logger = null
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Guard XLog usage against pre-initialization crashes and update callers to use safe, resettable loggers.

Bug Fixes:
- Prevent app crashes when logging before XLog is initialized by wrapping all logging calls in safe fallbacks that delegate to android.util.Log on failure.

Enhancements:
- Introduce safe logger factory helpers and a ResettableLogger wrapper for lazily caching XLog Logger instances that may need to be recreated after initialization or crashes.
- Skip emitting logs for LogLevel.None and add resilient formatting helpers for formatted log messages.