### PR TITLE
feat(reader): Add persistent info overlay (clock, battery, page)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/PersistentInfoOverlay.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/PersistentInfoOverlay.kt
@@ -1,0 +1,130 @@
+package eu.kanade.presentation.reader
+
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import eu.kanade.presentation.theme.TachiyomiPreviewTheme
+import kotlinx.coroutines.delay
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Persistent overlay shown on the top edge of the reader page while reading.
+ * Displays the current time, battery percentage, and page progress so the user
+ * can glance at this info without exiting the reader or opening the menu.
+ *
+ * KMK-only feature.
+ */
+@Composable
+fun PersistentInfoOverlay(
+    currentPage: String,
+    totalPages: Int,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+
+    // Clock — ticks every second
+    var clock by remember { mutableStateOf(LocalTime.now()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            clock = LocalTime.now()
+            delay(1000L)
+        }
+    }
+
+    // Battery — polled every 30s via sticky broadcast
+    var batteryPct by remember { mutableIntStateOf(-1) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            batteryPct = currentBatteryPercent(context)
+            delay(30_000L)
+        }
+    }
+
+    val timeText = clock.format(DateTimeFormatter.ofPattern("HH:mm"))
+    val batteryText = if (batteryPct >= 0) "$batteryPct%" else ""
+    val pageText = if (currentPage.isNotEmpty() && totalPages > 0) "$currentPage/$totalPages" else ""
+
+    val style = TextStyle(
+        // KMK -->
+        color = MaterialTheme.colorScheme.primary,
+        // KMK <--
+        fontSize = MaterialTheme.typography.bodySmall.fontSize,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 1.sp,
+    )
+    val strokeStyle = style.copy(
+        color = Color(45, 45, 45),
+        drawStyle = Stroke(width = 4f),
+    )
+
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+    ) {
+        OverlayText(timeText, style, strokeStyle)
+        if (batteryText.isNotEmpty()) {
+            OverlayText(batteryText, style, strokeStyle)
+        }
+        if (pageText.isNotEmpty()) {
+            OverlayText(pageText, style, strokeStyle)
+        }
+    }
+}
+
+@Composable
+private fun OverlayText(text: String, style: TextStyle, strokeStyle: TextStyle) {
+    if (text.isEmpty()) return
+    // Stroke (outline) drawn under the main text for readability over any page background
+    Text(text = text, style = strokeStyle)
+    Text(text = text, style = style)
+}
+
+private fun currentBatteryPercent(context: android.content.Context): Int {
+    return try {
+        val intent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        if (intent != null) {
+            val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+            val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+            if (level >= 0 && scale > 0) (level * 100 / scale) else -1
+        } else {
+            -1
+        }
+    } catch (e: Exception) {
+        -1
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun PersistentInfoOverlayPreview() {
+    TachiyomiPreviewTheme {
+        Surface {
+            PersistentInfoOverlay(currentPage = "10", totalPages = 69)
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
 import eu.kanade.tachiyomi.util.system.hasDisplayCutout
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.CheckboxItem
 import tachiyomi.presentation.core.components.SettingsChipRow
@@ -60,6 +61,13 @@ internal fun GeneralPage(screenModel: ReaderSettingsScreenModel) {
         label = stringResource(MR.strings.pref_show_page_number),
         pref = screenModel.preferences.showPageNumber(),
     )
+
+    // KMK -->
+    CheckboxItem(
+        label = stringResource(KMR.strings.pref_show_persistent_info_overlay),
+        pref = screenModel.preferences.showPersistentInfoOverlay(),
+    )
+    // KMK <--
 
     // SY -->
     val forceHorizontalSeekbar by screenModel.preferences.forceHorizontalSeekbar().collectAsState()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -69,6 +70,7 @@ import eu.kanade.domain.ui.UiPreferences
 import eu.kanade.presentation.reader.ChapterListDialog
 import eu.kanade.presentation.reader.DisplayRefreshHost
 import eu.kanade.presentation.reader.OrientationSelectDialog
+import eu.kanade.presentation.reader.PersistentInfoOverlay
 import eu.kanade.presentation.reader.ReaderContentOverlay
 import eu.kanade.presentation.reader.ReaderPageActionsDialog
 import eu.kanade.presentation.reader.ReaderPageIndicator
@@ -326,6 +328,9 @@ class ReaderActivity : BaseActivity() {
             // KMK <--
             val state by viewModel.state.collectAsState()
             val showPageNumber by readerPreferences.showPageNumber().collectAsState()
+            // KMK -->
+            val showPersistentInfoOverlay by readerPreferences.showPersistentInfoOverlay().collectAsState()
+            // KMK <--
             val settingsScreenModel = remember {
                 ReaderSettingsScreenModel(
                     readerState = viewModel.state,
@@ -346,6 +351,18 @@ class ReaderActivity : BaseActivity() {
                             .navigationBarsPadding(),
                     )
                 }
+
+                // KMK -->
+                if (showPersistentInfoOverlay) {
+                    PersistentInfoOverlay(
+                        currentPage = state.currentPageText,
+                        totalPages = state.totalPages,
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .statusBarsPadding(),
+                    )
+                }
+                // KMK <--
 
                 ContentOverlay(state = state)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -35,6 +35,10 @@ class ReaderPreferences(
 
     fun showPageNumber() = preferenceStore.getBoolean("pref_show_page_number_key", true)
 
+    // KMK -->
+    fun showPersistentInfoOverlay() = preferenceStore.getBoolean("pref_show_persistent_info_overlay_key", false)
+    // KMK <--
+
     fun showReadingMode() = preferenceStore.getBoolean("pref_show_reading_mode", true)
 
     fun fullscreen() = preferenceStore.getBoolean("fullscreen", true)

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -31,6 +31,7 @@
     <string name="pref_pinch_to_zoom">Pinch to zoom</string>
     <string name="pref_paged_disable_zoom_in">Disable zoom in</string>
     <string name="pref_landscape_zoom_type">Wide images zoom mode</string>
+    <string name="pref_show_persistent_info_overlay">Show persistent info overlay (clock, battery, page)</string>
     <string name="scale_type_double">Double zoom</string>
     <string name="pref_webtoon_scale_type">Smart scale on wide screen</string>
     <string name="pref_smart_scale_long_strip_gap">Apply Smart scale to Long strip with gaps</string>


### PR DESCRIPTION
## Summary
- Adds a small persistent overlay at the top edge of the reader page showing the current time (HH:mm), battery percentage, and page progress (`currentPage/totalPages`).
- Lets readers check time/battery/progress at a glance without opening the reader menu or scrolling.
- Off by default; toggle via **Reader settings > General > Show persistent info overlay (clock, battery, page)**.
- Overlay text uses the same outlined-stroke style as the existing `ReaderPageIndicator` for readability over any page background, and is offset by `statusBarsPadding` so it doesn't sit under the status bar / cutout.

## Files
- `PersistentInfoOverlay.kt` (new) — composable rendering clock + battery + page text with outlined stroke.
- `ReaderPreferences.kt` — new `showPersistentInfoOverlay()` preference (default `false`).
- `ReaderActivity.kt` — overlay placed in the reader `Box` at `TopCenter`, gated by the preference.
- `GeneralSettingsPage.kt` — checkbox toggle in the reader General settings page.
- `i18n-kmk/.../strings.xml` — new KMR string `pref_show_persistent_info_overlay`.

## Implementation notes
- Clock ticks every second via `LaunchedEffect` + `delay(1000)`.
- Battery is read via the sticky `ACTION_BATTERY_CHANGED` broadcast and polled every 30s — no runtime permission required.
- Overlay is independent of `state.menuVisible` (always shown while the pref is on), so it stays visible even when the reader menu is hidden.

#### Test plan
- [ ] Build succeeds (`spotlessApply spotlessCheck assembleDebug`).
- [ ] Toggle the new setting on in Reader > General; verify overlay appears at the top center of the reader.
- [ ] Verify clock updates every second.
- [ ] Verify battery percentage matches the system battery level.
- [ ] Verify page progress updates as you flip pages.
- [ ] Verify overlay remains visible when the reader menu is hidden.
- [ ] Toggle the setting off; verify overlay disappears.
- [ ] Verify overlay does not overlap the status bar / cutout on devices with a cutout.

Generated with [Devin](https://devin.ai)

## Summary by Sourcery

Add an optional persistent information overlay to the reader showing time, battery level, and page progress, configurable via reader settings.

New Features:
- Introduce a persistent top-edge overlay in the reader that displays current time, battery percentage, and page progress.
- Add a reader preference and settings toggle to enable or disable the persistent info overlay.

Enhancements:
- Align the new overlay within the reader layout using status bar padding to avoid cutouts and overlap.
- Reuse outlined text styling for the overlay to maintain readability over varied page backgrounds.

Documentation:
- Add a localized KMR string for the new persistent info overlay setting label.