### PR TITLE
feat(reader): Add persistent status overlay (clock, battery, chapter)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/reader/PersistentInfoOverlay.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/PersistentInfoOverlay.kt
@@ -1,0 +1,280 @@
+package eu.kanade.presentation.reader
+
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.BatteryFull
+import androidx.compose.material.icons.outlined.BatteryStd
+import androidx.compose.material.icons.outlined.Book
+import androidx.compose.material.icons.outlined.Bookmark
+import androidx.compose.material.icons.outlined.Percent
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import eu.kanade.presentation.theme.TachiyomiPreviewTheme
+import kotlinx.coroutines.delay
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * Persistent overlay shown on the top edge of the reader page while reading.
+ * Displays the current time, battery percentage, and chapter name so the user
+ * can glance at this info without exiting the reader or opening the menu.
+ *
+ * KMK-only feature.
+ */
+@Composable
+fun TimeOverlay(modifier: Modifier = Modifier) {
+    // Clock — ticks every second
+    var clock by remember { mutableStateOf(LocalTime.now()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            clock = LocalTime.now()
+            delay(1000L)
+        }
+    }
+    val timeText = clock.format(DateTimeFormatter.ofPattern("HH:mm"))
+    val style = getOverlayStyle()
+    val strokeStyle = getOverlayStrokeStyle(style)
+
+    OverlayItem(Icons.Outlined.Schedule, timeText, style, strokeStyle, modifier)
+}
+
+@Composable
+fun BatteryOverlay(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    var batteryPct by remember { mutableIntStateOf(-1) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            batteryPct = currentBatteryPercent(context)
+            delay(30_000L)
+        }
+    }
+    val batteryText = if (batteryPct >= 0) "$batteryPct%" else ""
+    if (batteryText.isEmpty()) return
+    val batteryIcon = if (batteryPct >= 100) Icons.Outlined.BatteryFull else Icons.Outlined.BatteryStd
+    val style = getOverlayStyle()
+    val strokeStyle = getOverlayStrokeStyle(style)
+
+    OverlayItem(batteryIcon, batteryText, style, strokeStyle, modifier)
+}
+
+@Composable
+fun ChapterOverlay(chapterName: String?, modifier: Modifier = Modifier) {
+    if (chapterName.isNullOrBlank()) return
+    val chapterParts = remember(chapterName) {
+        val trimName = chapterName.trim()
+
+        // Find Vol/Volume prefix anywhere in the string
+        val volRegex = Regex("(?:vol\\.\\s*|vol\\s+|volume\\s+|v)(\\d+(?:\\.\\d+)?)", RegexOption.IGNORE_CASE)
+        val volMatch = volRegex.find(trimName)
+        val volValue = volMatch?.groupValues?.get(1)
+
+        // Find Ch/Chapter prefix anywhere in the string (not overlapping with Vol match)
+        val chRegex = Regex("(?:ch\\.\\s*|ch\\s+|chapter\\s+|c)(\\d+(?:\\.\\d+)?)", RegexOption.IGNORE_CASE)
+        var chValue: String? = null
+
+        val chMatches = chRegex.findAll(trimName)
+        for (match in chMatches) {
+            if (volMatch == null || match.range.first >= volMatch.range.last || match.range.last <= volMatch.range.first) {
+                chValue = match.groupValues[1]
+                break
+            }
+        }
+
+        // Fallback: search for any number not overlapping with Vol match
+        if (chValue == null) {
+            val numRegex = Regex("\\d+(?:\\.\\d+)?")
+            val numMatches = numRegex.findAll(trimName)
+            for (match in numMatches) {
+                if (volMatch == null || match.range.first >= volMatch.range.last || match.range.last <= volMatch.range.first) {
+                    chValue = match.value
+                    break
+                }
+            }
+        }
+
+        if (volValue != null && chValue != null) {
+            "Vol $volValue  •  Ch $chValue"
+        } else if (volValue != null) {
+            "Vol $volValue"
+        } else if (chValue != null) {
+            "Ch $chValue"
+        } else {
+            trimName
+        }
+    }
+    val style = getOverlayStyle()
+    val strokeStyle = getOverlayStrokeStyle(style)
+
+    OverlayItem(null, chapterParts, style, strokeStyle, modifier)
+}
+
+@Composable
+fun ProgressOverlay(currentPage: Int, totalPages: Int, modifier: Modifier = Modifier) {
+    if (totalPages <= 0 || currentPage <= 0) return
+    val chapterPct = (currentPage * 100 / totalPages).coerceIn(0, 100)
+    val progressText = "$chapterPct%"
+    val style = getOverlayStyle()
+    val strokeStyle = getOverlayStrokeStyle(style)
+
+    OverlayItem(null, progressText, style, strokeStyle, modifier)
+}
+
+@Composable
+private fun getOverlayStyle(): TextStyle {
+    return TextStyle(
+        // KMK -->
+        color = MaterialTheme.colorScheme.primary,
+        // KMK <--
+        fontSize = MaterialTheme.typography.bodySmall.fontSize,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = 1.sp,
+    )
+}
+
+@Composable
+private fun getOverlayStrokeStyle(style: TextStyle): TextStyle {
+    return style.copy(
+        color = Color(45, 45, 45),
+        drawStyle = Stroke(width = 4f),
+    )
+}
+
+@Composable
+private fun OverlayItem(
+    icon: ImageVector?,
+    text: String,
+    style: TextStyle,
+    strokeStyle: TextStyle,
+    modifier: Modifier = Modifier,
+) {
+    if (text.isEmpty()) return
+    // Icon uses primary color; text has stroke outline for readability over any page background
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier,
+    ) {
+        if (icon != null) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = style.color,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                text = text,
+                style = strokeStyle,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = text,
+                style = style,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+private fun currentBatteryPercent(context: android.content.Context): Int {
+    return try {
+        val intent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        if (intent != null) {
+            val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+            val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
+            if (level >= 0 && scale > 0) (level * 100 / scale) else -1
+        } else {
+            -1
+        }
+    } catch (e: Exception) {
+        -1
+    }
+}
+
+private fun extractNumber(text: String, isChapter: Boolean): String {
+    val trimmed = text.trim()
+    val prefixPattern = if (isChapter) {
+        Regex("(?:ch\\.|ch|chapter|c)\\s*(\\d+(?:\\.\\d+)?)", RegexOption.IGNORE_CASE)
+    } else {
+        Regex("(?:vol\\.|vol|volume|v)\\s*(\\d+(?:\\.\\d+)?)", RegexOption.IGNORE_CASE)
+    }
+
+    val prefixMatch = prefixPattern.find(trimmed)
+    if (prefixMatch != null) {
+        return prefixMatch.groupValues[1]
+    }
+
+    val numberPattern = Regex("\\d+(?:\\.\\d+)?")
+    val numberMatch = numberPattern.find(trimmed)
+    if (numberMatch != null) {
+        return numberMatch.value
+    }
+
+    return trimmed
+}
+
+@PreviewLightDark
+@Composable
+private fun TimeOverlayPreview() {
+    TachiyomiPreviewTheme {
+        Surface {
+            TimeOverlay()
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun BatteryOverlayPreview() {
+    TachiyomiPreviewTheme {
+        Surface {
+            BatteryOverlay()
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun ChapterOverlayPreview() {
+    TachiyomiPreviewTheme {
+        Surface {
+            ChapterOverlay(chapterName = "Vol. 1 Ch. 12")
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/settings/GeneralSettingsPage.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
 import eu.kanade.tachiyomi.util.system.hasDisplayCutout
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
 import tachiyomi.i18n.sy.SYMR
 import tachiyomi.presentation.core.components.CheckboxItem
 import tachiyomi.presentation.core.components.SettingsChipRow
@@ -60,6 +61,13 @@ internal fun GeneralPage(screenModel: ReaderSettingsScreenModel) {
         label = stringResource(MR.strings.pref_show_page_number),
         pref = screenModel.preferences.showPageNumber(),
     )
+
+    // KMK -->
+    CheckboxItem(
+        label = stringResource(KMR.strings.pref_show_persistent_info_overlay),
+        pref = screenModel.preferences.showPersistentInfoOverlay(),
+    )
+    // KMK <--
 
     // SY -->
     val forceHorizontalSeekbar by screenModel.preferences.forceHorizontalSeekbar().collectAsState()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -29,8 +29,15 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -66,13 +73,17 @@ import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.connections.service.ConnectionsPreferences
 import eu.kanade.domain.manga.model.readingMode
 import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.presentation.reader.BatteryOverlay
 import eu.kanade.presentation.reader.ChapterListDialog
+import eu.kanade.presentation.reader.ChapterOverlay
 import eu.kanade.presentation.reader.DisplayRefreshHost
 import eu.kanade.presentation.reader.OrientationSelectDialog
+import eu.kanade.presentation.reader.ProgressOverlay
 import eu.kanade.presentation.reader.ReaderContentOverlay
 import eu.kanade.presentation.reader.ReaderPageActionsDialog
 import eu.kanade.presentation.reader.ReaderPageIndicator
 import eu.kanade.presentation.reader.ReadingModeSelectDialog
+import eu.kanade.presentation.reader.TimeOverlay
 import eu.kanade.presentation.reader.appbars.NavBarType
 import eu.kanade.presentation.reader.appbars.ReaderAppBars
 import eu.kanade.presentation.reader.settings.ReaderSettingsDialog
@@ -102,6 +113,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
 import eu.kanade.tachiyomi.ui.reader.viewer.pager.PagerConfig
 import eu.kanade.tachiyomi.ui.reader.viewer.pager.PagerViewer
+import eu.kanade.tachiyomi.ui.reader.viewer.pager.R2LPagerViewer
 import eu.kanade.tachiyomi.ui.reader.viewer.pager.VerticalPagerViewer
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
@@ -326,6 +338,9 @@ class ReaderActivity : BaseActivity() {
             // KMK <--
             val state by viewModel.state.collectAsState()
             val showPageNumber by readerPreferences.showPageNumber().collectAsState()
+            // KMK -->
+            val showPersistentInfoOverlay by readerPreferences.showPersistentInfoOverlay().collectAsState()
+            // KMK <--
             val settingsScreenModel = remember {
                 ReaderSettingsScreenModel(
                     readerState = viewModel.state,
@@ -346,6 +361,46 @@ class ReaderActivity : BaseActivity() {
                             .navigationBarsPadding(),
                     )
                 }
+
+                // KMK -->
+                if (showPersistentInfoOverlay) {
+                    val isRtl = state.viewer is R2LPagerViewer
+                    val chapterAlignment = if (isRtl) Alignment.BottomStart else Alignment.BottomEnd
+                    val progressAlignment = if (isRtl) Alignment.BottomEnd else Alignment.BottomStart
+
+                    TimeOverlay(
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .padding(start = 12.dp, top = 6.dp),
+                    )
+                    BatteryOverlay(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(end = 12.dp, top = 6.dp),
+                    )
+                    ChapterOverlay(
+                        chapterName = state.currentChapter?.chapter?.name,
+                        modifier = Modifier
+                            .align(chapterAlignment)
+                            .navigationBarsPadding()
+                            .padding(
+                                start = if (isRtl) 12.dp else 0.dp,
+                                end = if (!isRtl) 12.dp else 0.dp,
+                            ),
+                    )
+                    ProgressOverlay(
+                        currentPage = state.currentPage,
+                        totalPages = state.totalPages,
+                        modifier = Modifier
+                            .align(progressAlignment)
+                            .navigationBarsPadding()
+                            .padding(
+                                start = if (isRtl) 0.dp else 12.dp,
+                                end = if (!isRtl) 0.dp else 12.dp,
+                            ),
+                    )
+                }
+                // KMK <--
 
                 ContentOverlay(state = state)
 
@@ -930,8 +985,10 @@ class ReaderActivity : BaseActivity() {
         viewModel.showMenus(visible)
         if (visible) {
             windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
-        } else if (readerPreferences.fullscreen().get()) {
+        } else if (readerPreferences.fullscreen().get() || readerPreferences.showPersistentInfoOverlay().get()) {
+            // KMK --> hide status bar when persistent overlay is on so info isn't duplicated
             windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+            // KMK <--
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -35,6 +35,10 @@ class ReaderPreferences(
 
     fun showPageNumber() = preferenceStore.getBoolean("pref_show_page_number_key", true)
 
+    // KMK -->
+    fun showPersistentInfoOverlay() = preferenceStore.getBoolean("pref_show_persistent_info_overlay_key", false)
+    // KMK <--
+
     fun showReadingMode() = preferenceStore.getBoolean("pref_show_reading_mode", true)
 
     fun fullscreen() = preferenceStore.getBoolean("fullscreen", true)

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -31,6 +31,7 @@
     <string name="pref_pinch_to_zoom">Pinch to zoom</string>
     <string name="pref_paged_disable_zoom_in">Disable zoom in</string>
     <string name="pref_landscape_zoom_type">Wide images zoom mode</string>
+    <string name="pref_show_persistent_info_overlay">Always show status</string>
     <string name="scale_type_double">Double zoom</string>
     <string name="pref_webtoon_scale_type">Smart scale on wide screen</string>
     <string name="pref_smart_scale_long_strip_gap">Apply Smart scale to Long strip with gaps</string>


### PR DESCRIPTION
## Summary
- Adds a toggleable overlay in the reader showing the current time, battery percentage, and chapter name in the top-right corner
- Hides the system status bar when active to avoid duplicate info
- The volume, chapter, and progress labels adapt based on the reading page direction (LTR / RTL)
- Toggle: Reader settings → General → "Always show status"

Tested in all reading modes:
- Portrait + paged (left-to-right / right-to-left)
- Landscape + paged (left-to-right / right-to-left)
- Portrait + long strip (webtoon)
- Landscape + long strip (webtoon)
- Portrait + double pages
- Landscape + double pages

<img width="456" height="1003" alt="screenshot-2026-07-21_20-43-20" src="https://github.com/user-attachments/assets/3c331b8d-6d9a-48a6-9f05-8d4600772bbd" />
<img width="463" height="1002" alt="screenshot-2026-07-21_20-59-45" src="https://github.com/user-attachments/assets/2381267a-1fc5-47b8-9723-b2cf0859929c" />

https://github.com/user-attachments/assets/9d140588-5e6c-4620-b61b-1c45d3787789

## Summary by Sourcery

Add an optional persistent status overlay to the reader that shows time, battery, chapter, and reading progress, with layout adapting to reading direction and system status bar hidden to avoid duplicate information.

New Features:
- Introduce a toggleable persistent status overlay in the reader displaying current time, battery percentage, chapter, and progress.
- Add a reader setting option "Always show status" to control the persistent info overlay.

Enhancements:
- Adjust overlay alignment so chapter and progress indicators respect left-to-right and right-to-left paged reading modes.