### PR TITLE
fix(delegated-sources): Fix loading delegated sources with latest extension DSL changes

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -93,8 +93,8 @@ import eu.kanade.tachiyomi.source.online.all.EHentai
 import eu.kanade.tachiyomi.source.online.all.Lanraragi
 import eu.kanade.tachiyomi.source.online.all.MangaDex
 import eu.kanade.tachiyomi.source.online.all.NHentai
+import eu.kanade.tachiyomi.source.online.all.Pururin
 import eu.kanade.tachiyomi.source.online.english.EightMuses
-import eu.kanade.tachiyomi.source.online.english.Pururin
 import eu.kanade.tachiyomi.ui.manga.ChapterList
 import eu.kanade.tachiyomi.ui.manga.MangaScreenModel
 import eu.kanade.tachiyomi.ui.manga.MergedMangaData

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAdvancedScreen.kt
@@ -795,7 +795,7 @@ object SettingsAdvancedScreen : SearchableSettings {
                     subtitle = stringResource(
                         SYMR.strings.toggle_delegated_sources_summary,
                         stringResource(MR.strings.app_name),
-                        AndroidSourceManager.DELEGATED_SOURCES.values.map { it.sourceName }.distinct()
+                        AndroidSourceManager.DELEGATED_SOURCES.map { it.sourceName }.distinct()
                             .joinToString(),
                     ),
                 ),

--- a/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
@@ -12,8 +12,8 @@ import eu.kanade.tachiyomi.source.online.all.Lanraragi
 import eu.kanade.tachiyomi.source.online.all.MangaDex
 import eu.kanade.tachiyomi.source.online.all.MergedSource
 import eu.kanade.tachiyomi.source.online.all.NHentai
+import eu.kanade.tachiyomi.source.online.all.Pururin
 import eu.kanade.tachiyomi.source.online.english.EightMuses
-import eu.kanade.tachiyomi.source.online.english.Pururin
 import exh.log.xLogD
 import exh.source.BlacklistedSources
 import exh.source.DelegatedHttpSource

--- a/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/AndroidSourceManager.kt
@@ -23,7 +23,6 @@ import exh.source.EXHENTAI_EXT_SOURCES
 import exh.source.EnhancedHttpSource
 import exh.source.ExhPreferences
 import exh.source.MERGED_SOURCE_ID
-import exh.source.PURURIN_SOURCE_ID
 import exh.source.handleSourceLibrary
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -146,16 +145,13 @@ class AndroidSourceManager(
     ): Source? {
         // EXH -->
         val sourceQName = this::class.qualifiedName
-        val factories = DELEGATED_SOURCES.entries
-            .filter { it.value.factory }
-            .map { it.value.originalSourceQualifiedClassName }
         val delegate = if (sourceQName != null) {
-            val matched = factories.find { sourceQName.startsWith(it) }
-            if (matched != null) {
-                DELEGATED_SOURCES[matched]
-            } else {
-                DELEGATED_SOURCES[sourceQName]
+            // KMK -->
+            DELEGATED_SOURCES.firstOrNull { delegated ->
+                sourceQName == delegated.originalSourceQualifiedClassName ||
+                    (delegated.factory && sourceQName.startsWith(delegated.originalSourceQualifiedClassName))
             }
+            // KMK <--
         } else {
             null
         }
@@ -268,19 +264,24 @@ class AndroidSourceManager(
     // SY -->
     companion object {
         private const val fillInSourceId = Long.MAX_VALUE
+
+        /*
+         * If an extension is declaring sub-classes based on the main class, then set `factory=true` and
+         * only put the package without the class name. For example:
+         * "eu.kanade.tachiyomi.extension.all.mangadex" instead of "eu.kanade.tachiyomi.extension.all.mangadex.MangaDex"
+         */
         val DELEGATED_SOURCES = listOf(
             DelegatedSource(
                 "Pururin",
-                PURURIN_SOURCE_ID,
-                "eu.kanade.tachiyomi.extension.en.pururin.Pururin",
+                fillInSourceId,
+                "eu.kanade.tachiyomi.extension.all.pururin.Pururin",
                 Pururin::class,
             ),
             DelegatedSource(
                 "MangaDex",
                 fillInSourceId,
-                "eu.kanade.tachiyomi.extension.all.mangadex",
+                "eu.kanade.tachiyomi.extension.all.mangadex.MangaDex",
                 MangaDex::class,
-                true,
             ),
             DelegatedSource(
                 "8Muses",
@@ -293,16 +294,14 @@ class AndroidSourceManager(
                 fillInSourceId,
                 "eu.kanade.tachiyomi.extension.all.nhentai.NHentai",
                 NHentai::class,
-                true,
             ),
             DelegatedSource(
                 "LANraragi",
                 fillInSourceId,
                 "eu.kanade.tachiyomi.extension.all.lanraragi.LANraragi",
                 Lanraragi::class,
-                true,
             ),
-        ).associateBy { it.originalSourceQualifiedClassName }
+        )
 
         val currentDelegatedSources: MutableMap<Long, DelegatedSource> =
             ListenMutableMap(mutableMapOf(), ::handleSourceLibrary)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/Lanraragi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/Lanraragi.kt
@@ -42,7 +42,6 @@ class Lanraragi(delegate: HttpSource, val context: Context) :
     PagePreviewSource {
     override val metaClass = LanraragiSearchMetadata::class
     override fun newMetaInstance() = LanraragiSearchMetadata()
-    override val lang = delegate.lang
 
     private fun getApiUriBuilder(path: String): Uri.Builder {
         return LanraragiSearchMetadata.getApiUriBuilder(baseUrl, path)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/NHentai.kt
@@ -41,7 +41,6 @@ class NHentai(delegate: HttpSource, val context: Context) :
     PagePreviewSource {
     override val metaClass = NHentaiSearchMetadata::class
     override fun newMetaInstance() = NHentaiSearchMetadata()
-    override val lang = delegate.lang
 
     private val sourcePreferences: SharedPreferences by lazy {
         context.getSharedPreferences("source_$id", 0x0000)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/Pururin.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/Pururin.kt
@@ -1,4 +1,4 @@
-package eu.kanade.tachiyomi.source.online.english
+package eu.kanade.tachiyomi.source.online.all
 
 import android.content.Context
 import android.net.Uri
@@ -29,10 +29,6 @@ class Pururin(delegate: HttpSource, val context: Context) :
     MetadataSource<PururinSearchMetadata, Document>,
     UrlImportableSource,
     NamespaceSource {
-    /**
-     * An ISO 639-1 compliant language code (two letters in lower case).
-     */
-    override val lang = "en"
 
     /**
      * The class of the metadata used by this source

--- a/app/src/main/java/exh/source/SourceHelper.kt
+++ b/app/src/main/java/exh/source/SourceHelper.kt
@@ -4,8 +4,8 @@ import eu.kanade.tachiyomi.source.AndroidSourceManager
 import eu.kanade.tachiyomi.source.online.all.Lanraragi
 import eu.kanade.tachiyomi.source.online.all.MangaDex
 import eu.kanade.tachiyomi.source.online.all.NHentai
+import eu.kanade.tachiyomi.source.online.all.Pururin
 import eu.kanade.tachiyomi.source.online.english.EightMuses
-import eu.kanade.tachiyomi.source.online.english.Pururin
 
 /**
  * Source helpers


### PR DESCRIPTION
## Summary by Sourcery

Fix delegated source resolution to work with updated extension class structure and adjust delegated source metadata accordingly.

Bug Fixes:
- Resolve delegated sources by matching against original source class names and factory-based prefixes to restore proper loading behavior.

Enhancements:
- Convert delegated source configuration from a map to a list with clearer matching rules and document factory usage for subclass-based extensions.