### PR TITLE
fix(Lanraragi): Fix updating manga

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/Lanraragi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/Lanraragi.kt
@@ -141,7 +141,7 @@ class Lanraragi(delegate: HttpSource, val context: Context) :
     @Serializable
     data class Archive(
         val arcid: String,
-        val isnew: String,
+        val isnew: Boolean,
         val tags: String?,
         val summary: String?,
         val title: String,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct archive 'isnew' field type to boolean to fix issues when updating manga metadata.