### PR TITLE
fix(chapter-hash): Fix preference migration for existing users

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
     defaultConfig {
         applicationId = "app.komikku"
 
-        versionCode = 80
-        versionName = "1.14.0"
+        versionCode = 81
+        versionName = "1.14.1"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getGitSha()}\"")

--- a/app/src/main/java/mihon/core/migration/migrations/ChapterUrlHashMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/ChapterUrlHashMigration.kt
@@ -1,0 +1,28 @@
+package mihon.core.migration.migrations
+
+import mihon.core.migration.Migration
+import mihon.core.migration.MigrationContext
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.domain.download.service.DownloadPreferences
+
+/**
+ * Old installs relied on chapter URL hashing being implicitly enabled prior to
+ * this preference existing. Since version-gated migrations never run for a
+ * fresh install (only for upgrades), this only defaults the preference to
+ * true for existing users who haven't explicitly set it, preserving their
+ * previous download folder naming behavior.
+ */
+class ChapterUrlHashMigration : Migration {
+    override val version: Float = 81f
+
+    override suspend fun invoke(migrationContext: MigrationContext): Boolean = withIOContext {
+        val downloadPreferences = migrationContext.get<DownloadPreferences>() ?: return@withIOContext false
+
+        val includeChapterUrlHash = downloadPreferences.includeChapterUrlHash()
+        if (!includeChapterUrlHash.isSet()) {
+            includeChapterUrlHash.set(true)
+        }
+
+        return@withIOContext true
+    }
+}

--- a/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/Migrations.kt
@@ -55,5 +55,6 @@ val migrations: List<Migration>
         // KMK -->
         DisabledRepoMigration(),
         SyncPrefKeyMigration(),
+        ChapterUrlHashMigration(),
         // KMK <--
     )


### PR DESCRIPTION
## Summary by Sourcery

Migrate existing users’ download preferences to explicitly enable chapter URL hashing and bump the app version to 1.14.1.

Bug Fixes:
- Ensure chapter URL hashing is correctly defaulted for existing users who had relied on the previous implicit behavior.

Enhancements:
- Add a version-gated migration that sets the chapter URL hash preference for users who have not explicitly configured it.

Build:
- Update app versionCode to 81 and versionName to 1.14.1.