### PR TITLE
Replace @Contextual with @Transient for customMangaInfo in Manga model

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesTextArea.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesTextArea.kt
@@ -55,9 +55,6 @@ import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import kotlin.time.Duration.Companion.seconds
 
-private const val MAX_LENGTH = 250
-private const val MAX_LENGTH_WARN = MAX_LENGTH * 0.9
-
 @Composable
 fun MangaNotesTextArea(
     state: MangaNotesScreen.State,
@@ -102,7 +99,6 @@ fun MangaNotesTextArea(
         RichTextEditor(
             state = richTextState,
             textStyle = MaterialTheme.typography.bodyLarge,
-            maxLength = MAX_LENGTH,
             placeholder = {
                 Text(text = stringResource(MR.strings.notes_placeholder))
             },
@@ -182,12 +178,7 @@ fun MangaNotesTextArea(
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = (MAX_LENGTH - textLength).toString(),
-                    color = if (textLength > MAX_LENGTH_WARN) {
-                        MaterialTheme.colorScheme.error
-                    } else {
-                        Color.Unspecified
-                    },
+                    text = textLength.toString(),
                     modifier = Modifier.padding(MaterialTheme.padding.extraSmall),
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -420,7 +420,7 @@ class MangaScreen(
                         context,
                         navigator,
                         successState.mergedData,
-                        action = { _, nav, manga, source -> screenModel.openMangaFolder(source, manga) },
+                        action = { _, _, manga, source -> screenModel.openMangaFolder(source, manga) },
                         titleRes = KMR.strings.action_open_folder,
                     )
                 }

--- a/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
@@ -3,8 +3,8 @@ package tachiyomi.domain.manga.model
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Immutable
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
-import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import mihon.core.common.extensions.EMPTY
@@ -49,7 +49,7 @@ data class Manga(
 ) : JavaSerializable {
 
     // SY -->
-    @Contextual
+    /* KMK --> */ @Transient /* KMK <-- */
     private val customMangaInfo = if (favorite) {
         getCustomMangaInfo.get(id)
     } else {

--- a/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
@@ -1,15 +1,22 @@
 package tachiyomi.domain.manga.model
 
+import android.annotation.SuppressLint
 import androidx.compose.runtime.Immutable
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import mihon.core.common.extensions.EMPTY
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.domain.manga.interactor.GetCustomMangaInfo
 import uy.kohesive.injekt.injectLazy
-import java.io.Serializable
+import java.io.ObjectStreamException
 import java.time.Instant
+import java.io.Serializable as JavaSerializable
 
+@SuppressLint("UnsafeOptInUsageError")
+@Serializable
 @Immutable
 data class Manga(
     val id: Long,
@@ -39,9 +46,10 @@ data class Manga(
     val version: Long,
     val notes: String,
     val memo: JsonObject,
-) : Serializable {
+) : JavaSerializable {
 
     // SY -->
+    @Contextual
     private val customMangaInfo = if (favorite) {
         getCustomMangaInfo.get(id)
     } else {
@@ -176,5 +184,18 @@ data class Manga(
         // SY -->
         private val getCustomMangaInfo: GetCustomMangaInfo by injectLazy()
         // SY <--
+    }
+
+    @Throws(ObjectStreamException::class)
+    private fun writeReplace(): Any {
+        return JavaToKotlinXSerializable(Json.encodeToString<Manga>(this))
+    }
+
+    class JavaToKotlinXSerializable(private val data: String) : JavaSerializable {
+
+        @Throws(ObjectStreamException::class)
+        private fun readResolve(): Any {
+            return Json.decodeFromString<Manga>(data)
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,7 @@ image-decoder = "com.github.tachiyomiorg:image-decoder:41c059e540"
 
 natural-comparator = "com.github.gpanther:java-nat-sort:natural-comparator-1.1"
 
-richeditor-compose = "com.mohamedrejeb.richeditor:richeditor-compose:1.0.0-rc14"
+richeditor-compose = "com.mohamedrejeb.richeditor:richeditor-compose:1.0.0-rc13"
 
 material = "com.google.android.material:material:1.13.0"
 flexible-adapter-core = "com.github.arkon.FlexibleAdapter:flexible-adapter:c8013533"

--- a/i18n-sy/src/commonMain/moko-resources/vi/strings.xml
+++ b/i18n-sy/src/commonMain/moko-resources/vi/strings.xml
@@ -112,7 +112,7 @@
     <string name="google_drive_sync_data_not_found">Không tìm thấy dữ liệu đồng bộ trong Google Drive</string>
     <string name="author">Tác giả</string>
     <string name="artist">Họa sĩ</string>
-    <string name="clear_db_exclude_read">Giữ các mục có chương đã đọc</string>
+    <string name="clear_db_exclude_read">Giữ các truyện có chương đã đọc</string>
     <string name="action_clean_titles">Làm sạch tiêu đề</string>
     <string name="pref_category_fork">Cài đặt nhánh</string>
     <string name="ehentai_prefs_account_settings">Cài đặt tài khoản trang web E-Hentai</string>


### PR DESCRIPTION
## Summary by Sourcery

Make Manga a kotlinx-serializable model compatible with Java serialization while keeping customMangaInfo out of the serialized form.

Enhancements:
- Mark Manga as a kotlinx Serializable data class and introduce a Java-compatible surrogate for serialization/deserialization.
- Exclude customMangaInfo from serialization using kotlinx Transient instead of the previous contextual approach.
- Adjust manga notes UI to remove the character limit and show the current note length instead.
- Update merged manga action callback signature in MangaScreen to drop an unused navigation parameter.

Build:
- Downgrade the richeditor-compose library dependency from 1.0.0-rc14 to 1.0.0-rc13.

Documentation:
- Refine the Vietnamese translation for the clear database option to more clearly refer to keeping manga with read chapters.