### PR TITLE
feat(manga): Add chapter number to resume button

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -156,6 +156,9 @@ fun MangaScreen(
     onFilterButtonClicked: () -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
+    // KMK -->
+    nextUnreadChapterNumber: Double?,
+    // KMK <--
     onSearch: (query: String, global: Boolean) -> Unit,
 
     // For cover dialog
@@ -236,6 +239,9 @@ fun MangaScreen(
             onFilterClicked = onFilterButtonClicked,
             onRefresh = onRefresh,
             onContinueReading = onContinueReading,
+            // KMK -->
+            nextUnreadChapterNumber = nextUnreadChapterNumber,
+            // KMK <--
             onSearch = onSearch,
             onCoverClicked = onCoverClicked,
             onShareClicked = onShareClicked,
@@ -298,6 +304,9 @@ fun MangaScreen(
             onFilterButtonClicked = onFilterButtonClicked,
             onRefresh = onRefresh,
             onContinueReading = onContinueReading,
+            // KMK -->
+            nextUnreadChapterNumber = nextUnreadChapterNumber,
+            // KMK <--
             onSearch = onSearch,
             onCoverClicked = onCoverClicked,
             onShareClicked = onShareClicked,
@@ -366,6 +375,9 @@ private fun MangaScreenSmallImpl(
     onFilterClicked: () -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
+    // KMK -->
+    nextUnreadChapterNumber: Double?,
+    // KMK <--
     onSearch: (query: String, global: Boolean) -> Unit,
 
     // For cover dialog
@@ -538,9 +550,15 @@ private fun MangaScreenSmallImpl(
                     val isReading = remember(state.chapters) {
                         state.chapters.fastAny { it.chapter.read }
                     }
-                    Text(
-                        text = stringResource(if (isReading) MR.strings.action_resume else MR.strings.action_start),
-                    )
+                    // KMK -->
+                    val label = stringResource(if (isReading) MR.strings.action_resume else MR.strings.action_start)
+                    val text = if (isReading && nextUnreadChapterNumber != null && nextUnreadChapterNumber >= 0) {
+                        // KMK <--
+                        "$label ${formatChapterNumber(nextUnreadChapterNumber)}"
+                    } else {
+                        label
+                    }
+                    Text(text = text)
                 },
                 icon = { Icon(imageVector = Icons.Filled.PlayArrow, contentDescription = null) },
                 onClick = onContinueReading,
@@ -830,6 +848,9 @@ private fun MangaScreenLargeImpl(
     onFilterButtonClicked: () -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
+    // KMK -->
+    nextUnreadChapterNumber: Double?,
+    // KMK <--
     onSearch: (query: String, global: Boolean) -> Unit,
 
     // For cover dialog
@@ -998,11 +1019,17 @@ private fun MangaScreenLargeImpl(
                     val isReading = remember(state.chapters) {
                         state.chapters.fastAny { it.chapter.read }
                     }
-                    Text(
-                        text = stringResource(
-                            if (isReading) MR.strings.action_resume else MR.strings.action_start,
-                        ),
+                    // KMK -->
+                    val label = stringResource(
+                        if (isReading) MR.strings.action_resume else MR.strings.action_start,
                     )
+                    val text = if (isReading && nextUnreadChapterNumber != null && nextUnreadChapterNumber >= 0) {
+                        // KMK <--
+                        "$label ${formatChapterNumber(nextUnreadChapterNumber)}"
+                    } else {
+                        label
+                    }
+                    Text(text = text)
                 },
                 icon = { Icon(imageVector = Icons.Filled.PlayArrow, contentDescription = null) },
                 onClick = onContinueReading,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -334,6 +334,9 @@ class MangaScreen(
             onFilterButtonClicked = screenModel::showSettingsDialog,
             onRefresh = screenModel::fetchAllFromSource,
             onContinueReading = { continueReading(context, screenModel.getNextUnreadChapter()) },
+            // KMK -->
+            nextUnreadChapterNumber = remember(successState) { screenModel.getNextUnreadChapter()?.chapterNumber },
+            // KMK <--
             onSearch = { query, global -> scope.launch { performSearch(navigator, query, global) } },
             // KMK -->
             librarySearch = { query ->


### PR DESCRIPTION
## Summary
- Shows the next unread chapter number next to "Resume" on the manga screen FAB (e.g. "Resume 12")
- Uses existing `getNextUnreadChapter()` and `formatChapterNumber()` logic — no new APIs
- Updates automatically when returning from the reader (keyed to `successState`)
- Chapter 0 and unrecognized chapters (-1) show plain "Resume" without a number

## Summary by Sourcery

Display the next unread chapter number on the manga screen resume button when available, while falling back to the original label when no valid chapter is detected.

New Features:
- Show the formatted next unread chapter number alongside the Resume action on the manga screen floating action button when a valid unread chapter exists.

Enhancements:
- Propagate the next unread chapter number through manga screen composables and derive it from existing chapter state without introducing new data sources.