### PR TITLE
feat(ui): Auto-hide top bar and bottom nav on scroll

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -84,6 +84,10 @@ class UiPreferences(
 
     fun showNavHistory() = preferenceStore.getBoolean("pref_show_history_button", true)
 
+    // KMK -->
+    fun autoHideBarsOnScroll() = preferenceStore.getBoolean("pref_auto_hide_bars_on_scroll", true)
+    // KMK <--
+
     // SY <--
 
     companion object {

--- a/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/TabbedScreen.kt
@@ -1,5 +1,8 @@
 package eu.kanade.presentation.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -26,6 +29,7 @@ import androidx.compose.ui.zIndex
 import dev.icerock.moko.resources.StringResource
 import eu.kanade.tachiyomi.ui.browse.BulkFavoriteScreenModel
 import eu.kanade.tachiyomi.ui.browse.feed.FeedScreenModel
+import eu.kanade.tachiyomi.ui.home.HomeScreen
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
@@ -55,40 +59,51 @@ fun TabbedScreen(
 
     Scaffold(
         topBar = {
-            val tab = tabs[state.currentPage]
-            val searchEnabled = tab.searchEnabled
             // KMK -->
-            if (bulkFavoriteState.selectionMode) {
-                BulkSelectionToolbar(
-                    selectedCount = bulkFavoriteState.selection.size,
-                    isRunning = bulkFavoriteState.isRunning,
-                    onClickClearSelection = bulkFavoriteScreenModel::toggleSelectionMode,
-                    onChangeCategoryClick = bulkFavoriteScreenModel::addFavorite,
-                    onSelectAll = {
-                        feedState.items?.let { result ->
-                            result.mapNotNull { it.results }
-                                .flatten()
-                                .forEach { bulkFavoriteScreenModel.select(it) }
-                        }
-                    },
-                    onReverseSelection = {
-                        feedState.items?.let { result ->
-                            result.mapNotNull { it.results }
-                                .flatten()
-                                .let { bulkFavoriteScreenModel.reverseSelection(it) }
-                        }
-                    },
-                )
-            } else {
+            // Auto-hide top bar on scroll for more viewing space
+            AnimatedVisibility(
+                visible = !HomeScreen.LocalBarsScrolledDown.current,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
                 // KMK <--
-                SearchToolbar(
-                    titleContent = { AppBarTitle(stringResource(titleRes)) },
-                    searchEnabled = searchEnabled,
-                    searchQuery = if (searchEnabled) searchQuery else null,
-                    onChangeSearchQuery = onChangeSearchQuery,
-                    actions = { AppBarActions(tab.actions) },
-                )
+                val tab = tabs[state.currentPage]
+                val searchEnabled = tab.searchEnabled
+                // KMK -->
+                if (bulkFavoriteState.selectionMode) {
+                    BulkSelectionToolbar(
+                        selectedCount = bulkFavoriteState.selection.size,
+                        isRunning = bulkFavoriteState.isRunning,
+                        onClickClearSelection = bulkFavoriteScreenModel::toggleSelectionMode,
+                        onChangeCategoryClick = bulkFavoriteScreenModel::addFavorite,
+                        onSelectAll = {
+                            feedState.items?.let { result ->
+                                result.mapNotNull { it.results }
+                                    .flatten()
+                                    .forEach { bulkFavoriteScreenModel.select(it) }
+                            }
+                        },
+                        onReverseSelection = {
+                            feedState.items?.let { result ->
+                                result.mapNotNull { it.results }
+                                    .flatten()
+                                    .let { bulkFavoriteScreenModel.reverseSelection(it) }
+                            }
+                        },
+                    )
+                } else {
+                    // KMK <--
+                    SearchToolbar(
+                        titleContent = { AppBarTitle(stringResource(titleRes)) },
+                        searchEnabled = searchEnabled,
+                        searchQuery = if (searchEnabled) searchQuery else null,
+                        onChangeSearchQuery = onChangeSearchQuery,
+                        actions = { AppBarActions(tab.actions) },
+                    )
+                }
+                // KMK -->
             }
+            // KMK <--
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { contentPadding ->

--- a/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/HistoryScreen.kt
@@ -1,6 +1,9 @@
 package eu.kanade.presentation.history
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.items
@@ -30,6 +33,7 @@ import eu.kanade.presentation.theme.TachiyomiPreviewTheme
 import eu.kanade.presentation.util.animateItemFastScroll
 import eu.kanade.tachiyomi.ui.history.HistoryScreenModel
 import eu.kanade.tachiyomi.ui.history.HistoryScreenModel.HistorySelectionOptions
+import eu.kanade.tachiyomi.ui.home.HomeScreen
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.domain.history.model.HistoryWithRelations
 import tachiyomi.i18n.MR
@@ -68,43 +72,53 @@ fun HistoryScreen(
     Scaffold(
         topBar = { scrollBehavior ->
             // KMK -->
-            when {
-                state.selectionMode -> HistorySelectionToolbar(
-                    selectedCount = state.selection.size,
-                    onCancelActionMode = toggleSelectionMode,
-                    onClickSelectAll = { onSelectAll(true) },
-                    onClickInvertSelection = onInvertSelection,
-                    onClickClearHistory = { onDialogChange(HistoryScreenModel.Dialog.Delete(state.selected)) },
-                )
+            // Auto-hide top bar on scroll for more viewing space
+            AnimatedVisibility(
+                visible = !HomeScreen.LocalBarsScrolledDown.current,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
                 // KMK <--
-                else -> SearchToolbar(
-                    titleContent = { AppBarTitle(stringResource(MR.strings.history)) },
-                    searchQuery = state.searchQuery,
-                    onChangeSearchQuery = onSearchQueryChange,
-                    actions = {
-                        AppBarActions(
-                            persistentListOf(
-                                // KMK -->
-                                AppBar.Action(
-                                    title = stringResource(MR.strings.action_filter),
-                                    icon = Icons.Outlined.FilterList,
-                                    iconTint = if (hasActiveFilters) MaterialTheme.colorScheme.active else LocalContentColor.current,
-                                    onClick = onFilterClicked,
-                                ),
-                                // KMK <--
-                                AppBar.Action(
-                                    title = stringResource(MR.strings.pref_clear_history),
+                when {
+                    state.selectionMode -> HistorySelectionToolbar(
+                        selectedCount = state.selection.size,
+                        onCancelActionMode = toggleSelectionMode,
+                        onClickSelectAll = { onSelectAll(true) },
+                        onClickInvertSelection = onInvertSelection,
+                        onClickClearHistory = { onDialogChange(HistoryScreenModel.Dialog.Delete(state.selected)) },
+                    )
+                    // KMK <--
+                    else -> SearchToolbar(
+                        titleContent = { AppBarTitle(stringResource(MR.strings.history)) },
+                        searchQuery = state.searchQuery,
+                        onChangeSearchQuery = onSearchQueryChange,
+                        actions = {
+                            AppBarActions(
+                                persistentListOf(
                                     // KMK -->
-                                    icon = Icons.Outlined.Checklist,
-                                    onClick = toggleSelectionMode,
+                                    AppBar.Action(
+                                        title = stringResource(MR.strings.action_filter),
+                                        icon = Icons.Outlined.FilterList,
+                                        iconTint = if (hasActiveFilters) MaterialTheme.colorScheme.active else LocalContentColor.current,
+                                        onClick = onFilterClicked,
+                                    ),
                                     // KMK <--
+                                    AppBar.Action(
+                                        title = stringResource(MR.strings.pref_clear_history),
+                                        // KMK -->
+                                        icon = Icons.Outlined.Checklist,
+                                        onClick = toggleSelectionMode,
+                                        // KMK <--
+                                    ),
                                 ),
-                            ),
-                        )
-                    },
-                    scrollBehavior = scrollBehavior,
-                )
+                            )
+                        },
+                        scrollBehavior = scrollBehavior,
+                    )
+                }
+                // KMK -->
             }
+            // KMK <--
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
     ) { contentPadding ->

--- a/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/LibraryContent.kt
@@ -1,5 +1,8 @@
 package eu.kanade.presentation.library.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
@@ -16,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import eu.kanade.core.preference.PreferenceMutableState
+import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.library.LibraryItem
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -75,16 +79,24 @@ fun LibraryContent(
                 }
                 // KMK <--
             }
-            LibraryTabs(
-                categories = categories,
-                pagerState = pagerState,
-                getItemCountForCategory = getItemCountForCategory,
-                onTabItemClick = {
-                    scope.launch {
-                        pagerState.animateScrollToPage(it)
-                    }
-                },
-            )
+            // KMK -->
+            AnimatedVisibility(
+                visible = !HomeScreen.LocalBarsScrolledDown.current,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                // KMK <--
+                LibraryTabs(
+                    categories = categories,
+                    pagerState = pagerState,
+                    getItemCountForCategory = getItemCountForCategory,
+                    onTabItemClick = {
+                        scope.launch {
+                            pagerState.animateScrollToPage(it)
+                        }
+                    },
+                )
+            }
         }
 
         PullRefresh(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -343,6 +343,12 @@ object SettingsAppearanceScreen : SearchableSettings {
                     preference = uiPreferences.bottomBarLabels(),
                     title = stringResource(SYMR.strings.pref_show_bottom_bar_labels),
                 ),
+                // KMK -->
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = uiPreferences.autoHideBarsOnScroll(),
+                    title = stringResource(KMR.strings.pref_auto_hide_bars_on_scroll),
+                ),
+                // KMK <--
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/updates/UpdatesScreen.kt
@@ -1,6 +1,9 @@
 package eu.kanade.presentation.updates
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -28,6 +31,7 @@ import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.manga.components.ChapterDownloadAction
 import eu.kanade.presentation.manga.components.MangaBottomActionMenu
 import eu.kanade.tachiyomi.data.download.model.Download
+import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.updates.UpdatesItem
 import eu.kanade.tachiyomi.ui.updates.UpdatesScreenModel
 import kotlinx.collections.immutable.persistentListOf
@@ -80,17 +84,28 @@ fun UpdateScreen(
 
     Scaffold(
         topBar = { scrollBehavior ->
-            UpdatesAppBar(
-                onCalendarClicked = { onCalendarClicked() },
-                onUpdateLibrary = { onUpdateLibrary() },
-                onFilterClicked = { onFilterClicked() },
-                hasFilters = hasActiveFilters,
-                actionModeCounter = state.selected.size,
-                onSelectAll = { onSelectAll(true) },
-                onInvertSelection = { onInvertSelection() },
-                onCancelActionMode = { onSelectAll(false) },
-                scrollBehavior = scrollBehavior,
-            )
+            // KMK -->
+            // Auto-hide top bar on scroll for more viewing space
+            AnimatedVisibility(
+                visible = !HomeScreen.LocalBarsScrolledDown.current,
+                enter = expandVertically(),
+                exit = shrinkVertically(),
+            ) {
+                // KMK <--
+                UpdatesAppBar(
+                    onCalendarClicked = { onCalendarClicked() },
+                    onUpdateLibrary = { onUpdateLibrary() },
+                    onFilterClicked = { onFilterClicked() },
+                    hasFilters = hasActiveFilters,
+                    actionModeCounter = state.selected.size,
+                    onSelectAll = { onSelectAll(true) },
+                    onInvertSelection = { onInvertSelection() },
+                    onCancelActionMode = { onSelectAll(false) },
+                    scrollBehavior = scrollBehavior,
+                )
+                // KMK -->
+            }
+            // KMK <--
         },
         bottomBar = {
             UpdatesBottomBar(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -3,7 +3,9 @@ package eu.kanade.tachiyomi.ui.home
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
@@ -22,14 +24,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.util.fastFilter
 import androidx.compose.ui.util.fastForEach
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -68,6 +78,15 @@ import uy.kohesive.injekt.api.get
 object HomeScreen : Screen() {
     private fun readResolve(): Any = HomeScreen
 
+    // KMK -->
+    /**
+     * CompositionLocal that exposes the current scroll-driven "bars hidden" state
+     * to descendant tab composables. Each tab's top bar can observe this to
+     * hide/show in sync with the bottom nav.
+     */
+    val LocalBarsScrolledDown = compositionLocalOf { false }
+    // KMK <--
+
     private val librarySearchEvent = Channel<String>()
     private val openTabEvent = Channel<Tab>()
     private val showBottomNavEvent = Channel<Boolean>()
@@ -93,24 +112,72 @@ object HomeScreen : Screen() {
             Injekt.get<UiPreferences>().bottomBarLabels().asState(scope)
         }
         // SY <--
+        // KMK -->
+        // Auto-hide bars on scroll: tracks whether the user has scrolled down
+        // in the current tab content. Combined with the selection-mode signal
+        // (showBottomNavEvent) to drive both the bottom nav (phone) and the
+        // navigation rail (tablet) visibility.
+        val autoHideBars by remember {
+            Injekt.get<UiPreferences>().autoHideBarsOnScroll().asState(scope)
+        }
+        var scrolledDown by remember { mutableStateOf(false) }
+        val scrollConnection = remember(autoHideBars) {
+            object : NestedScrollConnection {
+                override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                    if (autoHideBars && source == NestedScrollSource.UserInput && available.y != 0f) {
+                        scrolledDown = true
+                    }
+                    return Offset.Zero
+                }
+
+                override suspend fun onPreFling(available: Velocity): Velocity {
+                    scrolledDown = false
+                    return Velocity.Zero
+                }
+            }
+        }
+        // KMK <--
 
         TabNavigator(
             tab = LibraryTab,
             key = TAB_NAVIGATOR_KEY,
         ) { tabNavigator ->
             // Provide usable navigator to content screen
-            CompositionLocalProvider(LocalNavigator provides navigator) {
+            CompositionLocalProvider(
+                LocalNavigator provides navigator,
+                // KMK -->
+                HomeScreen.LocalBarsScrolledDown provides scrolledDown,
+                // KMK <--
+            ) {
+                // KMK -->
+                // Reset scroll state when switching tabs so bars are visible
+                // at the top of each newly-selected tab.
+                LaunchedEffect(tabNavigator.current) {
+                    scrolledDown = false
+                }
+                // KMK <--
                 Scaffold(
                     startBar = {
                         if (isTabletUi()) {
-                            NavigationRail {
-                                TABS
-                                    // SY -->
-                                    .fastFilter { it.isEnabled() }
-                                    // SY <--
-                                    .fastForEach {
-                                        NavigationRailItem(it/* SY --> */, alwaysShowLabel/* SY <-- */)
-                                    }
+                            // KMK -->
+                            val sideNavVisible by produceState(initialValue = true) {
+                                showBottomNavEvent.receiveAsFlow().collectLatest { value = it }
+                            }
+                            AnimatedVisibility(
+                                visible = sideNavVisible && !scrolledDown,
+                                enter = expandHorizontally(),
+                                exit = shrinkHorizontally(),
+                            ) {
+                                // KMK <--
+                                NavigationRail {
+                                    TABS
+                                        // SY -->
+                                        .fastFilter { it.isEnabled() }
+                                        // SY <--
+                                        .fastForEach {
+                                            NavigationRailItem(it/* SY --> */, alwaysShowLabel/* SY <-- */)
+                                        }
+                                }
                             }
                         }
                     },
@@ -120,7 +187,9 @@ object HomeScreen : Screen() {
                                 showBottomNavEvent.receiveAsFlow().collectLatest { value = it }
                             }
                             AnimatedVisibility(
-                                visible = bottomNavVisible,
+                                // KMK -->
+                                visible = bottomNavVisible && !scrolledDown,
+                                // KMK <--
                                 enter = expandVertically(),
                                 exit = shrinkVertically(),
                             ) {
@@ -141,7 +210,10 @@ object HomeScreen : Screen() {
                     Box(
                         modifier = Modifier
                             .padding(contentPadding)
-                            .consumeWindowInsets(contentPadding),
+                            .consumeWindowInsets(contentPadding)
+                            // KMK -->
+                            .nestedScroll(scrollConnection),
+                        // KMK <--
                     ) {
                         AnimatedContent(
                             targetState = tabNavigator.current,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -1,9 +1,12 @@
 package eu.kanade.tachiyomi.ui.library
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.graphics.res.animatedVectorResource
 import androidx.compose.animation.graphics.res.rememberAnimatedVectorPainter
 import androidx.compose.animation.graphics.vector.AnimatedImageVector
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
@@ -145,53 +148,63 @@ data object LibraryTab : Tab {
 
         Scaffold(
             topBar = { scrollBehavior ->
-                val title = state.getToolbarTitle(
-                    defaultTitle = stringResource(MR.strings.label_library),
-                    defaultCategoryTitle = stringResource(MR.strings.label_default),
-                    page = state.coercedActiveCategoryIndex,
-                )
-                LibraryToolbar(
-                    hasActiveFilters = state.hasActiveFilters,
-                    selectedCount = state.selection.size,
-                    title = title,
-                    onClickUnselectAll = screenModel::clearSelection,
-                    onClickSelectAll = screenModel::selectAll,
-                    onClickInvertSelection = screenModel::invertSelection,
-                    onClickFilter = screenModel::showSettingsDialog,
-                    onClickRefresh = { onClickRefresh(state.activeCategory) },
-                    onClickGlobalUpdate = { onClickRefresh(null) },
-                    onClickOpenRandomManga = {
-                        scope.launch {
-                            val randomItem = screenModel.getRandomLibraryItemForCurrentCategory()
-                            if (randomItem != null) {
-                                navigator.push(MangaScreen(randomItem.libraryManga.manga.id))
-                            } else {
-                                snackbarHostState.showSnackbar(
-                                    context.stringResource(MR.strings.information_no_entries_found),
-                                )
+                // KMK -->
+                // Auto-hide top bar on scroll for more viewing space
+                AnimatedVisibility(
+                    visible = !HomeScreen.LocalBarsScrolledDown.current,
+                    enter = expandVertically(),
+                    exit = shrinkVertically(),
+                ) {
+                    // KMK <--
+                    val title = state.getToolbarTitle(
+                        defaultTitle = stringResource(MR.strings.label_library),
+                        defaultCategoryTitle = stringResource(MR.strings.label_default),
+                        page = state.coercedActiveCategoryIndex,
+                    )
+                    LibraryToolbar(
+                        hasActiveFilters = state.hasActiveFilters,
+                        selectedCount = state.selection.size,
+                        title = title,
+                        onClickUnselectAll = screenModel::clearSelection,
+                        onClickSelectAll = screenModel::selectAll,
+                        onClickInvertSelection = screenModel::invertSelection,
+                        onClickFilter = screenModel::showSettingsDialog,
+                        onClickRefresh = { onClickRefresh(state.activeCategory) },
+                        onClickGlobalUpdate = { onClickRefresh(null) },
+                        onClickOpenRandomManga = {
+                            scope.launch {
+                                val randomItem = screenModel.getRandomLibraryItemForCurrentCategory()
+                                if (randomItem != null) {
+                                    navigator.push(MangaScreen(randomItem.libraryManga.manga.id))
+                                } else {
+                                    snackbarHostState.showSnackbar(
+                                        context.stringResource(MR.strings.information_no_entries_found),
+                                    )
+                                }
                             }
-                        }
-                    },
-                    onClickSyncNow = {
-                        if (!SyncDataJob.isRunning(context)) {
-                            SyncDataJob.startNow(context, manual = true)
-                        } else {
-                            context.toast(SYMR.strings.sync_in_progress)
-                        }
-                    },
-                    // SY -->
-                    onClickSyncExh = screenModel::openFavoritesSyncDialog.takeIf { state.showSyncExh },
-                    isSyncEnabled = state.isSyncEnabled,
-                    // SY <--
-                    searchQuery = state.searchQuery,
-                    onSearchQueryChange = screenModel::search,
-                    onInvalidateDownloadCache = { context ->
-                        Injekt.get<DownloadCache>().invalidateCache()
-                        context.toast(MR.strings.download_cache_invalidated)
-                    },
-                    // For scroll overlay when no tab
-                    scrollBehavior = scrollBehavior.takeIf { !state.showCategoryTabs },
-                )
+                        },
+                        onClickSyncNow = {
+                            if (!SyncDataJob.isRunning(context)) {
+                                SyncDataJob.startNow(context, manual = true)
+                            } else {
+                                context.toast(SYMR.strings.sync_in_progress)
+                            }
+                        },
+                        // SY -->
+                        onClickSyncExh = screenModel::openFavoritesSyncDialog.takeIf { state.showSyncExh },
+                        isSyncEnabled = state.isSyncEnabled,
+                        // SY <--
+                        searchQuery = state.searchQuery,
+                        onSearchQueryChange = screenModel::search,
+                        onInvalidateDownloadCache = { context ->
+                            Injekt.get<DownloadCache>().invalidateCache()
+                            context.toast(MR.strings.download_cache_invalidated)
+                        },
+                        scrollBehavior = scrollBehavior,
+                    )
+                    // KMK -->
+                }
+                // KMK <--
             },
             bottomBar = {
                 LibraryBottomActionMenu(

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -238,4 +238,5 @@
     <string name="pref_discord_show_download_button_summary">Displays a button to download the app</string>
     <string name="pref_discord_show_discord_button">Show Discord Button</string>
     <string name="pref_discord_show_discord_button_summary">Displays a button to join the Discord server</string>
+    <string name="pref_auto_hide_bars_on_scroll">Hide navigation bars on scroll</string>
 </resources>


### PR DESCRIPTION
## Summary
- Hide the top app bar (title, search, menu) and bottom navigation (phone) / navigation rail (tablet) while the user is actively dragging to scroll
- Reveal both bars the moment the finger lifts (drag ends)
- A `NestedScrollConnection` in `HomeScreen` drives a shared `LocalBarsScrolledDown` CompositionLocal that each tab's top bar observes, keeping top bar, bottom nav, and rail in sync
- State resets to visible on tab switch

## Files changed
- `HomeScreen.kt` — Added `LocalBarsScrolledDown` CompositionLocal + `NestedScrollConnection` for scroll detection
- `LibraryTab.kt` — Wrapped top bar in `AnimatedVisibility`
- `UpdatesScreen.kt` — Wrapped top bar in `AnimatedVisibility`
- `HistoryScreen.kt` — Wrapped top bar in `AnimatedVisibility`
- `TabbedScreen.kt` (Browse) — Wrapped top bar in `AnimatedVisibility`

## Summary by Sourcery

Auto-hide top and bottom navigation bars while scrolling in the home tabs to increase visible content area, keeping their visibility synchronized across phone and tablet layouts.

New Features:
- Introduce a shared scroll-driven visibility state for app bars and navigation bars via a CompositionLocal in HomeScreen.
- Auto-hide and animate the Library, Updates, History, and Browse tab top bars based on the shared scroll state.
- Hide the bottom navigation bar on phones and the navigation rail on tablets while the user is actively scrolling, restoring them when scrolling ends.

https://github.com/user-attachments/assets/f2894d41-02c9-47c1-8e39-7ff21f370503