### PR TITLE
fix(page-preview): Replace slider with number input in go-to dialog

### DIFF
--- a/app/src/main/java/exh/pagepreview/components/PagePreviewScreen.kt
+++ b/app/src/main/java/exh/pagepreview/components/PagePreviewScreen.kt
@@ -1,7 +1,5 @@
 package exh.pagepreview.components
 
-import androidx.compose.animation.core.AnimationState
-import androidx.compose.animation.core.animateTo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
@@ -10,10 +8,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.UTurnRight
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Slider
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -22,19 +21,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
-import eu.kanade.presentation.components.AroundLayout
 import eu.kanade.presentation.manga.components.PagePreview
 import exh.pagepreview.PagePreviewState
 import exh.util.floor
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.launch
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.ScrollbarLazyColumn
@@ -44,7 +42,6 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
 import tachiyomi.presentation.core.util.plus
-import kotlin.math.roundToInt
 
 @Composable
 fun PagePreviewScreen(
@@ -127,17 +124,19 @@ fun PagePreviewPageDialog(
     onDismissPageDialog: () -> Unit,
     onPageSelected: (Int) -> Unit,
 ) {
-    var page by remember(currentPage) {
-        mutableStateOf(currentPage.toFloat())
+    var pageText by remember(currentPage) {
+        mutableStateOf(currentPage.toString())
     }
-    val scope = rememberCoroutineScope()
     AlertDialog(
         onDismissRequest = onDismissPageDialog,
         confirmButton = {
-            TextButton(onClick = {
-                onPageSelected(page.roundToInt())
-                onDismissPageDialog()
-            }) {
+            TextButton(
+                onClick = {
+                    val page = pageText.toIntOrNull()?.coerceIn(1, pageCount) ?: currentPage
+                    onPageSelected(page)
+                    onDismissPageDialog()
+                },
+            ) {
                 Text(stringResource(MR.strings.action_ok))
             }
         },
@@ -150,27 +149,19 @@ fun PagePreviewPageDialog(
             Text(stringResource(SYMR.strings.page_preview_page_go_to))
         },
         text = {
-            AroundLayout(
-                startLayout = { Text(text = page.roundToInt().toString()) },
-                endLayout = { Text(text = pageCount.toString()) },
-                content = {
-                    Slider(
-                        modifier = Modifier.fillMaxWidth(),
-                        value = page,
-                        onValueChange = { page = it },
-                        onValueChangeFinished = {
-                            scope.launch {
-                                val newPage = page
-                                AnimationState(
-                                    newPage,
-                                ).animateTo(newPage.roundToInt().toFloat()) {
-                                    page = value
-                                }
-                            }
-                        },
-                        valueRange = 1F..pageCount.toFloat(),
-                    )
+            OutlinedTextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = pageText,
+                onValueChange = { input ->
+                    pageText = input.filter { it.isDigit() }
                 },
+                singleLine = true,
+                label = { Text(stringResource(SYMR.strings.page_preview_page_go_to)) },
+                suffix = { Text(text = " / $pageCount") },
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done,
+                ),
             )
         },
     )


### PR DESCRIPTION
## Summary
- Replaced the slider in the page preview "Go to page" dialog with a number input field (`OutlinedTextField`)
- The slider was imprecise for jumping to a specific page, especially with many pages
- The input accepts only digits, clamps to the valid range (1..pageCount), and shows a " / [total]" suffix
- Falls back to the current page if the input is empty or invalid

Fixes #1678

Before:
<img width="400" height="859" alt="screenshot-2026-07-20_20-27-58" src="https://github.com/user-attachments/assets/d3fb7bb2-ebc4-44aa-bc00-8a2e711e613b" />

After:
<img width="436" height="693" alt="screenshot-2026-07-20_19-57-38" src="https://github.com/user-attachments/assets/d56a9adc-c476-4f5e-95df-0a91e1e10334" />