### PR TITLE
feat: Drag-to-reorder sources and groups in Browse

### DIFF
--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -145,6 +145,13 @@ class SourcePreferences(
     // KMK -->
     fun relatedMangas() = preferenceStore.getBoolean("related_mangas", true)
 
+    /**
+     * Stores custom group ordering as a comma-separated string of group keys.
+     * e.g. "pinned,category-English,ja,last_used"
+     * Groups not in this list fall back to default ordering after custom-ordered ones.
+     */
+    fun customGroupOrder() = preferenceStore.getString("custom_source_group_order", "")
+
     companion object {
         const val PINNED_SOURCES_PREF_KEY = "pinned_catalogues"
     }

--- a/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/SourcesScreen.kt
@@ -6,13 +6,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.DragHandle
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
@@ -22,11 +25,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -35,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
 import eu.kanade.domain.source.model.installedExtension
 import eu.kanade.presentation.browse.components.BaseSourceItem
+import eu.kanade.presentation.browse.components.SourceIcon
 import eu.kanade.presentation.components.AnimatedFloatingSearchBox
 import eu.kanade.presentation.components.SOURCE_SEARCH_BOX_HEIGHT
 import eu.kanade.presentation.util.animateItemFastScroll
@@ -44,6 +50,9 @@ import eu.kanade.tachiyomi.util.system.LocaleHelper
 import exh.source.EH_SOURCE_ID
 import exh.source.EXH_SOURCE_ID
 import kotlinx.collections.immutable.ImmutableList
+import sh.calvin.reorderable.ReorderableCollectionItemScope
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 import tachiyomi.domain.source.model.Pin
 import tachiyomi.domain.source.model.Source
 import tachiyomi.i18n.MR
@@ -71,6 +80,8 @@ fun SourcesScreen(
     // KMK -->
     @Suppress("UNUSED_PARAMETER") modifier: Modifier = Modifier,
     onChangeSearchQuery: (String?) -> Unit,
+    onReorderGroup: (String, Int) -> Unit,
+    onReorderSource: (String, Long, Int) -> Unit,
     // KMK <--
 ) {
     // KMK -->
@@ -97,46 +108,221 @@ fun SourcesScreen(
             val density = LocalDensity.current
             var searchBoxHeight by remember { mutableStateOf(SOURCE_SEARCH_BOX_HEIGHT) }
 
-            FastScrollLazyColumn(
-                state = lazyListState,
-                contentPadding = PaddingValues(top = searchBoxHeight),
-                // KMK <--
-            ) {
-                state.items.forEach { model ->
-                    when (model) {
-                        is SourceUiModel.Header -> {
-                            stickyHeader(
-                                key = "$STICKY_HEADER_KEY_PREFIX-header-${model.hashCode()}",
-                                contentType = "header",
-                            ) {
-                                SourceHeader(
-                                    modifier = Modifier
-                                        .animateItemFastScroll()
-                                        .background(MaterialTheme.colorScheme.background)
-                                        .fillMaxWidth(),
-                                    language = model.language,
-                                    // SY -->
-                                    isCategory = model.isCategory,
-                                    // SY <--
-                                )
+            if (state.reorderMode) {
+                // Reorder mode: flat list with drag handles on both group headers and source items.
+                // Headers move the entire group block; items only move within their own group.
+                val itemsState = remember { state.items.toMutableStateList() }
+                val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
+                    val fromItem = itemsState.getOrNull(from.index)
+                    val toItem = itemsState.getOrNull(to.index)
+                    if (fromItem == null || toItem == null) return@rememberReorderableLazyListState
+
+                    val isMovingHeader = fromItem is SourceUiModel.Header
+                    val isTargetHeader = toItem is SourceUiModel.Header
+
+                    if (isMovingHeader) {
+                        val fromHeader = fromItem as SourceUiModel.Header
+                        val fromGroupKey = SourcesScreenModel.groupKeyOf(fromHeader)
+
+                        // Pinned and last_used groups are fixed — skip reordering
+                        if (fromGroupKey == SourcesScreenModel.PINNED_KEY ||
+                            fromGroupKey == SourcesScreenModel.LAST_USED_KEY
+                        ) {
+                            return@rememberReorderableLazyListState
+                        }
+
+                        // Find the range of the source group
+                        var groupEnd = from.index
+                        for (i in (from.index + 1) until itemsState.size) {
+                            if (itemsState[i] is SourceUiModel.Header) break
+                            groupEnd = i
+                        }
+                        val groupSize = groupEnd - from.index + 1
+
+                        // Find target group position (the header we're dropping onto)
+                        val targetHeaderIndex = if (isTargetHeader) {
+                            to.index
+                        } else {
+                            // Find the header above the target item
+                            var headerIdx = to.index
+                            while (headerIdx > 0 && itemsState[headerIdx] !is SourceUiModel.Header) {
+                                headerIdx--
+                            }
+                            headerIdx
+                        }
+
+                        val targetHeader = itemsState.getOrNull(targetHeaderIndex) as? SourceUiModel.Header
+                            ?: return@rememberReorderableLazyListState
+                        val targetGroupKey = SourcesScreenModel.groupKeyOf(targetHeader)
+
+                        if (fromGroupKey == targetGroupKey) return@rememberReorderableLazyListState
+
+                        // Remove the source group block
+                        val groupBlock = itemsState.subList(from.index, from.index + groupSize).toList()
+                        repeat(groupSize) { itemsState.removeAt(from.index) }
+
+                        // Find new insertion index (target header may have shifted)
+                        val newHeaderIndex = itemsState.indexOfFirst {
+                            it is SourceUiModel.Header && SourcesScreenModel.groupKeyOf(it) == targetGroupKey
+                        }
+                        if (newHeaderIndex == -1) return@rememberReorderableLazyListState
+
+                        // Insert before or after target based on drag direction
+                        val insertIndex = if (to.index > from.index) {
+                            // Dragging down: insert after target group
+                            var afterGroup = newHeaderIndex
+                            for (i in (newHeaderIndex + 1) until itemsState.size) {
+                                if (itemsState[i] is SourceUiModel.Header) break
+                                afterGroup = i
+                            }
+                            afterGroup + 1
+                        } else {
+                            // Dragging up: insert before target group
+                            newHeaderIndex
+                        }
+
+                        itemsState.addAll(insertIndex.coerceIn(0, itemsState.size), groupBlock)
+
+                        // Compute the new group index and save
+                        val newGroupIndex = itemsState.indexOfFirst {
+                            it is SourceUiModel.Header && SourcesScreenModel.groupKeyOf(it) == fromGroupKey
+                        }
+                        // Count how many headers are before this one
+                        val groupIndex = itemsState.take(newGroupIndex)
+                            .count { it is SourceUiModel.Header }
+                        onReorderGroup(fromGroupKey, groupIndex)
+                    } else {
+                        // Moving a source item within its group
+                        val sourceItem = fromItem as SourceUiModel.Item
+                        if (isTargetHeader) return@rememberReorderableLazyListState
+
+                        // Find the group (header) for both from and to
+                        var fromHeaderIdx = from.index
+                        while (fromHeaderIdx > 0 && itemsState[fromHeaderIdx] !is SourceUiModel.Header) {
+                            fromHeaderIdx--
+                        }
+                        val fromHeader = itemsState.getOrNull(fromHeaderIdx) as? SourceUiModel.Header
+                            ?: return@rememberReorderableLazyListState
+                        val groupKey = SourcesScreenModel.groupKeyOf(fromHeader)
+
+                        // Check that target is in the same group
+                        var toHeaderIdx = to.index
+                        while (toHeaderIdx > 0 && itemsState[toHeaderIdx] !is SourceUiModel.Header) {
+                            toHeaderIdx--
+                        }
+                        if (toHeaderIdx != fromHeaderIdx) return@rememberReorderableLazyListState
+
+                        // Move the item in the list (adjust index after removal)
+                        val targetIndex = if (from.index < to.index) to.index - 1 else to.index
+                        itemsState.removeAt(from.index)
+                        itemsState.add(targetIndex.coerceIn(0, itemsState.size), sourceItem)
+
+                        // Compute new index within the group
+                        val groupStart = fromHeaderIdx + 1
+                        val newIndex = targetIndex - groupStart
+                        onReorderSource(groupKey, sourceItem.source.id, newIndex)
+                    }
+                }
+
+                LaunchedEffect(state.items) {
+                    if (!reorderableState.isAnyItemDragging) {
+                        itemsState.clear()
+                        itemsState.addAll(state.items)
+                    }
+                }
+
+                LazyColumn(
+                    state = lazyListState,
+                    contentPadding = PaddingValues(top = searchBoxHeight),
+                ) {
+                    itemsState.forEachIndexed { index, model ->
+                        when (model) {
+                            is SourceUiModel.Header -> {
+                                val groupKey = SourcesScreenModel.groupKeyOf(model)
+                                val isFixed = groupKey == SourcesScreenModel.PINNED_KEY ||
+                                    groupKey == SourcesScreenModel.LAST_USED_KEY
+                                item(
+                                    key = "header-${model.hashCode()}",
+                                    contentType = "header",
+                                ) {
+                                    ReorderableItem(reorderableState, key = "header-${model.hashCode()}") {
+                                        SourceHeader(
+                                            modifier = Modifier
+                                                .animateItem()
+                                                .background(MaterialTheme.colorScheme.background)
+                                                .fillMaxWidth(),
+                                            language = model.language,
+                                            isCategory = model.isCategory,
+                                            showDragHandle = !isFixed,
+                                            dragModifier = if (isFixed) Modifier else Modifier.draggableHandle(),
+                                        )
+                                    }
+                                }
+                            }
+                            is SourceUiModel.Item -> {
+                                item(
+                                    key = "source-${model.source.key()}",
+                                    contentType = "item",
+                                ) {
+                                    ReorderableItem(reorderableState, key = "source-${model.source.key()}") {
+                                        SourceItem(
+                                            modifier = Modifier.animateItem(),
+                                            source = model.source,
+                                            showLatest = state.showLatest,
+                                            showPin = state.showPin,
+                                            onClickItem = onClickItem,
+                                            onLongClickItem = onLongClickItem,
+                                            onClickPin = onClickPin,
+                                            showDragHandle = true,
+                                            dragModifier = Modifier.draggableHandle(),
+                                        )
+                                    }
+                                }
                             }
                         }
-                        is SourceUiModel.Item -> {
-                            item(
-                                key = "source-${model.source.key()}",
-                                contentType = "item",
-                            ) {
-                                SourceItem(
-                                    modifier = Modifier.animateItemFastScroll(),
-                                    source = model.source,
-                                    // SY -->
-                                    showLatest = state.showLatest,
-                                    showPin = state.showPin,
-                                    // SY <--
-                                    onClickItem = onClickItem,
-                                    onLongClickItem = onLongClickItem,
-                                    onClickPin = onClickPin,
-                                )
+                    }
+                }
+            } else {
+                FastScrollLazyColumn(
+                    state = lazyListState,
+                    contentPadding = PaddingValues(top = searchBoxHeight),
+                ) {
+                    state.items.forEach { model ->
+                        when (model) {
+                            is SourceUiModel.Header -> {
+                                stickyHeader(
+                                    key = "$STICKY_HEADER_KEY_PREFIX-header-${model.hashCode()}",
+                                    contentType = "header",
+                                ) {
+                                    SourceHeader(
+                                        modifier = Modifier
+                                            .animateItemFastScroll()
+                                            .background(MaterialTheme.colorScheme.background)
+                                            .fillMaxWidth(),
+                                        language = model.language,
+                                        // SY -->
+                                        isCategory = model.isCategory,
+                                        // SY <--
+                                    )
+                                }
+                            }
+                            is SourceUiModel.Item -> {
+                                item(
+                                    key = "source-${model.source.key()}",
+                                    contentType = "item",
+                                ) {
+                                    SourceItem(
+                                        modifier = Modifier.animateItemFastScroll(),
+                                        source = model.source,
+                                        // SY -->
+                                        showLatest = state.showLatest,
+                                        showPin = state.showPin,
+                                        // SY <--
+                                        onClickItem = onClickItem,
+                                        onLongClickItem = onLongClickItem,
+                                        onClickPin = onClickPin,
+                                    )
+                                }
                             }
                         }
                     }
@@ -171,21 +357,41 @@ private fun SourceHeader(
     // SY -->
     isCategory: Boolean,
     // SY <--
+    // KMK -->
+    showDragHandle: Boolean = false,
+    dragModifier: Modifier = Modifier,
+    // KMK <--
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    Text(
-        // SY -->
-        text = if (!isCategory) {
-            LocaleHelper.getSourceDisplayName(language, context)
-        } else {
-            language
-        },
-        // SY <--
+    Row(
         modifier = modifier
             .padding(horizontal = MaterialTheme.padding.medium, vertical = MaterialTheme.padding.small),
-        style = MaterialTheme.typography.header,
-    )
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // KMK -->
+        if (showDragHandle) {
+            Icon(
+                imageVector = Icons.Outlined.DragHandle,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .padding(end = MaterialTheme.padding.small)
+                    .then(dragModifier),
+            )
+        }
+        // KMK <--
+        Text(
+            // SY -->
+            text = if (!isCategory) {
+                LocaleHelper.getSourceDisplayName(language, context)
+            } else {
+                language
+            },
+            // SY <--
+            style = MaterialTheme.typography.header,
+        )
+    }
 }
 
 @Composable
@@ -198,6 +404,10 @@ private fun SourceItem(
     onClickItem: (Source, Listing) -> Unit,
     onLongClickItem: (Source) -> Unit,
     onClickPin: (Source) -> Unit,
+    // KMK -->
+    showDragHandle: Boolean = false,
+    dragModifier: Modifier = Modifier,
+    // KMK <--
     modifier: Modifier = Modifier,
 ) {
     BaseSourceItem(
@@ -205,6 +415,21 @@ private fun SourceItem(
         source = source,
         onClickItem = { onClickItem(source, Listing.Popular) },
         onLongClickItem = { onLongClickItem(source) },
+        // KMK -->
+        icon = {
+            if (showDragHandle) {
+                Icon(
+                    imageVector = Icons.Outlined.DragHandle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier
+                        .padding(end = MaterialTheme.padding.small)
+                        .then(dragModifier),
+                )
+            }
+            SourceIcon(source = source)
+        },
+        // KMK <--
         action = {
             if (source.supportsLatest /* SY --> */ && showLatest /* SY <-- */) {
                 TextButton(onClick = { onClickItem(source, Listing.Latest) }) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesScreenModel.kt
@@ -35,9 +35,11 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import logcat.LogPriority
+import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.source.model.Pin
 import tachiyomi.domain.source.model.Source
+import tachiyomi.domain.source.repository.SourceRepository
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.TreeMap
@@ -55,6 +57,9 @@ class SourcesScreenModel(
     private val sourcePreferences: SourcePreferences = Injekt.get(),
     val smartSearchConfig: SourcesScreen.SmartSearchConfig?,
     // SY <--
+    // KMK -->
+    private val sourceRepository: SourceRepository = Injekt.get(),
+    // KMK <--
 ) : StateScreenModel<SourcesScreenModel.State>(State()) {
 
     private val _events = Channel<Event>(Int.MAX_VALUE)
@@ -122,15 +127,29 @@ class SourcesScreenModel(
         val sources = unfilteredSources
             .filter { !nsfwOnly || it.installedExtension?.isNsfw != false }
             .filter(queryFilter(searchQuery))
-        // KMK <--
+
+        // User-customized group order stored as comma-separated keys (e.g. "en,ja")
+        // Special groups (pinned, last_used) are excluded — they always stay at top
+        val customGroupOrderList = sourcePreferences.customGroupOrder().get()
+            .split(",")
+            .filter { it.isNotBlank() && it != PINNED_KEY && it != LAST_USED_KEY }
         mutableState.update { state ->
             val map = TreeMap<String, MutableList<Source>> { d1, d2 ->
+                // Pinned and last_used always stay at top, regardless of custom order
+                when {
+                    d1 == PINNED_KEY && d2 != PINNED_KEY -> return@TreeMap -1
+                    d2 == PINNED_KEY && d1 != PINNED_KEY -> return@TreeMap 1
+                    d1 == LAST_USED_KEY && d2 != LAST_USED_KEY -> return@TreeMap -1
+                    d2 == LAST_USED_KEY && d1 != LAST_USED_KEY -> return@TreeMap 1
+                }
+                // Custom group order takes priority over default alphabetical sorting
+                val d1Custom = customGroupOrderList.indexOf(d1)
+                val d2Custom = customGroupOrderList.indexOf(d2)
+                if (d1Custom != -1 && d2Custom != -1) return@TreeMap d1Custom.compareTo(d2Custom)
+                if (d1Custom != -1) return@TreeMap -1
+                if (d2Custom != -1) return@TreeMap 1
                 // Sources without a lang defined will be placed at the end
                 when {
-                    d1 == LAST_USED_KEY && d2 != LAST_USED_KEY -> -1
-                    d2 == LAST_USED_KEY && d1 != LAST_USED_KEY -> 1
-                    d1 == PINNED_KEY && d2 != PINNED_KEY -> -1
-                    d2 == PINNED_KEY && d1 != PINNED_KEY -> 1
                     // SY -->
                     d1.startsWith(CATEGORY_KEY_PREFIX) && !d2.startsWith(CATEGORY_KEY_PREFIX) -> -1
                     d2.startsWith(CATEGORY_KEY_PREFIX) && !d1.startsWith(CATEGORY_KEY_PREFIX) -> 1
@@ -140,29 +159,22 @@ class SourcesScreenModel(
                     else -> d1.compareTo(d2)
                 }
             }
-            val byLang = sources.groupByTo(map) {
-                when {
-                    // SY -->
-                    it.category != null -> "$CATEGORY_KEY_PREFIX${it.category}"
-                    // SY <--
-                    it.isUsedLast -> LAST_USED_KEY
-                    Pin.Actual in it.pin -> PINNED_KEY
-                    else -> it.lang
-                }
-            }
+            val byLang = sources.groupByTo(map) { sourceGroupKey(it) }
 
             state.copy(
                 isLoading = false,
                 items = byLang
-                    .flatMap {
+                    .flatMap { (groupKey, groupSources) ->
                         listOf(
                             SourceUiModel.Header(
-                                it.key.removePrefix(CATEGORY_KEY_PREFIX),
-                                it.value.firstOrNull()?.category != null,
+                                groupKey.removePrefix(CATEGORY_KEY_PREFIX),
+                                groupSources.firstOrNull()?.category != null,
                             ),
-                            *it.value.map { source ->
-                                SourceUiModel.Item(source)
-                            }.toTypedArray(),
+                            // Sort sources within each group by DB position, then name as tiebreaker
+                            *groupSources
+                                .sortedWith(compareBy<Source> { it.sort }.thenBy { it.name.lowercase() })
+                                .map { SourceUiModel.Item(it) }
+                                .toTypedArray(),
                         )
                     }
                     .toImmutableList(),
@@ -207,19 +219,66 @@ class SourcesScreenModel(
         mutableState.update { it.copy(dialog = null) }
     }
 
-    // KMK -->
     fun search(query: String?) {
-        mutableState.update {
-            it.copy(searchQuery = query)
-        }
+        mutableState.update { it.copy(searchQuery = query) }
     }
 
     fun toggleNsfwOnly() {
-        mutableState.update {
-            it.copy(nsfwOnly = !it.nsfwOnly)
+        mutableState.update { it.copy(nsfwOnly = !it.nsfwOnly) }
+    }
+
+    fun toggleReorderMode() {
+        mutableState.update { it.copy(reorderMode = !it.reorderMode) }
+    }
+
+    // Reorder a group header to a new position among reorderable groups.
+    // Pinned and last_used are excluded — they always stay at top.
+    fun reorderGroup(groupKey: String, newIndex: Int) {
+        if (groupKey == PINNED_KEY || groupKey == LAST_USED_KEY) return
+
+        val allGroups = state.value.items
+            .filterIsInstance<SourceUiModel.Header>()
+            .map { groupKeyOf(it) }
+            .filter { it != PINNED_KEY && it != LAST_USED_KEY }
+
+        // Merge saved custom order with any new groups not yet in the preference
+        val ordered = sourcePreferences.customGroupOrder().get()
+            .split(",")
+            .filter { it.isNotBlank() && it in allGroups }
+            .let { custom -> custom + allGroups.filter { it !in custom } }
+            .toMutableList()
+
+        val currentIndex = ordered.indexOf(groupKey)
+        if (currentIndex == -1) return
+
+        ordered.removeAt(currentIndex)
+        ordered.add(newIndex.coerceIn(0, ordered.size), groupKey)
+        sourcePreferences.customGroupOrder().set(ordered.joinToString(","))
+    }
+
+    // Reorder a source within its group by writing new sort positions to the DB.
+    fun reorderSourceWithinGroup(groupKey: String, sourceId: Long, newIndex: Int) {
+        screenModelScope.launchIO {
+            val sourceIds = state.value.items
+                .filterIsInstance<SourceUiModel.Item>()
+                .map { it.source }
+                .filter { sourceGroupKey(it) == groupKey }
+                .sortedBy { it.sort }
+                .map { it.id }
+                .toMutableList()
+
+            val currentIndex = sourceIds.indexOf(sourceId)
+            if (currentIndex == -1) return@launchIO
+
+            sourceIds.removeAt(currentIndex)
+            sourceIds.add(newIndex.coerceIn(0, sourceIds.size), sourceId)
+
+            // Rewrite sort positions for all sources in the group
+            sourceIds.forEachIndexed { index, id ->
+                sourceRepository.updateSort(id, index.toLong())
+            }
         }
     }
-    // KMK <--
 
     sealed interface Event {
         data object FailedFetchingSources : Event
@@ -244,6 +303,7 @@ class SourcesScreenModel(
         // KMK -->
         val searchQuery: String? = null,
         val nsfwOnly: Boolean = false,
+        val reorderMode: Boolean = false,
         // KMK <--
     ) {
         val isEmpty = items.isEmpty()
@@ -256,5 +316,18 @@ class SourcesScreenModel(
         // SY -->
         const val CATEGORY_KEY_PREFIX = "category-"
         // SY <--
+
+        // Compute the group key for a source (e.g. "en", "pinned", "category-English")
+        fun sourceGroupKey(source: Source) = when {
+            // SY -->
+            source.category != null -> "$CATEGORY_KEY_PREFIX${source.category}"
+            // SY <--
+            source.isUsedLast -> LAST_USED_KEY
+            Pin.Actual in source.pin -> PINNED_KEY
+            else -> source.lang
+        }
+
+        fun groupKeyOf(header: SourceUiModel.Header) =
+            if (header.isCategory) "$CATEGORY_KEY_PREFIX${header.language}" else header.language
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/SourcesTab.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.browse.source
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.DragIndicator
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.TravelExplore
 import androidx.compose.material.icons.outlined._18UpRating
@@ -62,6 +63,12 @@ fun Screen.sourcesTab(
                 iconTint = if (state.nsfwOnly) MaterialTheme.colorScheme.error else LocalContentColor.current,
                 onClick = { screenModel.toggleNsfwOnly() },
             ),
+            AppBar.Action(
+                title = stringResource(KMR.strings.action_reorder_sources),
+                icon = Icons.Outlined.DragIndicator,
+                iconTint = if (state.reorderMode) MaterialTheme.colorScheme.primary else LocalContentColor.current,
+                onClick = { screenModel.toggleReorderMode() },
+            ),
             // KMK <--
         ).let {
             when (smartSearchConfig) {
@@ -98,6 +105,8 @@ fun Screen.sourcesTab(
                 onLongClickItem = screenModel::showSourceDialog,
                 // KMK -->
                 onChangeSearchQuery = screenModel::search,
+                onReorderGroup = screenModel::reorderGroup,
+                onReorderSource = screenModel::reorderSourceWithinGroup,
                 // KMK <--
             )
 

--- a/data/src/main/java/tachiyomi/data/source/SourceRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/SourceRepositoryImpl.kt
@@ -22,13 +22,20 @@ class SourceRepositoryImpl(
 ) : SourceRepository {
 
     override fun getSources(): Flow<List<DomainSource>> {
-        return sourceManager.sources.map { sources ->
+        // KMK -->
+        return combine(
+            sourceManager.sources,
+            handler.subscribeToList { sourcesQueries.findAll { id, _, _, sort -> id to sort } },
+        ) { sources, sourceSorts ->
+            val sortMap = sourceSorts.associate { it.first to it.second }
             sources.map {
                 mapSourceToDomainSource(it).copy(
                     supportsLatest = it.supportsLatest,
+                    sort = sortMap[it.id] ?: 0L,
                 )
             }
         }
+        // KMK <--
     }
 
     override fun getOnlineSources(): Flow<List<DomainSource>> {
@@ -113,4 +120,12 @@ class SourceRepositoryImpl(
         supportsLatest = false,
         isStub = false,
     )
+
+    // KMK -->
+    override suspend fun updateSort(sourceId: Long, sort: Long) {
+        handler.await {
+            sourcesQueries.updateSort(sort, sourceId)
+        }
+    }
+    // KMK <--
 }

--- a/data/src/main/java/tachiyomi/data/source/StubSourceRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/StubSourceRepositoryImpl.kt
@@ -25,5 +25,11 @@ class StubSourceRepositoryImpl(
         id: Long,
         lang: String,
         name: String,
+        // KMK -->
+        // sort is required by SQLDelight (findAll returns 4 columns) but unused here —
+        // StubSource is a source API impl, not the domain model. Sort is applied
+        // when converting to domain Source in SourceRepositoryImpl.getSources().
+        @Suppress("UNUSED_PARAMETER") sort: Long,
+        // KMK <--
     ): StubSource = StubSource(id = id, lang = lang, name = name)
 }

--- a/data/src/main/sqldelight/tachiyomi/data/sources.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/sources.sq
@@ -1,7 +1,10 @@
 CREATE TABLE sources(
     _id INTEGER NOT NULL PRIMARY KEY,
     lang TEXT NOT NULL,
-    name TEXT NOT NULL
+    name TEXT NOT NULL,
+    -- KMK -->
+    sort INTEGER NOT NULL DEFAULT 0
+    -- KMK <--
 );
 
 findAll:
@@ -22,3 +25,10 @@ SET
     lang = :lang,
     name = :name
 WHERE _id = :id;
+
+-- KMK -->
+updateSort:
+UPDATE sources
+SET sort = :sort
+WHERE _id = :id;
+-- KMK <--

--- a/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
@@ -1,0 +1,4 @@
+-- KMK -->
+-- Add sort column to sources for custom source ordering within groups
+ALTER TABLE sources ADD COLUMN sort INTEGER NOT NULL DEFAULT 0;
+-- KMK <--

--- a/domain/src/main/java/tachiyomi/domain/source/model/Source.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/model/Source.kt
@@ -13,6 +13,9 @@ data class Source(
     val isExcludedFromDataSaver: Boolean = false,
     val categories: Set<String> = emptySet(),
     // SY <--
+    // KMK -->
+    val sort: Long = 0,
+    // KMK <--
 ) {
 
     val visualName: String

--- a/domain/src/main/java/tachiyomi/domain/source/repository/SourceRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/repository/SourceRepository.kt
@@ -25,4 +25,8 @@ interface SourceRepository {
     fun getPopular(sourceId: Long): SourcePagingSource
 
     fun getLatest(sourceId: Long): SourcePagingSource
+
+    // KMK -->
+    suspend fun updateSort(sourceId: Long, sort: Long)
+    // KMK <--
 }

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -5,6 +5,7 @@
     <string name="action_source_search">Search in source</string>
     <string name="action_library_search">Library search</string>
     <string name="action_toggle_nsfw_only">Toggle NSFW only</string>
+    <string name="action_reorder_sources">Reorder sources</string>
     <string name="action_bulk_select">Bulk selection mode</string>
     <string name="action_faq_and_guides">FAQ and Guides</string>
     <string name="action_move_up">Move up</string>


### PR DESCRIPTION
## Summary
- Add `sort` column to `sources` table (migration 47) for persisting source order within groups
- Add `customGroupOrder` preference for persisting group order
- Add reorder mode toggle (drag handle icon in Sources toolbar) with drag handles on both group headers and source items
- Group headers move the entire group block; sources only move within their own group
- Pinned group always stays at top, then last_used, then custom-ordered groups, then SY categories, then alphabetical language groups
- Extract `sourceGroupKey()` and `groupKeyOf()` helpers to deduplicate group key computation

#### Test plan
- [ ] Open Browse → Sources, tap drag handle icon in toolbar
- [ ] Drag a source within a group — order persists after app restart
- [ ] Drag a group header — entire group block moves
- [ ] Verify pinned sources stay at top regardless of custom order
- [ ] Verify last_used group stays below pinned
- [ ] Exit reorder mode, verify normal browse still works

## Summary by Sourcery

Add a drag-to-reorder mode in the Browse → Sources screen, persisting custom ordering of source groups and individual sources.

New Features:
- Introduce a reorder mode toggle in the Sources tab with drag handles on group headers and source items.
- Allow reordering of source groups with a custom group order preference that affects listing order.
- Enable reordering of sources within each group and persist their positions via a new sort field.

Enhancements:
- Update source grouping and sorting logic so pinned and last-used groups remain at the top, followed by custom-ordered groups, SY categories, and language groups.
- Refine source list UI headers and items to support integrated drag handles while keeping normal browsing behavior unchanged.
- Centralize group key computation into reusable helpers for consistent grouping across the screen model.

Build:
- Wire up SourceRepository to read and update per-source sort values from the database, including stubs for testing.

Documentation:
- Add a localized string for the new "Reorder sources" action in the toolbar.

Chores:
- Extend the Source domain model with a sort field used for custom in-group ordering.

https://github.com/user-attachments/assets/a0c3ce50-546b-433a-ae39-1b215e5c1c02