### PR TITLE
fix(repo-migration): Correct URL formatting when migrating repo

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/ExtensionStoreRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/ExtensionStoreRestorer.kt
@@ -14,7 +14,8 @@ class ExtensionStoreRestorer(
     ) {
         // KMK -->
         val indexUrl = if (backupStore.isLegacy == null) {
-            backupStore.indexUrl.removeSuffix("/index.min.json").removeSuffix("/index.json") + "/repo.json"
+            backupStore.indexUrl.removeSuffix("/index.min.json").removeSuffix("/index.json")
+                .removeSuffix("/repo.json") + "/repo.json"
         } else {
             backupStore.indexUrl
         }

--- a/app/src/main/java/mihon/core/migration/migrations/DisabledRepoMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/DisabledRepoMigration.kt
@@ -19,7 +19,8 @@ class DisabledRepoMigration : Migration {
             val disabledRepos = prefs.getStringSet(sourcePreferences.disabledRepos().key(), emptySet()) ?: return@edit
             disabledRepos
                 .map {
-                    it.removeSuffix("/index.min.json").removeSuffix("/index.json") + "/repo.json"
+                    it.removeSuffix("/index.min.json").removeSuffix("/index.json")
+                        .removeSuffix("/repo.json") + "/repo.json"
                 }.toSet()
                 .let {
                     putStringSet(sourcePreferences.disabledRepos().key(), it)

--- a/app/src/main/java/mihon/core/migration/migrations/TrustExtensionRepositoryMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/TrustExtensionRepositoryMigration.kt
@@ -17,7 +17,10 @@ class TrustExtensionRepositoryMigration : Migration {
         for ((index, source) in sourcePreferences.extensionRepos().get().withIndex()) {
             try {
                 repository.insertFromPreference(
-                    indexUrl = source.removeSuffix("/index.min.json").removeSuffix("/index.json") + "/repo.json",
+                    indexUrl = source.removeSuffix("/index.min.json").removeSuffix("/index.json")
+                        // KMK -->
+                        .removeSuffix("/repo.json") + "/repo.json",
+                    // KMK <--
                     name = "Repo #${index + 1}",
                 )
             } catch (e: Exception) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure migrated and restored extension repository URLs correctly end with a single /repo.json by stripping existing index and repo suffixes.