### PR TITLE
Performance Improvements

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/advanced/ClearDatabaseScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/advanced/ClearDatabaseScreen.kt
@@ -48,6 +48,7 @@ import tachiyomi.core.common.util.lang.launchUI
 import tachiyomi.core.common.util.lang.toLong
 import tachiyomi.core.common.util.lang.withNonCancellableContext
 import tachiyomi.data.Database
+import tachiyomi.domain.history.repository.HistoryRepository
 import tachiyomi.domain.source.interactor.GetSourcesWithNonLibraryManga
 import tachiyomi.domain.source.model.Source
 import tachiyomi.domain.source.model.SourceWithCount
@@ -225,6 +226,11 @@ private class ClearDatabaseScreenModel : StateScreenModel<ClearDatabaseScreenMod
     private val getSourcesWithNonLibraryManga: GetSourcesWithNonLibraryManga = Injekt.get()
     private val database: Database = Injekt.get()
 
+    // KMK -->
+    // Goes through the repository so the cached chapter aggregates are rebuilt in bulk.
+    private val historyRepository: HistoryRepository = Injekt.get()
+    // KMK <--
+
     init {
         screenModelScope.launchIO {
             getSourcesWithNonLibraryManga.subscribe()
@@ -243,7 +249,7 @@ private class ClearDatabaseScreenModel : StateScreenModel<ClearDatabaseScreenMod
     suspend fun removeMangaBySourceId(keepReadManga: Boolean) = withNonCancellableContext {
         val state = state.value as? State.Ready ?: return@withNonCancellableContext
         database.mangasQueries.deleteNonLibraryManga(state.selection, keepReadManga.toLong())
-        database.historyQueries.removeResettedHistory()
+        historyRepository.removeResettedHistory()
     }
 
     fun toggleSelection(source: Source) = mutableState.update { state ->

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -165,12 +165,19 @@ class MangaCoverFetcher(
             }
 
             // Fetch from network
-            val response = executeNetworkRequest()
+            // KMK -->
+            val (response, permit) = executeNetworkRequest()
+            // KMK <--
             val responseBody = checkNotNull(response.body) { "Null response source" }
             try {
                 // Read from cover cache after library manga cover updated
                 val responseCoverCache = writeResponseToCoverCache(response, libraryCoverCacheFile)
                 if (responseCoverCache != null) {
+                    // KMK -->
+                    // The cache owns the copied body.
+                    response.close()
+                    permit.release()
+                    // KMK <--
                     return fileLoader(responseCoverCache)
                 }
 
@@ -178,6 +185,9 @@ class MangaCoverFetcher(
                 snapshot = writeToDiskCache(response)
                 if (snapshot != null) {
                     // KMK -->
+                    // The disk cache consumed the body.
+                    response.close()
+                    permit.release()
                     setRatioAndColorsInScope(mangaCover, bufferedSource = snapshot.toImageSource().source())
                     // KMK <--
                     return SourceFetchResult(
@@ -188,22 +198,21 @@ class MangaCoverFetcher(
                 }
 
                 // KMK -->
-                setRatioAndColorsInScope(
-                    mangaCover,
-                    bufferedSource = ImageSource(
-                        source = responseBody.source(),
-                        fileSystem = FileSystem.SYSTEM,
-                    ).source(),
-                )
-                // KMK <--
-                // Read from response if cache is unused or unusable
+                // Coil alone consumes the uncached body; the permit follows it until drained or closed.
                 return SourceFetchResult(
-                    source = ImageSource(source = responseBody.source(), fileSystem = FileSystem.SYSTEM),
+                    source = ImageSource(
+                        source = permit.releaseWhenConsumed(responseBody.source()),
+                        fileSystem = FileSystem.SYSTEM,
+                    ),
                     mimeType = "image/*",
                     dataSource = if (response.cacheResponse != null) DataSource.DISK else DataSource.NETWORK,
                 )
+                // KMK <--
             } catch (e: Exception) {
                 responseBody.close()
+                // KMK -->
+                permit.release()
+                // KMK <--
                 throw e
             }
         } catch (e: Exception) {
@@ -212,15 +221,25 @@ class MangaCoverFetcher(
         }
     }
 
-    private suspend fun executeNetworkRequest(): Response {
+    // KMK -->
+    /** The caller owns the returned permit and must release it once the body is done with. */
+    private suspend fun executeNetworkRequest(): Pair<Response, SourceImageCallLimiter.Permit> {
         val client = sourceLazy.value?.client ?: callFactoryLazy.value
-        val response = client.newCall(newRequest()).await()
-        if (!response.isSuccessful && response.code != HTTP_NOT_MODIFIED) {
-            response.close()
-            throw IOException(response.message)
+        val permit = SourceImageCallLimiter.acquire(mangaCover.sourceId)
+        try {
+            val response = client.newCall(newRequest()).await()
+            if (!response.isSuccessful && response.code != HTTP_NOT_MODIFIED) {
+                response.close()
+                throw IOException(response.message)
+            }
+            return response to permit
+        } catch (e: Throwable) {
+            // Covers cancellation as well, so a dropped request cannot leak its permit.
+            permit.release()
+            throw e
         }
-        return response
     }
+    // KMK <--
 
     private fun newRequest(): Request {
         val request = Request.Builder().apply {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/PagePreviewFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/PagePreviewFetcher.kt
@@ -88,18 +88,30 @@ class PagePreviewFetcher(
             }
 
             // Fetch from network
-            val response = executeNetworkRequest()
+            // KMK -->
+            val (response, permit) = executeNetworkRequest()
+            // KMK <--
             val responseBody = checkNotNull(response.body) { "Null response source" }
             try {
                 // Read from page preview cache after page preview updated
                 val responsePagePreviewCache = writeResponseToPagePreviewCache(response)
                 if (responsePagePreviewCache != null) {
+                    // KMK -->
+                    // The cache owns the copied body.
+                    response.close()
+                    permit.release()
+                    // KMK <--
                     return fileLoader(responsePagePreviewCache)
                 }
 
                 // Read from disk cache
                 snapshot = writeToDiskCache(response)
                 if (snapshot != null) {
+                    // KMK -->
+                    // The disk cache consumed the body.
+                    response.close()
+                    permit.release()
+                    // KMK <--
                     return SourceFetchResult(
                         source = snapshot.toImageSource(),
                         mimeType = "image/*",
@@ -109,12 +121,21 @@ class PagePreviewFetcher(
 
                 // Read from response if cache is unused or unusable
                 return SourceFetchResult(
-                    source = ImageSource(source = responseBody.source(), fileSystem = FileSystem.SYSTEM),
+                    // KMK -->
+                    // The permit lasts until the body is drained or closed.
+                    source = ImageSource(
+                        source = permit.releaseWhenConsumed(responseBody.source()),
+                        fileSystem = FileSystem.SYSTEM,
+                    ),
+                    // KMK <--
                     mimeType = "image/*",
                     dataSource = if (response.cacheResponse != null) DataSource.DISK else DataSource.NETWORK,
                 )
             } catch (e: Exception) {
                 responseBody.close()
+                // KMK -->
+                permit.release()
+                // KMK <--
                 throw e
             }
         } catch (e: Exception) {
@@ -123,17 +144,27 @@ class PagePreviewFetcher(
         }
     }
 
-    private suspend fun executeNetworkRequest(): Response {
-        val response = sourceLazy.value?.fetchPreviewImage(
-            page.getPagePreviewInfo(),
-            getCacheControl(),
-        ) ?: callFactoryLazy.value.newCall(newRequest()).await()
-        if (!response.isSuccessful && response.code != HTTP_NOT_MODIFIED) {
-            response.close()
-            throw IOException(response.message)
+    // KMK -->
+    /** The caller owns the returned permit and must release it once the body is done with. */
+    private suspend fun executeNetworkRequest(): Pair<Response, SourceImageCallLimiter.Permit> {
+        val permit = SourceImageCallLimiter.acquire(page.source)
+        try {
+            val response = sourceLazy.value?.fetchPreviewImage(
+                page.getPagePreviewInfo(),
+                getCacheControl(),
+            ) ?: callFactoryLazy.value.newCall(newRequest()).await()
+            if (!response.isSuccessful && response.code != HTTP_NOT_MODIFIED) {
+                response.close()
+                throw IOException(response.message)
+            }
+            return response to permit
+        } catch (e: Throwable) {
+            // Covers cancellation as well, so a dropped request cannot leak its permit.
+            permit.release()
+            throw e
         }
-        return response
     }
+    // KMK <--
 
     private fun getCacheControl(): CacheControl {
         return when {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/SourceImageCallLimiter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/SourceImageCallLimiter.kt
@@ -1,0 +1,69 @@
+package eu.kanade.tachiyomi.data.coil
+
+import kotlinx.coroutines.sync.Semaphore
+import okio.Buffer
+import okio.BufferedSource
+import okio.ForwardingSource
+import okio.buffer
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+// KMK -->
+/** Limits concurrent image requests for each source. */
+internal object SourceImageCallLimiter {
+
+    /** Leaves OkHttp host slots for user requests. */
+    private const val CONCURRENCY = 2
+
+    private val semaphores = ConcurrentHashMap<Long, Semaphore>()
+
+    /** Acquires a permit whose ownership follows the guarded response body. */
+    suspend fun acquire(sourceId: Long): Permit {
+        // `computeIfAbsent` atomically creates the source semaphore.
+        val semaphore = semaphores.computeIfAbsent(sourceId) { Semaphore(CONCURRENCY) }
+        semaphore.acquire()
+        return Permit(semaphore)
+    }
+
+    /** Releasing is idempotent, so each exit path can release without tracking the others. */
+    class Permit(private val semaphore: Semaphore) {
+
+        private val released = AtomicBoolean(false)
+
+        fun release() {
+            if (released.compareAndSet(false, true)) {
+                semaphore.release()
+            }
+        }
+
+        /**
+         * Returns [source] with this permit's release attached to whichever comes first,
+         * the source being drained or closed.
+         *
+         * Close alone is not enough. Coil's file-backed decoding drains the source into a
+         * temp file and keeps the reference without closing it, so a permit waiting only on
+         * close is held through decoding, and leaks outright if the source is then dropped.
+         * Reaching the end of the body means the transfer this permit guards is over.
+         */
+        fun releaseWhenConsumed(source: BufferedSource): BufferedSource {
+            return object : ForwardingSource(source) {
+                override fun read(sink: Buffer, byteCount: Long): Long {
+                    val bytesRead = super.read(sink, byteCount)
+                    if (bytesRead == -1L) {
+                        release()
+                    }
+                    return bytesRead
+                }
+
+                override fun close() {
+                    try {
+                        super.close()
+                    } finally {
+                        release()
+                    }
+                }
+            }.buffer()
+        }
+    }
+}
+// KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/source/browse/BrowseSourceScreenModel.kt
@@ -228,12 +228,23 @@ open class BrowseSourceScreenModel(
                 // SY <--
             }.flow.map { pagingData ->
                 pagingData.map { (manga, metadata) ->
+                    // KMK -->
+                    // Load the initial favorite state for the synchronous filter below.
+                    val initialManga = getManga.await(manga.url, manga.source) ?: manga
+                    // KMK <--
                     getManga.subscribe(manga.url, manga.source)
                         .map { it ?: manga }
                         // SY -->
                         .combineMetadata(metadata)
                         // SY <--
-                        .stateIn(ioCoroutineScope)
+                        // KMK -->
+                        // Release the database subscription when the item leaves composition.
+                        .stateIn(
+                            ioCoroutineScope,
+                            SharingStarted.WhileSubscribed(stopTimeoutMillis = 5_000),
+                            initialManga to metadata,
+                        )
+                    // KMK <--
                 }
                     .filter { !hideInLibraryItems || !it.value.first.favorite }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -457,24 +457,32 @@ class MangaScreenModel(
             val needRefreshInfo = !manga.initialized
             val needRefreshChapter = chapters.isEmpty()
 
+            // KMK -->
+            // Resolve values outside the retrying state update.
+            // SY -->
+            val source = sourceManager.getOrStub(manga.source)
+            // SY <--
+            val availableScanlators = if (manga.source == MERGED_SOURCE_ID) {
+                getAvailableScanlators.awaitMerge(mangaId)
+            } else {
+                getAvailableScanlators.await(mangaId)
+            }.toImmutableSet()
+            val excludedScanlators = getExcludedScanlators.await(mangaId).toImmutableSet()
+            val raisedMeta = raiseMetadata(meta, source)
+            val hasPagePreviews = source.getMainSource() is PagePreviewSource
+            // KMK <--
+
             // Show what we have earlier
             mutableState.update {
-                // SY -->
-                val source = sourceManager.getOrStub(manga.source)
-                // SY <--
                 State.Success(
                     manga = manga,
                     source = source,
                     isFromSource = isFromSource,
                     chapters = chapters,
                     // SY -->
-                    availableScanlators = if (manga.source == MERGED_SOURCE_ID) {
-                        getAvailableScanlators.awaitMerge(mangaId)
-                    } else {
-                        getAvailableScanlators.await(mangaId)
-                    }.toImmutableSet(),
+                    availableScanlators = availableScanlators,
                     // SY <--
-                    excludedScanlators = getExcludedScanlators.await(mangaId).toImmutableSet(),
+                    excludedScanlators = excludedScanlators,
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
                     dialog = null,
                     hideMissingChapters = libraryPreferences.hideMissingChapters().get(),
@@ -483,9 +491,8 @@ class MangaScreenModel(
                     showMergeInOverflow = uiPreferences.mergeInOverflow().get(),
                     showMergeWithAnother = smartSearched,
                     mergedData = mergedData,
-                    meta = raiseMetadata(meta, source),
-                    pagePreviewsState = if (source.getMainSource() is PagePreviewSource) {
-                        getPagePreviews(manga, source)
+                    meta = raisedMeta,
+                    pagePreviewsState = if (hasPagePreviews) {
                         PagePreviewState.Loading
                     } else {
                         PagePreviewState.Unused
@@ -496,6 +503,13 @@ class MangaScreenModel(
                     // SY <--
                 )
             }
+
+            // KMK -->
+            // Fetch previews after the success state is available.
+            if (hasPagePreviews) {
+                getPagePreviews(manga, source)
+            }
+            // KMK <--
 
             // Start observe tracking since it only needs mangaId
             observeTrackers()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -74,6 +74,8 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import logcat.LogPriority
 import tachiyomi.core.common.preference.toggle
 import tachiyomi.core.common.storage.UniFileTempFileManager
@@ -248,33 +250,45 @@ class ReaderViewModel @JvmOverloads constructor(
 
     private var chapterToDownload: Download? = null
 
-    private val unfilteredChapterList by lazy {
-        val manga = manga!!
-        runBlocking {
-            // KMK -->
-            if (manga.source == MERGED_SOURCE_ID) {
-                getMergedChaptersByMangaId.await(manga.id, dedupe = false, applyFilter = false)
-            } else {
-                getChaptersByMangaId.await(manga.id, applyFilter = false)
-            }
-            // KMK <--
+    // KMK -->
+    /** Caches the unfiltered chapter list without blocking a thread. */
+    @Volatile
+    private var unfilteredChapterListCache: List<Chapter>? = null
+    private val unfilteredChapterListMutex = Mutex()
+
+    private suspend fun getUnfilteredChapterList(): List<Chapter> {
+        unfilteredChapterListCache?.let { return it }
+        return unfilteredChapterListMutex.withLock {
+            unfilteredChapterListCache ?: run {
+                val manga = manga!!
+                if (manga.source == MERGED_SOURCE_ID) {
+                    getMergedChaptersByMangaId.await(manga.id, dedupe = false, applyFilter = false)
+                } else {
+                    getChaptersByMangaId.await(manga.id, applyFilter = false)
+                }
+            }.also { unfilteredChapterListCache = it }
         }
     }
+    // KMK <--
 
-    /**
-     * Chapter list for the active manga. It's retrieved lazily and should be accessed for the first
-     * time in a background thread to avoid blocking the UI.
-     */
-    private val chapterList by lazy {
-        val manga = manga!!
+    // KMK -->
+    /** Chapter list for the active manga, built during [init]. */
+    @Volatile
+    private var chapterList: List<ReaderChapter> = emptyList()
+
+    /** Builds the chapter list before [init] publishes state. */
+    private suspend fun buildChapterList(
+        manga: Manga,
         // SY -->
-        val (chapters, mangaMap) = runBlocking {
-            if (manga.source == MERGED_SOURCE_ID) {
-                getMergedChaptersByMangaId.await(manga.id, applyFilter = true) to
-                    state.value.mergedManga
-            } else {
-                getChaptersByMangaId.await(manga.id, applyFilter = true) to null
-            }
+        mergedManga: Map<Long, Manga>?,
+        // SY <--
+    ): List<ReaderChapter> {
+        // SY -->
+        val (chapters, mangaMap) = if (manga.source == MERGED_SOURCE_ID) {
+            getMergedChaptersByMangaId.await(manga.id, applyFilter = true) to
+                mergedManga
+        } else {
+            getChaptersByMangaId.await(manga.id, applyFilter = true) to null
         }
         fun isChapterDownloaded(chapter: Chapter): Boolean {
             val chapterManga = mangaMap?.get(chapter.mangaId) ?: manga
@@ -325,7 +339,7 @@ class ReaderViewModel @JvmOverloads constructor(
             else -> chapters
         }
 
-        chaptersForReader
+        return chaptersForReader
             .sortedWith(getChapterSort(manga, sortDescending = false))
             .run {
                 if (readerPreferences.skipDupe().get()) {
@@ -344,6 +358,7 @@ class ReaderViewModel @JvmOverloads constructor(
             .map { it.toDbChapter() }
             .map(::ReaderChapter)
     }
+    // KMK <--
 
     val incognitoMode: Boolean by lazy { getIncognitoState.await(manga?.source) }
     private val downloadAheadAmount = downloadPreferences.autoDownloadWhileReading().get()
@@ -411,13 +426,28 @@ class ReaderViewModel @JvmOverloads constructor(
         return manga == null
     }
 
+    private val initMutex = Mutex()
+
     /**
      * Initializes this presenter with the given [mangaId] and [initialChapterId]. This method will
      * fetch the manga from the database and initialize the initial chapter.
      */
-    suspend fun init(mangaId: Long, initialChapterId: Long /* SY --> */, page: Int?/* SY <-- */): Result<Boolean> {
-        if (!needsInit()) return Result.success(true)
-        return withIOContext {
+    suspend fun init(
+        mangaId: Long,
+        initialChapterId: Long,
+        /* SY --> */
+        page: Int?,
+        /* SY <-- */
+    ): Result<Boolean> = initMutex.withLock {
+        if (!needsInit()) {
+            return@withLock Result.success(true)
+        }
+
+        // KMK -->
+        val previousChapterId = chapterId
+        // KMK <--
+
+        withIOContext {
             try {
                 val manga = getManga.await(mangaId)
                 if (manga != null) {
@@ -430,23 +460,29 @@ class ReaderViewModel @JvmOverloads constructor(
                     } else {
                         null
                     }
+                    // KMK -->
+                    // Do not block while already in a suspend context.
                     val mergedReferences = if (source is MergedSource) {
-                        runBlocking {
-                            getMergedReferencesById.await(manga.id)
-                        }
+                        getMergedReferencesById.await(manga.id)
                     } else {
                         emptyList()
                     }
                     val mergedManga = if (source is MergedSource) {
-                        runBlocking {
-                            getMergedMangaById.await(manga.id)
-                        }.associateBy { it.id }
+                        getMergedMangaById.await(manga.id).associateBy { it.id }
                     } else {
                         null
                     }
+                    // KMK <--
                     val relativeTime = uiPreferences.relativeTime().get()
                     val autoScrollFreq = readerPreferences.autoscrollInterval().get()
                     // SY <--
+
+                    // KMK -->
+                    // Build the list before publishing state.
+                    if (chapterId == -1L) chapterId = initialChapterId
+                    chapterList = buildChapterList(manga, /* SY --> */ mergedManga /* SY <-- */)
+                    // KMK <--
+
                     mutableState.update {
                         it.copy(
                             manga = manga,
@@ -463,7 +499,6 @@ class ReaderViewModel @JvmOverloads constructor(
                             // SY <--
                         )
                     }
-                    if (chapterId == -1L) chapterId = initialChapterId
 
                     val context = Injekt.get<Application>()
                     // val source = sourceManager.getOrStub(manga.source)
@@ -497,6 +532,11 @@ class ReaderViewModel @JvmOverloads constructor(
                 if (e is CancellationException) {
                     throw e
                 }
+                // KMK -->
+                // Nothing was published, so undo the id we claimed and let the next
+                // caller start from its own arguments.
+                if (needsInit()) chapterId = previousChapterId
+                // KMK <--
                 Result.failure(e)
             }
         }
@@ -861,7 +901,7 @@ class ReaderViewModel @JvmOverloads constructor(
         // SY -->
         if (manga?.isEhBasedManga() == true) {
             viewModelScope.launchNonCancellable {
-                val chapterUpdates = unfilteredChapterList
+                val chapterUpdates = getUnfilteredChapterList()
                     .filter { it.sourceOrder > readerChapter.chapter.source_order }
                     .map { chapter ->
                         ChapterUpdate(id = chapter.id, read = true)
@@ -878,7 +918,7 @@ class ReaderViewModel @JvmOverloads constructor(
             .contains(LibraryPreferences.MARK_DUPLICATE_CHAPTER_READ_EXISTING)
         if (!markDuplicateAsRead) return
 
-        val duplicateUnreadChapters = unfilteredChapterList
+        val duplicateUnreadChapters = getUnfilteredChapterList()
             .mapNotNull { chapter ->
                 if (
                     !chapter.read &&
@@ -1030,9 +1070,13 @@ class ReaderViewModel @JvmOverloads constructor(
                 val currChapter = currChapters.currChapter
                 currChapter.requestedPage = currChapter.chapter.last_page_read
 
+                // KMK -->
+                // Query outside the retrying state update.
+                val updatedManga = getManga.await(manga.id)
+                // KMK <--
                 mutableState.update {
                     it.copy(
-                        manga = getManga.await(manga.id),
+                        manga = updatedManga,
                         viewerChapters = currChapters,
                     )
                 }
@@ -1066,9 +1110,13 @@ class ReaderViewModel @JvmOverloads constructor(
                 val currChapter = currChapters.currChapter
                 currChapter.requestedPage = currChapter.chapter.last_page_read
 
+                // KMK -->
+                // Query outside the retrying state update.
+                val updatedManga = getManga.await(manga.id)
+                // KMK <--
                 mutableState.update {
                     it.copy(
-                        manga = getManga.await(manga.id),
+                        manga = updatedManga,
                         viewerChapters = currChapters,
                     )
                 }

--- a/app/src/main/java/exh/debug/DebugFunctions.kt
+++ b/app/src/main/java/exh/debug/DebugFunctions.kt
@@ -152,6 +152,16 @@ object DebugFunctions {
 
     fun clearSavedSearches() = runBlocking { handler.await { saved_searchQueries.deleteAll() } }
 
+    // KMK -->
+    /** Rebuilds cached chapter aggregates for repair. */
+    fun rebuildLibraryChapterStats() = runBlocking {
+        handler.await(inTransaction = true) {
+            manga_chapter_statsQueries.deleteAll()
+            manga_chapter_statsQueries.rebuild()
+        }
+    }
+    // KMK <--
+
     fun listAllSources() = sourceManager.getAll().joinToString("\n") {
         "${it.id}: ${it.name} (${it.lang.uppercase()})"
     }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/coil/SourceImageCallLimiterTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/coil/SourceImageCallLimiterTest.kt
@@ -1,0 +1,133 @@
+package eu.kanade.tachiyomi.data.coil
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import okio.Buffer
+import okio.buffer
+import okio.source
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// KMK -->
+@OptIn(ExperimentalCoroutinesApi::class)
+class SourceImageCallLimiterTest {
+
+    private fun bodyOf(size: Int) = ByteArrayInputStream(ByteArray(size)).source().buffer()
+
+    @Test
+    fun `draining the body releases the permit without a close`() = runTest {
+        val permit = SourceImageCallLimiter.acquire(sourceId = 1L)
+        val otherPermit = SourceImageCallLimiter.acquire(sourceId = 1L)
+        val guarded = permit.releaseWhenConsumed(bodyOf(64))
+        var waiterStarted = false
+        backgroundScope.launch {
+            SourceImageCallLimiter.acquire(sourceId = 1L).release()
+            waiterStarted = true
+        }
+        testScheduler.runCurrent()
+        waiterStarted shouldBe false
+
+        // Coil's file-backed path drains the source and keeps it open.
+        guarded.readAll(Buffer())
+        testScheduler.runCurrent()
+
+        waiterStarted shouldBe true
+        otherPermit.release()
+    }
+
+    @Test
+    fun `closing without draining releases the permit`() = runTest {
+        val permit = SourceImageCallLimiter.acquire(sourceId = 2L)
+        val otherPermit = SourceImageCallLimiter.acquire(sourceId = 2L)
+        val guarded = permit.releaseWhenConsumed(bodyOf(64))
+        var waiterStarted = false
+        backgroundScope.launch {
+            SourceImageCallLimiter.acquire(sourceId = 2L).release()
+            waiterStarted = true
+        }
+        testScheduler.runCurrent()
+        waiterStarted shouldBe false
+
+        guarded.close()
+        testScheduler.runCurrent()
+
+        waiterStarted shouldBe true
+        otherPermit.release()
+    }
+
+    @Test
+    fun `draining and then closing releases only once`() = runTest {
+        val permit = SourceImageCallLimiter.acquire(sourceId = 3L)
+        val otherPermit = SourceImageCallLimiter.acquire(sourceId = 3L)
+        val guarded = permit.releaseWhenConsumed(bodyOf(64))
+
+        guarded.readAll(Buffer())
+        guarded.close()
+        permit.release()
+
+        val releaseWaiters = CompletableDeferred<Unit>()
+        var waitersStarted = 0
+        repeat(2) {
+            backgroundScope.launch {
+                val waiterPermit = SourceImageCallLimiter.acquire(sourceId = 3L)
+                waitersStarted++
+                releaseWaiters.await()
+                waiterPermit.release()
+            }
+        }
+        testScheduler.runCurrent()
+
+        // Only the permit that was actually released is available.
+        waitersStarted shouldBe 1
+        otherPermit.release()
+        testScheduler.runCurrent()
+        waitersStarted shouldBe 2
+        releaseWaiters.complete(Unit)
+        testScheduler.runCurrent()
+    }
+
+    @Test
+    fun `the permit is held while the body is only partly read`() = runTest {
+        val permit = SourceImageCallLimiter.acquire(sourceId = 4L)
+        val otherPermit = SourceImageCallLimiter.acquire(sourceId = 4L)
+        val guarded = permit.releaseWhenConsumed(bodyOf(64))
+        var waiterStarted = false
+        backgroundScope.launch {
+            SourceImageCallLimiter.acquire(sourceId = 4L).release()
+            waiterStarted = true
+        }
+
+        guarded.readByte()
+        testScheduler.runCurrent()
+        waiterStarted shouldBe false
+
+        guarded.close()
+        testScheduler.runCurrent()
+        waiterStarted shouldBe true
+        otherPermit.release()
+    }
+
+    @Test
+    fun `a source runs at most two image requests at once`() = runTest {
+        val releaseRequests = CompletableDeferred<Unit>()
+        var started = 0
+        repeat(4) {
+            backgroundScope.launch {
+                val permit = SourceImageCallLimiter.acquire(sourceId = 5L)
+                started++
+                releaseRequests.await()
+                permit.release()
+            }
+        }
+        testScheduler.runCurrent()
+
+        started shouldBe 2
+        releaseRequests.complete(Unit)
+        testScheduler.runCurrent()
+        started shouldBe 4
+    }
+}
+// KMK <--

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -39,4 +39,10 @@ dependencies {
     implementation(kotlinx.serialization.protobuf)
 
     api(libs.bundles.sqldelight)
+
+    // KMK -->
+    testImplementation(libs.bundles.test)
+    testImplementation(libs.sqldelight.sqlite.driver)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    // KMK <--
 }

--- a/data/src/main/java/tachiyomi/data/AndroidDatabaseHandler.kt
+++ b/data/src/main/java/tachiyomi/data/AndroidDatabaseHandler.kt
@@ -10,8 +10,12 @@ import app.cash.sqldelight.coroutines.mapToOneOrNull
 import app.cash.sqldelight.db.SqlDriver
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.milliseconds
 
 class AndroidDatabaseHandler(
     val db: Database,
@@ -70,8 +74,26 @@ class AndroidDatabaseHandler(
         return dispatch(inTransaction) { block(db).executeAsOneOrNull() }
     }
 
-    override fun <T : Any> subscribeToList(block: Database.() -> Query<T>): Flow<List<T>> {
-        return block(db).asFlow().mapToList(queryDispatcher)
+    override fun <T : Any> subscribeToList(
+        // KMK -->
+        throttleMillis: Long,
+        // KMK <--
+        block: Database.() -> Query<T>,
+    ): Flow<List<T>> {
+        // KMK -->
+        val queries = block(db).asFlow()
+        if (throttleMillis <= 0) {
+            return queries.mapToList(queryDispatcher)
+        }
+        // Collapse invalidations from a write burst.
+        return queries
+            .conflate()
+            .transform { query ->
+                emit(query)
+                delay(throttleMillis.milliseconds)
+            }
+            .mapToList(queryDispatcher)
+        // KMK <--
     }
 
     override fun <T : Any> subscribeToOne(block: Database.() -> Query<T>): Flow<T> {

--- a/data/src/main/java/tachiyomi/data/DatabaseHandler.kt
+++ b/data/src/main/java/tachiyomi/data/DatabaseHandler.kt
@@ -41,7 +41,13 @@ interface DatabaseHandler {
         block: suspend Database.() -> ExecutableQuery<T>,
     ): T?
 
-    fun <T : Any> subscribeToList(block: Database.() -> Query<T>): Flow<List<T>>
+    // KMK -->
+    /** Use [throttleMillis] to collapse invalidations from write bursts. */
+    fun <T : Any> subscribeToList(
+        throttleMillis: Long = 0,
+        block: Database.() -> Query<T>,
+    ): Flow<List<T>>
+    // KMK <--
 
     fun <T : Any> subscribeToOne(block: Database.() -> Query<T>): Flow<T>
 

--- a/data/src/main/java/tachiyomi/data/MangaChapterStats.kt
+++ b/data/src/main/java/tachiyomi/data/MangaChapterStats.kt
@@ -1,0 +1,15 @@
+package tachiyomi.data
+
+// KMK -->
+/** Drops the cached stats rows, runs [block], then rebuilds them once. Bulk paths only; needs a transaction. */
+internal fun Database.rebuildingStats(resolveMangaIds: () -> List<Long>, block: Database.() -> Unit) {
+    val mangaIds = resolveMangaIds()
+    if (mangaIds.isEmpty()) {
+        block()
+        return
+    }
+    manga_chapter_statsQueries.deleteForMangaIds(mangaIds)
+    block()
+    manga_chapter_statsQueries.rebuildForMangaIds(mangaIds)
+}
+// KMK <--

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -78,7 +78,22 @@ class ChapterRepositoryImpl(
 
     override suspend fun removeChaptersWithIds(chapterIds: List<Long>) {
         try {
-            handler.await { chaptersQueries.removeChaptersWithIds(chapterIds) }
+            // KMK -->
+            // Dropping the cached rows first makes the delete trigger a no-op, so the maxima
+            // are recovered once per entry instead of once per chapter. Resolve the entries
+            // before the delete, while the chapters can still be joined back to them.
+            handler.await(inTransaction = true) {
+                val affectedMangaIds = chaptersQueries.getMangaIdsByChapterIds(chapterIds)
+                    .executeAsList()
+                if (affectedMangaIds.isNotEmpty()) {
+                    manga_chapter_statsQueries.deleteForMangaIds(affectedMangaIds)
+                }
+                chaptersQueries.removeChaptersWithIds(chapterIds)
+                if (affectedMangaIds.isNotEmpty()) {
+                    manga_chapter_statsQueries.rebuildForMangaIds(affectedMangaIds)
+                }
+            }
+            // KMK <--
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
         }

--- a/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapter/ChapterRepositoryImpl.kt
@@ -6,6 +6,7 @@ import tachiyomi.core.common.util.lang.toLong
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.data.DatabaseHandler
 import tachiyomi.data.MemoColumnAdapter
+import tachiyomi.data.rebuildingStats
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.repository.ChapterRepository
@@ -79,18 +80,10 @@ class ChapterRepositoryImpl(
     override suspend fun removeChaptersWithIds(chapterIds: List<Long>) {
         try {
             // KMK -->
-            // Dropping the cached rows first makes the delete trigger a no-op, so the maxima
-            // are recovered once per entry instead of once per chapter. Resolve the entries
-            // before the delete, while the chapters can still be joined back to them.
+            // Recovers the maxima once per entry instead of once per deleted chapter.
             handler.await(inTransaction = true) {
-                val affectedMangaIds = chaptersQueries.getMangaIdsByChapterIds(chapterIds)
-                    .executeAsList()
-                if (affectedMangaIds.isNotEmpty()) {
-                    manga_chapter_statsQueries.deleteForMangaIds(affectedMangaIds)
-                }
-                chaptersQueries.removeChaptersWithIds(chapterIds)
-                if (affectedMangaIds.isNotEmpty()) {
-                    manga_chapter_statsQueries.rebuildForMangaIds(affectedMangaIds)
+                rebuildingStats({ chaptersQueries.getMangaIdsByChapterIds(chapterIds).executeAsList() }) {
+                    chaptersQueries.removeChaptersWithIds(chapterIds)
                 }
             }
             // KMK <--

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.flow.Flow
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.toLong
 import tachiyomi.core.common.util.system.logcat
-import tachiyomi.data.Database
 import tachiyomi.data.DatabaseHandler
+import tachiyomi.data.rebuildingStats
 import tachiyomi.domain.history.model.History
 import tachiyomi.domain.history.model.HistoryUpdate
 import tachiyomi.domain.history.model.HistoryWithRelations
@@ -110,22 +110,6 @@ class HistoryRepositoryImpl(
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, throwable = e)
         }
-    }
-
-    /**
-     * Drops the cached stats rows for the affected entries so the per-row history triggers
-     * become no-ops, then rebuilds them once. [resolveMangaIds] runs before [block], while
-     * the history rows can still be joined back to their manga.
-     */
-    private fun Database.rebuildingStats(resolveMangaIds: () -> List<Long>, block: Database.() -> Unit) {
-        val mangaIds = resolveMangaIds()
-        if (mangaIds.isEmpty()) {
-            block()
-            return
-        }
-        manga_chapter_statsQueries.deleteForMangaIds(mangaIds)
-        block()
-        manga_chapter_statsQueries.rebuildForMangaIds(mangaIds)
     }
     // KMK <--
 

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.toLong
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.data.Database
 import tachiyomi.data.DatabaseHandler
 import tachiyomi.domain.history.model.History
 import tachiyomi.domain.history.model.HistoryUpdate
@@ -59,7 +60,11 @@ class HistoryRepositoryImpl(
     // KMK -->
     override suspend fun resetHistory(historyIds: List<Long>) {
         try {
-            handler.await { historyQueries.resetHistoryByIds(historyIds) }
+            handler.await(inTransaction = true) {
+                rebuildingStats({ historyQueries.getMangaIdsByHistoryIds(historyIds).executeAsList() }) {
+                    historyQueries.resetHistoryByIds(historyIds)
+                }
+            }
             // KMK <--
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, throwable = e)
@@ -69,7 +74,9 @@ class HistoryRepositoryImpl(
     // KMK -->
     override suspend fun resetHistoryByMangaIds(mangaIds: List<Long>) {
         try {
-            handler.await { historyQueries.resetHistoryByMangaIds(mangaIds) }
+            handler.await(inTransaction = true) {
+                rebuildingStats({ mangaIds }) { historyQueries.resetHistoryByMangaIds(mangaIds) }
+            }
             // KMK <--
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, throwable = e)
@@ -78,13 +85,49 @@ class HistoryRepositoryImpl(
 
     override suspend fun deleteAllHistory(): Boolean {
         return try {
-            handler.await { historyQueries.removeAllHistory() }
+            handler.await(inTransaction = true) {
+                // KMK -->
+                rebuildingStats({ historyQueries.getMangaIdsWithHistory().executeAsList() }) {
+                    historyQueries.removeAllHistory()
+                }
+                // KMK <--
+            }
             true
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, throwable = e)
             false
         }
     }
+
+    // KMK -->
+    override suspend fun removeResettedHistory() {
+        try {
+            handler.await(inTransaction = true) {
+                rebuildingStats({ historyQueries.getMangaIdsWithResettedHistory().executeAsList() }) {
+                    historyQueries.removeResettedHistory()
+                }
+            }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, throwable = e)
+        }
+    }
+
+    /**
+     * Drops the cached stats rows for the affected entries so the per-row history triggers
+     * become no-ops, then rebuilds them once. [resolveMangaIds] runs before [block], while
+     * the history rows can still be joined back to their manga.
+     */
+    private fun Database.rebuildingStats(resolveMangaIds: () -> List<Long>, block: Database.() -> Unit) {
+        val mangaIds = resolveMangaIds()
+        if (mangaIds.isEmpty()) {
+            block()
+            return
+        }
+        manga_chapter_statsQueries.deleteForMangaIds(mangaIds)
+        block()
+        manga_chapter_statsQueries.rebuildForMangaIds(mangaIds)
+    }
+    // KMK <--
 
     override suspend fun upsertHistory(historyUpdate: HistoryUpdate) {
         try {

--- a/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaMapper.kt
@@ -100,12 +100,15 @@ object MangaMapper {
         notes: String,
         memo: JsonObject,
         totalCount: Long,
-        readCount: Double,
+        // KMK -->
+        // Aggregates are stored integers now, not `SUM()` results.
+        readCount: Long,
+        // KMK <--
         latestUpload: Long,
         chapterFetchedAt: Long,
         lastRead: Long,
-        bookmarkCount: Double,
         // KMK -->
+        bookmarkCount: Long,
         bookmarkedReadCount: Long,
         // KMK <--
         categories: String,
@@ -143,9 +146,9 @@ object MangaMapper {
         ),
         categories = categories.split(",").map { it.toLong() },
         totalChapters = totalCount,
-        readCount = readCount.toLong(),
-        bookmarkCount = bookmarkCount.toLong(),
         // KMK -->
+        readCount = readCount,
+        bookmarkCount = bookmarkCount,
         bookmarkReadCount = bookmarkedReadCount,
         chapterFlags = chapterFlags,
         // KMK <--

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -60,7 +60,12 @@ class MangaRepositoryImpl(
     }
 
     override fun getLibraryMangaAsFlow(): Flow<List<LibraryManga>> {
-        return handler.subscribeToList { libraryViewQueries.library(MangaMapper::mapLibraryManga) }
+        // KMK -->
+        // Avoid repeated aggregate queries during write bursts.
+        return handler.subscribeToList(throttleMillis = LIBRARY_THROTTLE_MS) {
+            libraryViewQueries.library(MangaMapper::mapLibraryManga)
+        }
+        // KMK <--
     }
 
     override fun getFavoritesBySourceId(sourceId: Long): Flow<List<Manga>> {
@@ -216,4 +221,10 @@ class MangaRepositoryImpl(
         return handler.awaitList { libraryViewQueries.readMangaNonLibrary(MangaMapper::mapLibraryManga) }
     }
     // SY <--
+
+    // KMK -->
+    companion object {
+        private const val LIBRARY_THROTTLE_MS = 250L
+    }
+    // KMK <--
 }

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -139,6 +139,14 @@ removeChaptersWithIds:
 DELETE FROM chapters
 WHERE _id IN :chapterIds;
 
+-- KMK -->
+-- Entries whose cached aggregates a chapter deletion will invalidate.
+getMangaIdsByChapterIds:
+SELECT DISTINCT manga_id
+FROM chapters
+WHERE _id IN :chapterIds;
+-- KMK <--
+
 resetIsSyncing:
 UPDATE chapters
 SET is_syncing = 0

--- a/data/src/main/sqldelight/tachiyomi/data/history.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/history.sq
@@ -66,6 +66,29 @@ removeResettedHistory:
 DELETE FROM history
 WHERE last_read = 0;
 
+-- KMK -->
+-- Entries whose cached aggregates a bulk history change will invalidate.
+getMangaIdsWithHistory:
+SELECT DISTINCT C.manga_id
+FROM history H
+JOIN chapters C
+ON C._id = H.chapter_id;
+
+getMangaIdsByHistoryIds:
+SELECT DISTINCT C.manga_id
+FROM history H
+JOIN chapters C
+ON C._id = H.chapter_id
+WHERE H._id IN :historyIds;
+
+getMangaIdsWithResettedHistory:
+SELECT DISTINCT C.manga_id
+FROM history H
+JOIN chapters C
+ON C._id = H.chapter_id
+WHERE H.last_read = 0;
+-- KMK <--
+
 upsert:
 INSERT INTO history(chapter_id, last_read, time_read)
 VALUES (:chapterId, :readAt, :time_read)

--- a/data/src/main/sqldelight/tachiyomi/data/history.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/history.sq
@@ -9,8 +9,9 @@ CREATE TABLE history(
     ON DELETE CASCADE
 );
 
-CREATE INDEX history_history_chapter_id_index ON history(chapter_id);
-CREATE INDEX idx_history_last_read ON history(last_read) WHERE last_read > 0;
+-- KMK -->
+-- Dropped: UNIQUE already indexes chapter_id, and no query matches last_read > 0.
+-- KMK <--
 
 getHistoryByMangaId:
 SELECT

--- a/data/src/main/sqldelight/tachiyomi/data/manga_chapter_stats.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/manga_chapter_stats.sq
@@ -1,0 +1,422 @@
+-- KMK -->
+-- Cached per-manga chapter aggregates, maintained by triggers.
+
+CREATE TABLE manga_chapter_stats(
+    manga_id INTEGER NOT NULL PRIMARY KEY,
+    total_count INTEGER NOT NULL DEFAULT 0,
+    read_count INTEGER NOT NULL DEFAULT 0,
+    bookmark_count INTEGER NOT NULL DEFAULT 0,
+    bookmark_read_count INTEGER NOT NULL DEFAULT 0,
+    latest_upload INTEGER NOT NULL DEFAULT 0,
+    chapter_fetched_at INTEGER NOT NULL DEFAULT 0,
+    last_read INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id)
+    ON DELETE CASCADE
+);
+
+-- Triggers maintain aggregates for every write path.
+CREATE TRIGGER manga_chapter_stats_insert_chapter
+AFTER INSERT ON chapters
+WHEN NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = new.manga_id AND ES.scanlator = new.scanlator
+)
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    VALUES (
+        new.manga_id, 1, new.read, new.bookmark,
+        CASE WHEN new.bookmark = 1 AND new.read = 1 THEN 1 ELSE 0 END,
+        new.date_upload, new.date_fetch, 0
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = total_count + 1,
+        read_count = read_count + excluded.read_count,
+        bookmark_count = bookmark_count + excluded.bookmark_count,
+        bookmark_read_count = bookmark_read_count + excluded.bookmark_read_count,
+        latest_upload = max(latest_upload, excluded.latest_upload),
+        chapter_fetched_at = max(chapter_fetched_at, excluded.chapter_fetched_at);
+END;
+
+-- Update read and bookmark totals. Dates are handled separately.
+CREATE TRIGGER manga_chapter_stats_update_chapter
+AFTER UPDATE ON chapters
+WHEN old.manga_id = new.manga_id
+AND old.scanlator IS new.scanlator
+AND (old.read IS NOT new.read OR old.bookmark IS NOT new.bookmark)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = new.manga_id AND ES.scanlator = new.scanlator
+)
+BEGIN
+    UPDATE manga_chapter_stats SET
+        read_count = read_count + new.read - old.read,
+        bookmark_count = bookmark_count + new.bookmark - old.bookmark,
+        bookmark_read_count = bookmark_read_count
+            + (CASE WHEN new.bookmark = 1 AND new.read = 1 THEN 1 ELSE 0 END)
+            - (CASE WHEN old.bookmark = 1 AND old.read = 1 THEN 1 ELSE 0 END)
+    WHERE manga_id = new.manga_id;
+END;
+
+-- Rebuild after changes that affect aggregate membership.
+CREATE TRIGGER manga_chapter_stats_move_chapter
+AFTER UPDATE ON chapters
+WHEN old.manga_id IS NOT new.manga_id
+OR old.scanlator IS NOT new.scanlator
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    SELECT
+        new.manga_id,
+        count(*),
+        coalesce(sum(C.read), 0),
+        coalesce(sum(C.bookmark), 0),
+        coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+        coalesce(max(C.date_upload), 0),
+        coalesce(max(C.date_fetch), 0),
+        coalesce(max(H.last_read), 0)
+    FROM chapters C
+    LEFT JOIN history H ON H.chapter_id = C._id
+    WHERE C.manga_id = new.manga_id
+    AND NOT EXISTS (
+        SELECT 1 FROM excluded_scanlators ES
+        WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = excluded.total_count,
+        read_count = excluded.read_count,
+        bookmark_count = excluded.bookmark_count,
+        bookmark_read_count = excluded.bookmark_read_count,
+        latest_upload = excluded.latest_upload,
+        chapter_fetched_at = excluded.chapter_fetched_at,
+        last_read = excluded.last_read;
+END;
+
+-- Rebuild the source manga after a chapter move.
+CREATE TRIGGER manga_chapter_stats_move_chapter_source
+AFTER UPDATE ON chapters
+WHEN old.manga_id IS NOT new.manga_id
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    SELECT
+        old.manga_id,
+        count(*),
+        coalesce(sum(C.read), 0),
+        coalesce(sum(C.bookmark), 0),
+        coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+        coalesce(max(C.date_upload), 0),
+        coalesce(max(C.date_fetch), 0),
+        coalesce(max(H.last_read), 0)
+    FROM chapters C
+    LEFT JOIN history H ON H.chapter_id = C._id
+    WHERE C.manga_id = old.manga_id
+    AND NOT EXISTS (
+        SELECT 1 FROM excluded_scanlators ES
+        WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = excluded.total_count,
+        read_count = excluded.read_count,
+        bookmark_count = excluded.bookmark_count,
+        bookmark_read_count = excluded.bookmark_read_count,
+        latest_upload = excluded.latest_upload,
+        chapter_fetched_at = excluded.chapter_fetched_at,
+        last_read = excluded.last_read;
+END;
+
+-- Adjust the maxima for a date change; only lowering the current maximum needs a scan.
+CREATE TRIGGER manga_chapter_stats_update_chapter_dates
+AFTER UPDATE ON chapters
+WHEN old.manga_id = new.manga_id
+AND old.scanlator IS new.scanlator
+AND (old.date_upload IS NOT new.date_upload OR old.date_fetch IS NOT new.date_fetch)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = new.manga_id AND ES.scanlator = new.scanlator
+)
+BEGIN
+    UPDATE manga_chapter_stats SET
+        latest_upload = CASE
+            WHEN new.date_upload >= latest_upload THEN new.date_upload
+            WHEN old.date_upload < latest_upload THEN latest_upload
+            ELSE coalesce((
+                SELECT max(C.date_upload) FROM chapters C
+                WHERE C.manga_id = new.manga_id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END,
+        chapter_fetched_at = CASE
+            WHEN new.date_fetch >= chapter_fetched_at THEN new.date_fetch
+            WHEN old.date_fetch < chapter_fetched_at THEN chapter_fetched_at
+            ELSE coalesce((
+                SELECT max(C.date_fetch) FROM chapters C
+                WHERE C.manga_id = new.manga_id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END
+    WHERE manga_id = new.manga_id;
+END;
+
+-- Run before deletion so the chapter history is still available.
+CREATE TRIGGER manga_chapter_stats_delete_chapter
+BEFORE DELETE ON chapters
+WHEN EXISTS (SELECT 1 FROM mangas WHERE _id = old.manga_id)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = old.manga_id AND ES.scanlator = old.scanlator
+)
+BEGIN
+    UPDATE manga_chapter_stats SET
+        total_count = total_count - 1,
+        read_count = read_count - old.read,
+        bookmark_count = bookmark_count - old.bookmark,
+        bookmark_read_count = bookmark_read_count
+            - (CASE WHEN old.bookmark = 1 AND old.read = 1 THEN 1 ELSE 0 END),
+        latest_upload = CASE
+            WHEN old.date_upload < latest_upload THEN latest_upload
+            ELSE coalesce((
+                SELECT max(C.date_upload) FROM chapters C
+                WHERE C.manga_id = old.manga_id AND C._id != old._id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END,
+        chapter_fetched_at = CASE
+            WHEN old.date_fetch < chapter_fetched_at THEN chapter_fetched_at
+            ELSE coalesce((
+                SELECT max(C.date_fetch) FROM chapters C
+                WHERE C.manga_id = old.manga_id AND C._id != old._id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END,
+        last_read = CASE
+            WHEN coalesce((
+                SELECT H.last_read FROM history H WHERE H.chapter_id = old._id
+            ), 0) < last_read THEN last_read
+            ELSE coalesce((
+                SELECT max(H.last_read) FROM history H
+                JOIN chapters C ON C._id = H.chapter_id
+                WHERE C.manga_id = old.manga_id AND C._id != old._id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END
+    WHERE manga_id = old.manga_id;
+END;
+
+-- Update the latest read time.
+CREATE TRIGGER manga_chapter_stats_insert_history
+AFTER INSERT ON history
+BEGIN
+    UPDATE manga_chapter_stats
+    SET last_read = max(last_read, coalesce(new.last_read, 0))
+    WHERE manga_id = (
+        SELECT C.manga_id FROM chapters C
+        WHERE C._id = new.chapter_id
+        AND NOT EXISTS (
+            SELECT 1 FROM excluded_scanlators ES
+            WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+        )
+    );
+END;
+
+-- Recompute the latest read time when needed.
+CREATE TRIGGER manga_chapter_stats_update_history
+AFTER UPDATE OF last_read ON history
+WHEN old.last_read IS NOT new.last_read
+BEGIN
+    UPDATE manga_chapter_stats
+    SET last_read = CASE
+        WHEN coalesce(new.last_read, 0) >= last_read THEN coalesce(new.last_read, 0)
+        WHEN coalesce(old.last_read, 0) < last_read THEN last_read
+        ELSE coalesce((
+            SELECT max(H.last_read) FROM history H
+            JOIN chapters C ON C._id = H.chapter_id
+            WHERE C.manga_id = manga_chapter_stats.manga_id
+            AND NOT EXISTS (
+                SELECT 1 FROM excluded_scanlators ES
+                WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+            )
+        ), 0)
+        END
+    WHERE manga_id = (
+        SELECT C.manga_id FROM chapters C
+        WHERE C._id = new.chapter_id
+        AND NOT EXISTS (
+            SELECT 1 FROM excluded_scanlators ES
+            WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+        )
+    );
+END;
+
+CREATE TRIGGER manga_chapter_stats_delete_history
+AFTER DELETE ON history
+BEGIN
+    UPDATE manga_chapter_stats
+    SET last_read = CASE
+        WHEN coalesce(old.last_read, 0) < last_read THEN last_read
+        ELSE coalesce((
+            SELECT max(H.last_read) FROM history H
+            JOIN chapters C ON C._id = H.chapter_id
+            WHERE C.manga_id = manga_chapter_stats.manga_id
+            AND NOT EXISTS (
+                SELECT 1 FROM excluded_scanlators ES
+                WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+            )
+        ), 0)
+        END
+    WHERE manga_id = (
+        SELECT C.manga_id FROM chapters C
+        WHERE C._id = old.chapter_id
+        AND NOT EXISTS (
+            SELECT 1 FROM excluded_scanlators ES
+            WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+        )
+    );
+END;
+
+-- Rebuild aggregates after scanlator exclusions change.
+CREATE TRIGGER manga_chapter_stats_insert_excluded_scanlator
+AFTER INSERT ON excluded_scanlators
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    SELECT
+        new.manga_id,
+        count(*),
+        coalesce(sum(C.read), 0),
+        coalesce(sum(C.bookmark), 0),
+        coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+        coalesce(max(C.date_upload), 0),
+        coalesce(max(C.date_fetch), 0),
+        coalesce(max(H.last_read), 0)
+    FROM chapters C
+    LEFT JOIN history H ON H.chapter_id = C._id
+    WHERE C.manga_id = new.manga_id
+    AND NOT EXISTS (
+        SELECT 1 FROM excluded_scanlators ES
+        WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = excluded.total_count,
+        read_count = excluded.read_count,
+        bookmark_count = excluded.bookmark_count,
+        bookmark_read_count = excluded.bookmark_read_count,
+        latest_upload = excluded.latest_upload,
+        chapter_fetched_at = excluded.chapter_fetched_at,
+        last_read = excluded.last_read;
+END;
+
+CREATE TRIGGER manga_chapter_stats_delete_excluded_scanlator
+AFTER DELETE ON excluded_scanlators
+WHEN EXISTS (SELECT 1 FROM mangas WHERE _id = old.manga_id)
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    SELECT
+        old.manga_id,
+        count(*),
+        coalesce(sum(C.read), 0),
+        coalesce(sum(C.bookmark), 0),
+        coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+        coalesce(max(C.date_upload), 0),
+        coalesce(max(C.date_fetch), 0),
+        coalesce(max(H.last_read), 0)
+    FROM chapters C
+    LEFT JOIN history H ON H.chapter_id = C._id
+    WHERE C.manga_id = old.manga_id
+    AND NOT EXISTS (
+        SELECT 1 FROM excluded_scanlators ES
+        WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = excluded.total_count,
+        read_count = excluded.read_count,
+        bookmark_count = excluded.bookmark_count,
+        bookmark_read_count = excluded.bookmark_read_count,
+        latest_upload = excluded.latest_upload,
+        chapter_fetched_at = excluded.chapter_fetched_at,
+        last_read = excluded.last_read;
+END;
+
+-- Bulk paths drop the cached rows first, which turns the row triggers into cheap
+-- no-ops, then rebuild the affected entries once. Direct callers still hit the triggers.
+deleteForMangaIds:
+DELETE FROM manga_chapter_stats
+WHERE manga_id IN :mangaIds;
+
+rebuildForMangaIds:
+INSERT INTO manga_chapter_stats(
+    manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+    latest_upload, chapter_fetched_at, last_read
+)
+SELECT
+    C.manga_id,
+    count(*),
+    coalesce(sum(C.read), 0),
+    coalesce(sum(C.bookmark), 0),
+    coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+    coalesce(max(C.date_upload), 0),
+    coalesce(max(C.date_fetch), 0),
+    coalesce(max(H.last_read), 0)
+FROM chapters C
+LEFT JOIN history H ON H.chapter_id = C._id
+WHERE C.manga_id IN :mangaIds
+AND EXISTS (SELECT 1 FROM mangas WHERE _id = C.manga_id)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+)
+GROUP BY C.manga_id;
+
+-- Rebuild cached aggregates for repair.
+deleteAll:
+DELETE FROM manga_chapter_stats;
+
+rebuild:
+INSERT INTO manga_chapter_stats(
+    manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+    latest_upload, chapter_fetched_at, last_read
+)
+SELECT
+    C.manga_id,
+    count(*),
+    coalesce(sum(C.read), 0),
+    coalesce(sum(C.bookmark), 0),
+    coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+    coalesce(max(C.date_upload), 0),
+    coalesce(max(C.date_fetch), 0),
+    coalesce(max(H.last_read), 0)
+FROM chapters C
+LEFT JOIN history H ON H.chapter_id = C._id
+WHERE EXISTS (SELECT 1 FROM mangas WHERE _id = C.manga_id)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+)
+GROUP BY C.manga_id;
+-- KMK <--

--- a/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
@@ -1,0 +1,5 @@
+-- KMK -->
+-- Drop two history indexes no query can use.
+DROP INDEX IF EXISTS history_history_chapter_id_index;
+DROP INDEX IF EXISTS idx_history_last_read;
+-- KMK <--

--- a/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
@@ -2,4 +2,7 @@
 -- Drop two history indexes no query can use.
 DROP INDEX IF EXISTS history_history_chapter_id_index;
 DROP INDEX IF EXISTS idx_history_last_read;
+
+-- `libraryView` is replaced by the queries in libraryView.sq.
+DROP VIEW IF EXISTS libraryView;
 -- KMK <--

--- a/data/src/main/sqldelight/tachiyomi/migrations/48.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/48.sqm
@@ -1,0 +1,385 @@
+-- Create cached per-manga chapter aggregates.
+
+CREATE TABLE manga_chapter_stats(
+    manga_id INTEGER NOT NULL PRIMARY KEY,
+    total_count INTEGER NOT NULL DEFAULT 0,
+    read_count INTEGER NOT NULL DEFAULT 0,
+    bookmark_count INTEGER NOT NULL DEFAULT 0,
+    bookmark_read_count INTEGER NOT NULL DEFAULT 0,
+    latest_upload INTEGER NOT NULL DEFAULT 0,
+    chapter_fetched_at INTEGER NOT NULL DEFAULT 0,
+    last_read INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id)
+    ON DELETE CASCADE
+);
+
+-- Backfill aggregates from existing chapters.
+INSERT INTO manga_chapter_stats(
+    manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+    latest_upload, chapter_fetched_at, last_read
+)
+SELECT
+    C.manga_id,
+    count(*),
+    coalesce(sum(C.read), 0),
+    coalesce(sum(C.bookmark), 0),
+    coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+    coalesce(max(C.date_upload), 0),
+    coalesce(max(C.date_fetch), 0),
+    coalesce(max(H.last_read), 0)
+FROM chapters C
+LEFT JOIN history H ON H.chapter_id = C._id
+WHERE EXISTS (SELECT 1 FROM mangas WHERE _id = C.manga_id)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+)
+GROUP BY C.manga_id;
+
+CREATE TRIGGER manga_chapter_stats_insert_chapter
+AFTER INSERT ON chapters
+WHEN NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = new.manga_id AND ES.scanlator = new.scanlator
+)
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    VALUES (
+        new.manga_id, 1, new.read, new.bookmark,
+        CASE WHEN new.bookmark = 1 AND new.read = 1 THEN 1 ELSE 0 END,
+        new.date_upload, new.date_fetch, 0
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = total_count + 1,
+        read_count = read_count + excluded.read_count,
+        bookmark_count = bookmark_count + excluded.bookmark_count,
+        bookmark_read_count = bookmark_read_count + excluded.bookmark_read_count,
+        latest_upload = max(latest_upload, excluded.latest_upload),
+        chapter_fetched_at = max(chapter_fetched_at, excluded.chapter_fetched_at);
+END;
+
+-- Update read and bookmark totals. Dates are handled separately.
+CREATE TRIGGER manga_chapter_stats_update_chapter
+AFTER UPDATE ON chapters
+WHEN old.manga_id = new.manga_id
+AND old.scanlator IS new.scanlator
+AND (old.read IS NOT new.read OR old.bookmark IS NOT new.bookmark)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = new.manga_id AND ES.scanlator = new.scanlator
+)
+BEGIN
+    UPDATE manga_chapter_stats SET
+        read_count = read_count + new.read - old.read,
+        bookmark_count = bookmark_count + new.bookmark - old.bookmark,
+        bookmark_read_count = bookmark_read_count
+            + (CASE WHEN new.bookmark = 1 AND new.read = 1 THEN 1 ELSE 0 END)
+            - (CASE WHEN old.bookmark = 1 AND old.read = 1 THEN 1 ELSE 0 END)
+    WHERE manga_id = new.manga_id;
+END;
+
+-- Rebuild after changes that affect aggregate membership.
+CREATE TRIGGER manga_chapter_stats_move_chapter
+AFTER UPDATE ON chapters
+WHEN old.manga_id IS NOT new.manga_id
+OR old.scanlator IS NOT new.scanlator
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    SELECT
+        new.manga_id,
+        count(*),
+        coalesce(sum(C.read), 0),
+        coalesce(sum(C.bookmark), 0),
+        coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+        coalesce(max(C.date_upload), 0),
+        coalesce(max(C.date_fetch), 0),
+        coalesce(max(H.last_read), 0)
+    FROM chapters C
+    LEFT JOIN history H ON H.chapter_id = C._id
+    WHERE C.manga_id = new.manga_id
+    AND NOT EXISTS (
+        SELECT 1 FROM excluded_scanlators ES
+        WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = excluded.total_count,
+        read_count = excluded.read_count,
+        bookmark_count = excluded.bookmark_count,
+        bookmark_read_count = excluded.bookmark_read_count,
+        latest_upload = excluded.latest_upload,
+        chapter_fetched_at = excluded.chapter_fetched_at,
+        last_read = excluded.last_read;
+END;
+
+-- Rebuild the source manga after a chapter move.
+CREATE TRIGGER manga_chapter_stats_move_chapter_source
+AFTER UPDATE ON chapters
+WHEN old.manga_id IS NOT new.manga_id
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    SELECT
+        old.manga_id,
+        count(*),
+        coalesce(sum(C.read), 0),
+        coalesce(sum(C.bookmark), 0),
+        coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+        coalesce(max(C.date_upload), 0),
+        coalesce(max(C.date_fetch), 0),
+        coalesce(max(H.last_read), 0)
+    FROM chapters C
+    LEFT JOIN history H ON H.chapter_id = C._id
+    WHERE C.manga_id = old.manga_id
+    AND NOT EXISTS (
+        SELECT 1 FROM excluded_scanlators ES
+        WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = excluded.total_count,
+        read_count = excluded.read_count,
+        bookmark_count = excluded.bookmark_count,
+        bookmark_read_count = excluded.bookmark_read_count,
+        latest_upload = excluded.latest_upload,
+        chapter_fetched_at = excluded.chapter_fetched_at,
+        last_read = excluded.last_read;
+END;
+
+-- Adjust the maxima for a date change; only lowering the current maximum needs a scan.
+CREATE TRIGGER manga_chapter_stats_update_chapter_dates
+AFTER UPDATE ON chapters
+WHEN old.manga_id = new.manga_id
+AND old.scanlator IS new.scanlator
+AND (old.date_upload IS NOT new.date_upload OR old.date_fetch IS NOT new.date_fetch)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = new.manga_id AND ES.scanlator = new.scanlator
+)
+BEGIN
+    UPDATE manga_chapter_stats SET
+        latest_upload = CASE
+            WHEN new.date_upload >= latest_upload THEN new.date_upload
+            WHEN old.date_upload < latest_upload THEN latest_upload
+            ELSE coalesce((
+                SELECT max(C.date_upload) FROM chapters C
+                WHERE C.manga_id = new.manga_id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END,
+        chapter_fetched_at = CASE
+            WHEN new.date_fetch >= chapter_fetched_at THEN new.date_fetch
+            WHEN old.date_fetch < chapter_fetched_at THEN chapter_fetched_at
+            ELSE coalesce((
+                SELECT max(C.date_fetch) FROM chapters C
+                WHERE C.manga_id = new.manga_id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END
+    WHERE manga_id = new.manga_id;
+END;
+
+-- Run before deletion so the chapter history is still available.
+CREATE TRIGGER manga_chapter_stats_delete_chapter
+BEFORE DELETE ON chapters
+WHEN EXISTS (SELECT 1 FROM mangas WHERE _id = old.manga_id)
+AND NOT EXISTS (
+    SELECT 1 FROM excluded_scanlators ES
+    WHERE ES.manga_id = old.manga_id AND ES.scanlator = old.scanlator
+)
+BEGIN
+    UPDATE manga_chapter_stats SET
+        total_count = total_count - 1,
+        read_count = read_count - old.read,
+        bookmark_count = bookmark_count - old.bookmark,
+        bookmark_read_count = bookmark_read_count
+            - (CASE WHEN old.bookmark = 1 AND old.read = 1 THEN 1 ELSE 0 END),
+        latest_upload = CASE
+            WHEN old.date_upload < latest_upload THEN latest_upload
+            ELSE coalesce((
+                SELECT max(C.date_upload) FROM chapters C
+                WHERE C.manga_id = old.manga_id AND C._id != old._id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END,
+        chapter_fetched_at = CASE
+            WHEN old.date_fetch < chapter_fetched_at THEN chapter_fetched_at
+            ELSE coalesce((
+                SELECT max(C.date_fetch) FROM chapters C
+                WHERE C.manga_id = old.manga_id AND C._id != old._id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END,
+        last_read = CASE
+            WHEN coalesce((
+                SELECT H.last_read FROM history H WHERE H.chapter_id = old._id
+            ), 0) < last_read THEN last_read
+            ELSE coalesce((
+                SELECT max(H.last_read) FROM history H
+                JOIN chapters C ON C._id = H.chapter_id
+                WHERE C.manga_id = old.manga_id AND C._id != old._id
+                AND NOT EXISTS (
+                    SELECT 1 FROM excluded_scanlators ES
+                    WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+                )
+            ), 0)
+            END
+    WHERE manga_id = old.manga_id;
+END;
+
+-- Update the latest read time.
+CREATE TRIGGER manga_chapter_stats_insert_history
+AFTER INSERT ON history
+BEGIN
+    UPDATE manga_chapter_stats
+    SET last_read = max(last_read, coalesce(new.last_read, 0))
+    WHERE manga_id = (
+        SELECT C.manga_id FROM chapters C
+        WHERE C._id = new.chapter_id
+        AND NOT EXISTS (
+            SELECT 1 FROM excluded_scanlators ES
+            WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+        )
+    );
+END;
+
+-- Recompute the latest read time when needed.
+CREATE TRIGGER manga_chapter_stats_update_history
+AFTER UPDATE OF last_read ON history
+WHEN old.last_read IS NOT new.last_read
+BEGIN
+    UPDATE manga_chapter_stats
+    SET last_read = CASE
+        WHEN coalesce(new.last_read, 0) >= last_read THEN coalesce(new.last_read, 0)
+        WHEN coalesce(old.last_read, 0) < last_read THEN last_read
+        ELSE coalesce((
+            SELECT max(H.last_read) FROM history H
+            JOIN chapters C ON C._id = H.chapter_id
+            WHERE C.manga_id = manga_chapter_stats.manga_id
+            AND NOT EXISTS (
+                SELECT 1 FROM excluded_scanlators ES
+                WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+            )
+        ), 0)
+        END
+    WHERE manga_id = (
+        SELECT C.manga_id FROM chapters C
+        WHERE C._id = new.chapter_id
+        AND NOT EXISTS (
+            SELECT 1 FROM excluded_scanlators ES
+            WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+        )
+    );
+END;
+
+CREATE TRIGGER manga_chapter_stats_delete_history
+AFTER DELETE ON history
+BEGIN
+    UPDATE manga_chapter_stats
+    SET last_read = CASE
+        WHEN coalesce(old.last_read, 0) < last_read THEN last_read
+        ELSE coalesce((
+            SELECT max(H.last_read) FROM history H
+            JOIN chapters C ON C._id = H.chapter_id
+            WHERE C.manga_id = manga_chapter_stats.manga_id
+            AND NOT EXISTS (
+                SELECT 1 FROM excluded_scanlators ES
+                WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+            )
+        ), 0)
+        END
+    WHERE manga_id = (
+        SELECT C.manga_id FROM chapters C
+        WHERE C._id = old.chapter_id
+        AND NOT EXISTS (
+            SELECT 1 FROM excluded_scanlators ES
+            WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+        )
+    );
+END;
+
+-- Rebuild aggregates after scanlator exclusions change.
+CREATE TRIGGER manga_chapter_stats_insert_excluded_scanlator
+AFTER INSERT ON excluded_scanlators
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    SELECT
+        new.manga_id,
+        count(*),
+        coalesce(sum(C.read), 0),
+        coalesce(sum(C.bookmark), 0),
+        coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+        coalesce(max(C.date_upload), 0),
+        coalesce(max(C.date_fetch), 0),
+        coalesce(max(H.last_read), 0)
+    FROM chapters C
+    LEFT JOIN history H ON H.chapter_id = C._id
+    WHERE C.manga_id = new.manga_id
+    AND NOT EXISTS (
+        SELECT 1 FROM excluded_scanlators ES
+        WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = excluded.total_count,
+        read_count = excluded.read_count,
+        bookmark_count = excluded.bookmark_count,
+        bookmark_read_count = excluded.bookmark_read_count,
+        latest_upload = excluded.latest_upload,
+        chapter_fetched_at = excluded.chapter_fetched_at,
+        last_read = excluded.last_read;
+END;
+
+CREATE TRIGGER manga_chapter_stats_delete_excluded_scanlator
+AFTER DELETE ON excluded_scanlators
+WHEN EXISTS (SELECT 1 FROM mangas WHERE _id = old.manga_id)
+BEGIN
+    INSERT INTO manga_chapter_stats(
+        manga_id, total_count, read_count, bookmark_count, bookmark_read_count,
+        latest_upload, chapter_fetched_at, last_read
+    )
+    SELECT
+        old.manga_id,
+        count(*),
+        coalesce(sum(C.read), 0),
+        coalesce(sum(C.bookmark), 0),
+        coalesce(sum(CASE WHEN C.bookmark = 1 AND C.read = 1 THEN 1 ELSE 0 END), 0),
+        coalesce(max(C.date_upload), 0),
+        coalesce(max(C.date_fetch), 0),
+        coalesce(max(H.last_read), 0)
+    FROM chapters C
+    LEFT JOIN history H ON H.chapter_id = C._id
+    WHERE C.manga_id = old.manga_id
+    AND NOT EXISTS (
+        SELECT 1 FROM excluded_scanlators ES
+        WHERE ES.manga_id = C.manga_id AND ES.scanlator = C.scanlator
+    )
+    ON CONFLICT(manga_id) DO UPDATE SET
+        total_count = excluded.total_count,
+        read_count = excluded.read_count,
+        bookmark_count = excluded.bookmark_count,
+        bookmark_read_count = excluded.bookmark_read_count,
+        latest_upload = excluded.latest_upload,
+        chapter_fetched_at = excluded.chapter_fetched_at,
+        last_read = excluded.last_read;
+END;

--- a/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
@@ -1,51 +1,25 @@
 -- NOTE: must update MERGED_SOURCE_ID (6969) here
 
 -- KMK -->
--- These queries replace upstream's `libraryView`, which aggregated every chapter in the
--- database and only filtered on `favorite` afterwards.
+-- These queries replace upstream's `libraryView`; only merged entries still aggregate live.
 -- KMK <--
 
 library:
 SELECT
     M.*,
-    coalesce(C.total, 0) AS totalCount,
-    coalesce(C.readCount, 0) AS readCount,
-    coalesce(C.latestUpload, 0) AS latestUpload,
-    coalesce(C.fetchedAt, 0) AS chapterFetchedAt,
-    coalesce(C.lastRead, 0) AS lastRead,
-    coalesce(C.bookmarkCount, 0) AS bookmarkCount,
+    coalesce(S.total_count, 0) AS totalCount,
+    coalesce(S.read_count, 0) AS readCount,
+    coalesce(S.latest_upload, 0) AS latestUpload,
+    coalesce(S.chapter_fetched_at, 0) AS chapterFetchedAt,
+    coalesce(S.last_read, 0) AS lastRead,
+    coalesce(S.bookmark_count, 0) AS bookmarkCount,
     -- KMK -->
-    coalesce(C.bookmarkReadCount, 0) AS bookmarkedReadCount,
+    coalesce(S.bookmark_read_count, 0) AS bookmarkedReadCount,
     -- KMK <--
     coalesce(MC.categories, '0') AS categories
 FROM mangas M
-LEFT JOIN (
-    SELECT
-        chapters.manga_id,
-        count(*) AS total,
-        sum(read) AS readCount,
-        coalesce(max(chapters.date_upload), 0) AS latestUpload,
-        coalesce(max(history.last_read), 0) AS lastRead,
-        coalesce(max(chapters.date_fetch), 0) AS fetchedAt,
-        sum(chapters.bookmark) AS bookmarkCount,
-        -- KMK -->
-        sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
-        -- KMK <--
-        excluded_scanlators.scanlator AS ex_scanlator
-    FROM chapters
-    LEFT JOIN excluded_scanlators
-    ON chapters.manga_id = excluded_scanlators.manga_id
-    AND chapters.scanlator = excluded_scanlators.scanlator
-    LEFT JOIN history
-    ON chapters._id = history.chapter_id
-    WHERE ex_scanlator IS NULL
-    -- KMK -->
-    -- Aggregate only the entries this query returns; `IN` beats a join for the small favourite list.
-    AND chapters.manga_id IN (SELECT _id FROM mangas WHERE favorite = 1)
-    -- KMK <--
-    GROUP BY chapters.manga_id
-) AS C
-ON M._id = C.manga_id
+LEFT JOIN manga_chapter_stats S
+ON S.manga_id = M._id
 LEFT JOIN (
     SELECT manga_id, group_concat(category_id) AS categories
     FROM mangas_categories
@@ -73,14 +47,13 @@ LEFT JOIN (
     SELECT
         ME.merge_id,
         count(*) AS total,
-        sum(read) AS readCount,
+        CAST(sum(chapters.read) AS INTEGER) AS readCount,
         coalesce(max(chapters.date_upload), 0) AS latestUpload,
         coalesce(max(history.last_read), 0) AS lastRead,
         coalesce(max(chapters.date_fetch), 0) AS fetchedAt,
-        sum(chapters.bookmark) AS bookmarkCount,
-        sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
+        CAST(sum(chapters.bookmark) AS INTEGER) AS bookmarkCount,
+        CAST(sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS INTEGER) AS bookmarkReadCount,
         excluded_scanlators.scanlator AS ex_scanlator
-    -- Driving from `merged` restricts the scan to merged chapters.
     FROM merged ME
     JOIN chapters
     ON chapters.manga_id = ME.manga_id
@@ -102,59 +75,30 @@ ON MC.manga_id = M._id
 WHERE M.favorite = 1 AND M.source = 6969;
 -- KMK <--
 
+-- KMK -->
+-- Komikku-only query: non-library entries that have been read.
 readMangaNonLibrary:
 SELECT
     M.*,
-    coalesce(C.total, 0) AS totalCount,
-    coalesce(C.readCount, 0) AS readCount,
-    coalesce(C.latestUpload, 0) AS latestUpload,
-    coalesce(C.fetchedAt, 0) AS chapterFetchedAt,
-    coalesce(C.lastRead, 0) AS lastRead,
-    coalesce(C.bookmarkCount, 0) AS bookmarkCount,
-    -- KMK -->
-    coalesce(C.bookmarkReadCount, 0) AS bookmarkedReadCount,
-    -- KMK <--
+    coalesce(S.total_count, 0) AS totalCount,
+    coalesce(S.read_count, 0) AS readCount,
+    coalesce(S.latest_upload, 0) AS latestUpload,
+    coalesce(S.chapter_fetched_at, 0) AS chapterFetchedAt,
+    coalesce(S.last_read, 0) AS lastRead,
+    coalesce(S.bookmark_count, 0) AS bookmarkCount,
+    coalesce(S.bookmark_read_count, 0) AS bookmarkedReadCount,
     coalesce(MC.categories, '0') AS categories
 FROM mangas M
-LEFT JOIN (
-    SELECT
-        chapters.manga_id,
-        count(*) AS total,
-        sum(read) AS readCount,
-        coalesce(max(chapters.date_upload), 0) AS latestUpload,
-        coalesce(max(history.last_read), 0) AS lastRead,
-        coalesce(max(chapters.date_fetch), 0) AS fetchedAt,
-        sum(chapters.bookmark) AS bookmarkCount,
-        -- KMK -->
-        sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
-        -- KMK <--
-        excluded_scanlators.scanlator AS ex_scanlator
-    FROM chapters
-    -- KMK -->
-    -- Aggregate only the entries this query returns.
-    JOIN mangas MF
-    ON MF._id = chapters.manga_id
-    AND MF.favorite = 0
-    -- KMK <--
-    LEFT JOIN excluded_scanlators
-    ON chapters.manga_id = excluded_scanlators.manga_id
-    AND chapters.scanlator = excluded_scanlators.scanlator
-    LEFT JOIN history
-    ON chapters._id = history.chapter_id
-    WHERE ex_scanlator IS NULL
-    GROUP BY chapters.manga_id
-) AS C
-ON M._id = C.manga_id
+JOIN manga_chapter_stats S
+ON S.manga_id = M._id
 LEFT JOIN (
     SELECT manga_id, group_concat(category_id) AS categories
     FROM mangas_categories
     GROUP BY manga_id
 ) AS MC
 ON MC.manga_id = M._id
-WHERE M.favorite = 0 AND M.source <> 6969 AND coalesce(C.readCount, 0) != 0
+WHERE M.favorite = 0 AND M.source <> 6969 AND S.read_count != 0
 
--- KMK -->
--- Komikku-only: this `UNION ALL` and all below it go when upstream's filter above does.
 UNION ALL
 
 SELECT
@@ -172,14 +116,13 @@ LEFT JOIN (
     SELECT
         ME.merge_id,
         count(*) AS total,
-        sum(read) AS readCount,
+        CAST(sum(chapters.read) AS INTEGER) AS readCount,
         coalesce(max(chapters.date_upload), 0) AS latestUpload,
         coalesce(max(history.last_read), 0) AS lastRead,
         coalesce(max(chapters.date_fetch), 0) AS fetchedAt,
-        sum(chapters.bookmark) AS bookmarkCount,
-        sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
+        CAST(sum(chapters.bookmark) AS INTEGER) AS bookmarkCount,
+        CAST(sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS INTEGER) AS bookmarkReadCount,
         excluded_scanlators.scanlator AS ex_scanlator
-    -- Driving from `merged` restricts the scan to merged chapters.
     FROM merged ME
     JOIN chapters
     ON chapters.manga_id = ME.manga_id

--- a/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/libraryView.sq
@@ -1,5 +1,11 @@
 -- NOTE: must update MERGED_SOURCE_ID (6969) here
-CREATE VIEW libraryView AS
+
+-- KMK -->
+-- These queries replace upstream's `libraryView`, which aggregated every chapter in the
+-- database and only filtered on `favorite` afterwards.
+-- KMK <--
+
+library:
 SELECT
     M.*,
     coalesce(C.total, 0) AS totalCount,
@@ -33,6 +39,10 @@ LEFT JOIN (
     LEFT JOIN history
     ON chapters._id = history.chapter_id
     WHERE ex_scanlator IS NULL
+    -- KMK -->
+    -- Aggregate only the entries this query returns; `IN` beats a join for the small favourite list.
+    AND chapters.manga_id IN (SELECT _id FROM mangas WHERE favorite = 1)
+    -- KMK <--
     GROUP BY chapters.manga_id
 ) AS C
 ON M._id = C.manga_id
@@ -42,8 +52,57 @@ LEFT JOIN (
     GROUP BY manga_id
 ) AS MC
 ON MC.manga_id = M._id
-WHERE M.source <> 6969
-UNION
+WHERE M.favorite = 1 AND M.source <> 6969
+
+-- KMK -->
+-- Komikku-only: this `UNION ALL` and all below it go when upstream's filter above does.
+UNION ALL
+
+SELECT
+    M.*,
+    coalesce(C.total, 0) AS totalCount,
+    coalesce(C.readCount, 0) AS readCount,
+    coalesce(C.latestUpload, 0) AS latestUpload,
+    coalesce(C.fetchedAt, 0) AS chapterFetchedAt,
+    coalesce(C.lastRead, 0) AS lastRead,
+    coalesce(C.bookmarkCount, 0) AS bookmarkCount,
+    coalesce(C.bookmarkReadCount, 0) AS bookmarkedReadCount,
+    coalesce(MC.categories, '0') AS categories
+FROM mangas M
+LEFT JOIN (
+    SELECT
+        ME.merge_id,
+        count(*) AS total,
+        sum(read) AS readCount,
+        coalesce(max(chapters.date_upload), 0) AS latestUpload,
+        coalesce(max(history.last_read), 0) AS lastRead,
+        coalesce(max(chapters.date_fetch), 0) AS fetchedAt,
+        sum(chapters.bookmark) AS bookmarkCount,
+        sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
+        excluded_scanlators.scanlator AS ex_scanlator
+    -- Driving from `merged` restricts the scan to merged chapters.
+    FROM merged ME
+    JOIN chapters
+    ON chapters.manga_id = ME.manga_id
+    LEFT JOIN excluded_scanlators
+    ON chapters.manga_id = excluded_scanlators.manga_id
+    AND chapters.scanlator = excluded_scanlators.scanlator
+    LEFT JOIN history
+    ON chapters._id = history.chapter_id
+    WHERE ex_scanlator IS NULL
+    GROUP BY ME.merge_id
+) AS C
+ON M._id = C.merge_id
+LEFT JOIN (
+    SELECT manga_id, group_concat(category_id) AS categories
+    FROM mangas_categories
+    GROUP BY manga_id
+) AS MC
+ON MC.manga_id = M._id
+WHERE M.favorite = 1 AND M.source = 6969;
+-- KMK <--
+
+readMangaNonLibrary:
 SELECT
     M.*,
     coalesce(C.total, 0) AS totalCount,
@@ -58,14 +117,8 @@ SELECT
     coalesce(MC.categories, '0') AS categories
 FROM mangas M
 LEFT JOIN (
-    SELECT merged.manga_id,merged.merge_id
-    FROM merged
-    GROUP BY merged.merge_id
-) AS ME
-ON ME.merge_id = M._id
-LEFT JOIN(
     SELECT
-        ME.merge_id,
+        chapters.manga_id,
         count(*) AS total,
         sum(read) AS readCount,
         coalesce(max(chapters.date_upload), 0) AS latestUpload,
@@ -77,31 +130,73 @@ LEFT JOIN(
         -- KMK <--
         excluded_scanlators.scanlator AS ex_scanlator
     FROM chapters
+    -- KMK -->
+    -- Aggregate only the entries this query returns.
+    JOIN mangas MF
+    ON MF._id = chapters.manga_id
+    AND MF.favorite = 0
+    -- KMK <--
     LEFT JOIN excluded_scanlators
     ON chapters.manga_id = excluded_scanlators.manga_id
     AND chapters.scanlator = excluded_scanlators.scanlator
     LEFT JOIN history
     ON chapters._id = history.chapter_id
-    LEFT JOIN merged ME
-    ON ME.manga_id = chapters.manga_id
     WHERE ex_scanlator IS NULL
-    GROUP BY ME.merge_id
+    GROUP BY chapters.manga_id
 ) AS C
-ON M._id = C.merge_id  -- ON ME.merge_id = C.merge_id
+ON M._id = C.manga_id
 LEFT JOIN (
     SELECT manga_id, group_concat(category_id) AS categories
     FROM mangas_categories
     GROUP BY manga_id
 ) AS MC
 ON MC.manga_id = M._id
-WHERE M.source = 6969;
+WHERE M.favorite = 0 AND M.source <> 6969 AND coalesce(C.readCount, 0) != 0
 
-library:
-SELECT *
-FROM libraryView
-WHERE libraryView.favorite = 1;
+-- KMK -->
+-- Komikku-only: this `UNION ALL` and all below it go when upstream's filter above does.
+UNION ALL
 
-readMangaNonLibrary:
-SELECT *
-FROM libraryView
-WHERE libraryView.favorite = 0 AND libraryView.readCount != 0;
+SELECT
+    M.*,
+    coalesce(C.total, 0) AS totalCount,
+    coalesce(C.readCount, 0) AS readCount,
+    coalesce(C.latestUpload, 0) AS latestUpload,
+    coalesce(C.fetchedAt, 0) AS chapterFetchedAt,
+    coalesce(C.lastRead, 0) AS lastRead,
+    coalesce(C.bookmarkCount, 0) AS bookmarkCount,
+    coalesce(C.bookmarkReadCount, 0) AS bookmarkedReadCount,
+    coalesce(MC.categories, '0') AS categories
+FROM mangas M
+LEFT JOIN (
+    SELECT
+        ME.merge_id,
+        count(*) AS total,
+        sum(read) AS readCount,
+        coalesce(max(chapters.date_upload), 0) AS latestUpload,
+        coalesce(max(history.last_read), 0) AS lastRead,
+        coalesce(max(chapters.date_fetch), 0) AS fetchedAt,
+        sum(chapters.bookmark) AS bookmarkCount,
+        sum(CASE WHEN chapters.bookmark = 1 AND chapters.read = 1 THEN 1 ELSE 0 END) AS bookmarkReadCount,
+        excluded_scanlators.scanlator AS ex_scanlator
+    -- Driving from `merged` restricts the scan to merged chapters.
+    FROM merged ME
+    JOIN chapters
+    ON chapters.manga_id = ME.manga_id
+    LEFT JOIN excluded_scanlators
+    ON chapters.manga_id = excluded_scanlators.manga_id
+    AND chapters.scanlator = excluded_scanlators.scanlator
+    LEFT JOIN history
+    ON chapters._id = history.chapter_id
+    WHERE ex_scanlator IS NULL
+    GROUP BY ME.merge_id
+) AS C
+ON M._id = C.merge_id
+LEFT JOIN (
+    SELECT manga_id, group_concat(category_id) AS categories
+    FROM mangas_categories
+    GROUP BY manga_id
+) AS MC
+ON MC.manga_id = M._id
+WHERE M.favorite = 0 AND M.source = 6969 AND coalesce(C.readCount, 0) != 0;
+-- KMK <--

--- a/data/src/test/java/tachiyomi/data/manga/MangaChapterStatsTest.kt
+++ b/data/src/test/java/tachiyomi/data/manga/MangaChapterStatsTest.kt
@@ -1,0 +1,539 @@
+package tachiyomi.data.manga
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import tachiyomi.data.AndroidDatabaseHandler
+import tachiyomi.data.Chapters
+import tachiyomi.data.Database
+import tachiyomi.data.DateColumnAdapter
+import tachiyomi.data.Mangas
+import tachiyomi.data.MemoColumnAdapter
+import tachiyomi.data.StringListColumnAdapter
+import tachiyomi.data.UpdateStrategyColumnAdapter
+import tachiyomi.data.chapter.ChapterMapper
+import tachiyomi.data.chapter.ChapterRepositoryImpl
+import tachiyomi.data.history.HistoryRepositoryImpl
+import tachiyomi.domain.manga.interactor.GetCustomMangaInfo
+import tachiyomi.domain.manga.model.CustomMangaInfo
+import tachiyomi.domain.manga.repository.CustomMangaRepository
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.addSingletonFactory
+import java.util.Date
+import kotlin.random.Random
+
+// KMK -->
+/** Verifies cached chapter aggregates against a Kotlin recomputation. */
+class MangaChapterStatsTest {
+
+    private lateinit var driver: SqlDriver
+    private lateinit var db: Database
+    private lateinit var chapterRepository: ChapterRepositoryImpl
+    private lateinit var historyRepository: HistoryRepositoryImpl
+
+    private val scanlators = listOf(null, "alpha", "beta", "gamma")
+
+    @BeforeEach
+    fun setUp() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        Database.Schema.create(driver).value
+        driver.execute(null, "PRAGMA foreign_keys = ON", 0)
+        db = Database(
+            driver = driver,
+            historyAdapter = tachiyomi.data.History.Adapter(last_readAdapter = DateColumnAdapter),
+            mangasAdapter = Mangas.Adapter(
+                genreAdapter = StringListColumnAdapter,
+                update_strategyAdapter = UpdateStrategyColumnAdapter,
+                memoAdapter = MemoColumnAdapter,
+            ),
+            chaptersAdapter = Chapters.Adapter(memoAdapter = MemoColumnAdapter),
+        )
+        val handler = AndroidDatabaseHandler(db = db, driver = driver)
+        chapterRepository = ChapterRepositoryImpl(handler)
+        historyRepository = HistoryRepositoryImpl(handler)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        driver.close()
+    }
+
+    @Test
+    fun `aggregates survive a random sequence of writes`() {
+        val rng = Random(20260725)
+        seedLibrary(count = 12)
+
+        repeat(400) {
+            applyRandomWrite(rng)
+            assertAggregatesMatch()
+        }
+    }
+
+    @Test
+    fun `deleting an entry leaves no orphaned stats`() {
+        seedLibrary(count = 4)
+        val ids = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsList().map { it.id }
+        ids.forEach { insertChapter(it, scanlator = "alpha", read = true, bookmark = true) }
+
+        ids.forEach { db.mangasQueries.deleteById(it) }
+
+        statsRowCount() shouldBe 0
+    }
+
+    @Test
+    fun `direct low-level deletion still recovers the maxima`() {
+        // Bypasses the repository entirely, so only the trigger can keep this correct.
+        seedLibrary(count = 1)
+        val mangaId = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsOne().id
+        repeat(20) { i ->
+            insertChapter(mangaId, scanlator = null, read = true, bookmark = false, dates = (i + 1).toLong())
+        }
+        val chapters = chaptersOf(mangaId)
+        chapters.forEach { db.historyQueries.upsert(it.id, Date(it.dateUpload * 10), 1) }
+
+        val holdingEveryMaximum = chapters.maxBy { it.dateUpload }
+        db.chaptersQueries.removeChaptersWithIds(listOf(holdingEveryMaximum.id))
+
+        libraryRow(mangaId).let {
+            it.totalChapters shouldBe 19
+            it.latestUpload shouldBe 19
+            it.chapterFetchedAt shouldBe 19
+            it.lastRead shouldBe 190
+        }
+        assertAggregatesMatch()
+    }
+
+    @Test
+    fun `adversarial deletion through the repository path stays correct`() {
+        seedLibrary(count = 1)
+        val mangaId = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsOne().id
+        // Dates fall as ids rise, and every chapter carries history: the worst shape.
+        repeat(40) { i ->
+            insertChapter(mangaId, scanlator = null, read = true, bookmark = true, dates = (40 - i).toLong())
+        }
+        val chapters = chaptersOf(mangaId)
+        chapters.forEach { db.historyQueries.upsert(it.id, Date(it.dateUpload * 10), 1) }
+
+        deleteChapters(chapters.sortedBy { it.dateUpload }.drop(5).map { it.id })
+
+        libraryRow(mangaId).let {
+            it.totalChapters shouldBe 5
+            it.latestUpload shouldBe 5
+            it.chapterFetchedAt shouldBe 5
+            it.lastRead shouldBe 50
+        }
+        assertAggregatesMatch()
+    }
+
+    @Test
+    fun `bulk deletion leaves the other entries untouched`() {
+        seedLibrary(count = 4)
+        val ids = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsList().map { it.id }
+        ids.forEach { id ->
+            repeat(5) { i ->
+                insertChapter(id, scanlator = null, read = true, bookmark = false, dates = (i + 1).toLong())
+            }
+        }
+        // Avoid the merge relationship created by seedLibrary.
+        val deleteFrom = listOf(ids[0], ids[2])
+        val untouched = ids[1]
+        val before = libraryRow(untouched)
+
+        deleteChapters(deleteFrom.flatMap { chaptersOf(it) }.map { it.id })
+
+        libraryRow(untouched).let {
+            it.totalChapters shouldBe before.totalChapters
+            it.readCount shouldBe before.readCount
+            it.latestUpload shouldBe before.latestUpload
+        }
+        deleteFrom.forEach { libraryRow(it).totalChapters shouldBe 0 }
+        assertAggregatesMatch()
+    }
+
+    @Test
+    fun `bulk history reset through the repository path stays correct`() {
+        seedLibrary(count = 1)
+        val mangaId = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsOne().id
+        repeat(50) { i ->
+            insertChapter(mangaId, scanlator = null, read = true, bookmark = false, dates = (i + 1).toLong())
+        }
+        // Read times fall as ids rise, so each reset would destroy the stored maximum.
+        chaptersOf(mangaId).forEach { db.historyQueries.upsert(it.id, Date((60 - it.dateUpload) * 10), 1) }
+        libraryRow(mangaId).lastRead shouldBe 590
+
+        resetHistoryByMangaIds(listOf(mangaId))
+
+        libraryRow(mangaId).lastRead shouldBe 0
+        assertAggregatesMatch()
+    }
+
+    @Test
+    fun `removing resetted history through the repository path stays correct`() {
+        seedLibrary(count = 1)
+        val mangaId = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsOne().id
+        repeat(20) { i ->
+            insertChapter(mangaId, scanlator = null, read = true, bookmark = false, dates = (i + 1).toLong())
+        }
+        val chapters = chaptersOf(mangaId).sortedBy { it.dateUpload }
+        chapters.forEach { db.historyQueries.upsert(it.id, Date(it.dateUpload * 10), 1) }
+
+        // Reset the newest half, leaving an all-equal zero set for the delete to walk.
+        val newest = chapters.takeLast(10).map { it.id }.toSet()
+        resetHistory(historyIdsFor(mangaId).filter { it.second in newest }.map { it.first })
+        removeResettedHistory()
+
+        // The newest ten are gone, so the oldest ten now hold the maximum.
+        libraryRow(mangaId).lastRead shouldBe 100
+        assertAggregatesMatch()
+    }
+
+    @Test
+    fun `lowering the newest date recomputes it without a membership change`() {
+        seedLibrary(count = 1)
+        val mangaId = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsOne().id
+        insertChapter(mangaId, scanlator = null, read = false, bookmark = false, dates = 100)
+        insertChapter(mangaId, scanlator = null, read = false, bookmark = false, dates = 900)
+        val newest = chaptersOf(mangaId).maxBy { it.dateUpload }
+
+        libraryRow(mangaId).latestUpload shouldBe 900
+
+        // Pull the newest chapter below the runner-up; the stored maximum must follow it down.
+        db.chaptersQueries.update(
+            mangaId = null, url = null, name = null, scanlator = null,
+            read = null, bookmark = null, lastPageRead = null, chapterNumber = null,
+            sourceOrder = null, dateFetch = 50, dateUpload = 50,
+            chapterId = newest.id, version = null, isSyncing = 0, memo = null,
+        )
+
+        libraryRow(mangaId).let {
+            it.latestUpload shouldBe 100
+            it.chapterFetchedAt shouldBe 100
+        }
+        assertAggregatesMatch()
+    }
+
+    @Test
+    fun `raising a date and flipping read in one update keeps both correct`() {
+        seedLibrary(count = 1)
+        val mangaId = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsOne().id
+        insertChapter(mangaId, scanlator = null, read = false, bookmark = false, dates = 100)
+        val chapter = chaptersOf(mangaId).single()
+
+        db.chaptersQueries.update(
+            mangaId = null, url = null, name = null, scanlator = null,
+            read = true, bookmark = true, lastPageRead = null, chapterNumber = null,
+            sourceOrder = null, dateFetch = 700, dateUpload = 700,
+            chapterId = chapter.id, version = null, isSyncing = 0, memo = null,
+        )
+
+        libraryRow(mangaId).let {
+            it.readCount shouldBe 1
+            it.bookmarkCount shouldBe 1
+            it.bookmarkReadCount shouldBe 1
+            it.latestUpload shouldBe 700
+        }
+        assertAggregatesMatch()
+    }
+
+    @Test
+    fun `excluding a scanlator removes its chapters from the counts`() {
+        seedLibrary(count = 1)
+        val mangaId = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsOne().id
+        insertChapter(mangaId, scanlator = "alpha", read = true, bookmark = false)
+        insertChapter(mangaId, scanlator = "beta", read = true, bookmark = false)
+
+        libraryRow(mangaId).totalChapters shouldBe 2
+
+        db.excluded_scanlatorsQueries.insert(mangaId, "beta")
+        libraryRow(mangaId).totalChapters shouldBe 1
+        assertAggregatesMatch()
+
+        db.excluded_scanlatorsQueries.remove(mangaId, listOf("beta"))
+        libraryRow(mangaId).totalChapters shouldBe 2
+        assertAggregatesMatch()
+    }
+
+    // ------------------------------------------------------------------ oracle
+
+    private fun assertAggregatesMatch() {
+        db.libraryViewQueries.library(MangaMapper::mapLibraryManga).executeAsList().forEach { row ->
+            val expected = recompute(sourceMangaIdsFor(row.id))
+            withClue(row.id) {
+                row.totalChapters shouldBe expected.total
+                row.readCount shouldBe expected.read
+                row.bookmarkCount shouldBe expected.bookmark
+                row.bookmarkReadCount shouldBe expected.bookmarkRead
+                row.latestUpload shouldBe expected.latestUpload
+                row.chapterFetchedAt shouldBe expected.fetchedAt
+                row.lastRead shouldBe expected.lastRead
+            }
+        }
+    }
+
+    /** A merged entry aggregates child chapters. */
+    private fun sourceMangaIdsFor(mangaId: Long): List<Long> {
+        val children = db.mergedQueries.selectByMergeId(mangaId).executeAsList().mapNotNull { it.manga_id }
+        return children.ifEmpty { listOf(mangaId) }
+    }
+
+    private data class Aggregate(
+        val total: Long = 0,
+        val read: Long = 0,
+        val bookmark: Long = 0,
+        val bookmarkRead: Long = 0,
+        val latestUpload: Long = 0,
+        val fetchedAt: Long = 0,
+        val lastRead: Long = 0,
+    )
+
+    private fun recompute(mangaIds: List<Long>): Aggregate {
+        var agg = Aggregate()
+        mangaIds.forEach { mangaId ->
+            val excluded = db.excluded_scanlatorsQueries.getExcludedScanlatorsByMangaId(mangaId)
+                .executeAsList()
+                .filterNotNull()
+                .toSet()
+            val history = db.historyQueries.getHistoryByMangaId(mangaId) { _, chapterId, lastRead, _ ->
+                chapterId to (lastRead?.time ?: 0L)
+            }.executeAsList().toMap()
+
+            db.chaptersQueries
+                .getChaptersByMangaId(mangaId, 0L, 0L, 0L, ChapterMapper::mapChapter)
+                .executeAsList()
+                .filter { it.scanlator !in excluded }
+                .forEach { chapter ->
+                    agg = agg.copy(
+                        total = agg.total + 1,
+                        read = agg.read + if (chapter.read) 1 else 0,
+                        bookmark = agg.bookmark + if (chapter.bookmark) 1 else 0,
+                        bookmarkRead = agg.bookmarkRead + if (chapter.bookmark && chapter.read) 1 else 0,
+                        latestUpload = maxOf(agg.latestUpload, chapter.dateUpload),
+                        fetchedAt = maxOf(agg.fetchedAt, chapter.dateFetch),
+                        lastRead = maxOf(agg.lastRead, history[chapter.id] ?: 0L),
+                    )
+                }
+        }
+        return agg
+    }
+
+    // ------------------------------------------------------------------ writes
+
+    private fun applyRandomWrite(rng: Random) {
+        val mangaIds = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsList().map { it.id }
+        val chapters = mangaIds.flatMap { chaptersOf(it) }
+
+        when (rng.nextInt(10)) {
+            0, 1, 2 -> insertChapter(
+                mangaIds.random(rng),
+                scanlators.random(rng),
+                rng.nextBoolean(),
+                rng.nextBoolean(),
+                rng,
+            )
+            3, 4 -> chapters.randomOrNull(rng)?.let { chapter ->
+                // Match ChapterRepositoryImpl.partialUpdate.
+                db.chaptersQueries.update(
+                    mangaId = null,
+                    url = null,
+                    name = null,
+                    scanlator = null,
+                    read = rng.nextBoolean(),
+                    bookmark = rng.nextBoolean(),
+                    lastPageRead = rng.nextLong(50),
+                    chapterNumber = null,
+                    sourceOrder = null,
+                    dateFetch = null,
+                    dateUpload = null,
+                    chapterId = chapter.id,
+                    version = null,
+                    isSyncing = 0,
+                    memo = null,
+                )
+            }
+            5 -> chapters.randomOrNull(rng)?.let { chapter ->
+                // Simulate the reader page update.
+                db.chaptersQueries.update(
+                    mangaId = null, url = null, name = null, scanlator = null,
+                    read = null, bookmark = null, lastPageRead = rng.nextLong(50),
+                    chapterNumber = null, sourceOrder = null, dateFetch = null, dateUpload = null,
+                    chapterId = chapter.id, version = null, isSyncing = 0, memo = null,
+                )
+            }
+            6 -> chapters.randomOrNull(rng)?.let { chapter ->
+                db.chaptersQueries.update(
+                    mangaId = null, url = null, name = null, scanlator = scanlators.random(rng),
+                    read = null, bookmark = null, lastPageRead = null, chapterNumber = null,
+                    sourceOrder = null, dateFetch = rng.nextLong(1, 5_000),
+                    dateUpload = rng.nextLong(1, 5_000),
+                    chapterId = chapter.id, version = null, isSyncing = 0, memo = null,
+                )
+            }
+            7 -> chapters.randomOrNull(rng)?.let { chapter ->
+                db.historyQueries.upsert(chapter.id, Date(rng.nextLong(1, 9_000)), rng.nextLong(1, 60))
+            }
+            8 -> when (rng.nextInt(3)) {
+                0 -> db.historyQueries.resetHistoryByMangaIds(listOf(mangaIds.random(rng)))
+                1 -> db.historyQueries.removeAllHistory()
+                else -> chapters.randomOrNull(rng)
+                    ?.let { deleteChapters(listOf(it.id)) }
+            }
+            else -> {
+                val mangaId = mangaIds.random(rng)
+                val scanlator = scanlators.filterNotNull().random(rng)
+                val current = db.excluded_scanlatorsQueries.getExcludedScanlatorsByMangaId(mangaId)
+                    .executeAsList()
+                if (scanlator in current) {
+                    db.excluded_scanlatorsQueries.remove(mangaId, listOf(scanlator))
+                } else {
+                    db.excluded_scanlatorsQueries.insert(mangaId, scanlator)
+                }
+            }
+        }
+    }
+
+    private fun seedLibrary(count: Int) {
+        repeat(count) { i ->
+            db.mangasQueries.insert(
+                // The final entry is the merge parent.
+                source = if (count >= 3 && i == count - 1) MERGED_SOURCE_ID else 1L,
+                url = "/manga/$i",
+                artist = null,
+                author = null,
+                description = null,
+                genre = null,
+                title = "Manga $i",
+                status = 0,
+                thumbnailUrl = null,
+                favorite = true,
+                lastUpdate = 0,
+                nextUpdate = 0,
+                initialized = true,
+                viewerFlags = 0,
+                chapterFlags = 0,
+                coverLastModified = 0,
+                dateAdded = 0,
+                updateStrategy = UpdateStrategy.ALWAYS_UPDATE,
+                calculateInterval = 0,
+                version = 0,
+                notes = "",
+                memo = JsonObject(emptyMap()),
+            )
+        }
+        if (count >= 3) {
+            val ids = db.mangasQueries.getAll(MangaMapper::mapManga).executeAsList().map { it.id }
+            val mergeId = ids.last()
+            // Add two merge children.
+            listOf(ids[0], ids[1]).forEach { childId ->
+                db.mergedQueries.insert(
+                    infoManga = true,
+                    getChapterUpdates = true,
+                    chapterSortMode = 0,
+                    chapterPriority = 0,
+                    downloadChapters = true,
+                    mergeId = mergeId,
+                    mergeUrl = "/merge",
+                    mangaId = childId,
+                    mangaUrl = "/manga/$childId",
+                    mangaSource = 1,
+                )
+            }
+        }
+    }
+
+    private fun insertChapter(
+        mangaId: Long,
+        scanlator: String?,
+        read: Boolean,
+        bookmark: Boolean,
+        rng: Random = Random(0),
+        dates: Long? = null,
+    ) {
+        db.chaptersQueries.insert(
+            mangaId = mangaId,
+            url = "/chapter/${rng.nextLong()}",
+            name = "Chapter",
+            scanlator = scanlator,
+            read = read,
+            bookmark = bookmark,
+            lastPageRead = 0,
+            chapterNumber = 1.0,
+            sourceOrder = 0,
+            dateFetch = dates ?: rng.nextLong(1, 5_000),
+            dateUpload = dates ?: rng.nextLong(1, 5_000),
+            version = 0,
+            memo = JsonObject(emptyMap()),
+        )
+    }
+
+    private fun deleteChapters(chapterIds: List<Long>) = runBlocking {
+        chapterRepository.removeChaptersWithIds(chapterIds)
+    }
+
+    private fun historyIdsFor(mangaId: Long): List<Pair<Long, Long>> = db.historyQueries
+        .getHistoryByMangaId(mangaId) { id, chapterId, _, _ -> id to chapterId }
+        .executeAsList()
+
+    private fun resetHistory(historyIds: List<Long>) = runBlocking {
+        historyRepository.resetHistory(historyIds)
+    }
+
+    private fun resetHistoryByMangaIds(mangaIds: List<Long>) = runBlocking {
+        historyRepository.resetHistoryByMangaIds(mangaIds)
+    }
+
+    private fun removeResettedHistory() = runBlocking {
+        historyRepository.removeResettedHistory()
+    }
+
+    private fun chaptersOf(mangaId: Long) = db.chaptersQueries
+        .getChaptersByMangaId(mangaId, 0L, 0L, 0L, ChapterMapper::mapChapter)
+        .executeAsList()
+
+    private fun libraryRow(mangaId: Long) = db.libraryViewQueries
+        .library(MangaMapper::mapLibraryManga)
+        .executeAsList()
+        .single { it.id == mangaId }
+
+    private fun statsRowCount(): Long = driver.executeQuery(
+        identifier = null,
+        sql = "SELECT count(*) FROM manga_chapter_stats",
+        parameters = 0,
+        mapper = { cursor ->
+            cursor.next()
+            QueryResult.Value(cursor.getLong(0)!!)
+        },
+    ).value
+
+    private fun <T> withClue(clue: Any, block: () -> T): T = try {
+        block()
+    } catch (e: AssertionError) {
+        throw AssertionError("manga $clue: ${e.message}", e)
+    }
+
+    companion object {
+        private const val MERGED_SOURCE_ID = 6969L
+
+        // Manga resolves custom entry info through Injekt as soon as one is built.
+        @JvmStatic
+        @BeforeAll
+        fun registerCustomMangaInfo() {
+            Injekt.addSingletonFactory {
+                GetCustomMangaInfo(
+                    object : CustomMangaRepository {
+                        override fun get(mangaId: Long) = null
+                        override fun set(mangaInfo: CustomMangaInfo) = Unit
+                    },
+                )
+            }
+        }
+    }
+}
+// KMK <--

--- a/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
@@ -26,6 +26,8 @@ interface HistoryRepository {
     suspend fun resetHistory(historyIds: List<Long>)
 
     suspend fun resetHistoryByMangaIds(mangaIds: List<Long>)
+
+    suspend fun removeResettedHistory()
     // KMK <--
 
     suspend fun deleteAllHistory(): Boolean

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,6 +92,9 @@ sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", ver
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions-jvm", version.ref = "sqldelight" }
 sqldelight-android-paging = { module = "app.cash.sqldelight:androidx-paging3-extensions", version.ref = "sqldelight" }
 sqldelight-dialects-sql = { module = "app.cash.sqldelight:sqlite-3-38-dialect", version = "2.3.2" }
+# KMK -->
+sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+# KMK <--
 
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/Source.kt
+++ b/source-api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/Source.kt
@@ -10,10 +10,13 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import logcat.LogPriority
 import rx.Observable
 import tachiyomi.core.common.util.QuerySanitizer.sanitize
 import tachiyomi.core.common.util.system.logcat
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * A basic interface for creating a source. It could be an online source, a local source, etc...
@@ -222,15 +225,23 @@ interface Source {
 
         coroutineScope {
             val filterList = getFilterList()
+            // KMK -->
+            // Limit concurrent keyword searches for this source.
+            val semaphore = relatedMangaSearchSemaphore(id)
+            // KMK <--
             words.map { keyword ->
                 launch {
-                    runCatching {
-                        getSearchManga(1, keyword.sanitize(), filterList).mangas
-                    }
-                        .onSuccess { if (it.isNotEmpty()) pushResults(Pair(keyword, it), false) }
-                        .onFailure { e ->
-                            logcat(LogPriority.ERROR, e) { "## getRelatedMangaListBySearch: $e" }
+                    // KMK -->
+                    semaphore.withPermit {
+                        runCatching {
+                            getSearchManga(1, keyword.sanitize(), filterList).mangas
                         }
+                            .onSuccess { if (it.isNotEmpty()) pushResults(Pair(keyword, it), false) }
+                            .onFailure { e ->
+                                logcat(LogPriority.ERROR, e) { "## getRelatedMangaListBySearch: $e" }
+                            }
+                    }
+                    // KMK <--
                 }
             }
         }
@@ -246,3 +257,15 @@ interface Source {
     @Deprecated("Use the suspend API instead", ReplaceWith("getPageList"))
     fun fetchPageList(chapter: SChapter): Observable<List<Page>> = throw UnsupportedOperationException()
 }
+
+// KMK -->
+/** Limits concurrent related-manga searches for each source. */
+private const val RELATED_MANGA_SEARCH_CONCURRENCY = 2
+
+/** Semaphores are shared by source across overlapping searches. */
+private val relatedMangaSearchSemaphores = ConcurrentHashMap<Long, Semaphore>()
+
+/** `computeIfAbsent`, not `getOrPut`: the latter is a non-atomic get-then-put. */
+private fun relatedMangaSearchSemaphore(sourceId: Long): Semaphore =
+    relatedMangaSearchSemaphores.computeIfAbsent(sourceId) { Semaphore(RELATED_MANGA_SEARCH_CONCURRENCY) }
+// KMK <--


### PR DESCRIPTION
> **Disclosure:** Claude Opus 5 was used to help find, implement and measure these performance changes and draft this PR description.

## Summary

Several unrelated performance fixes, ordered least invasive first. You can merge up to any commit and stop.

Commits 8 and 9 both target the library query and are offered as alternatives. I wrote the cached-aggregates version (commit 9) first and found the query rewrite (commit 8) afterwards. Commit 8 is cheap and self-contained. Commit 9 is invasive but wins in cases commit 8 can't reach. Taking commit 8 and stopping is a reasonable outcome, and the branch is ordered so that works.

No UI changes, so themes and tablet mode aren't affected.

## At a glance

| # | Commit | Effect | Evidence |
|---|---|---|---|
| 1 | `perf(browse)` release off-screen database subscriptions | Browse items no longer hold a database subscription forever | structural |
| 2 | `perf(reader)` avoid blocking database work | Blocking calls moved out of suspend contexts, `init()` serialized | structural, correctness |
| 3 | `fix(manga)` keep side effects out of state updates | Side effects no longer run twice under contention | correctness |
| 4 | `perf(source)` bound related-manga search concurrency | Caps simultaneous requests per source | structural |
| 5 | `perf(coil)` bound source image transfers | Caps concurrent image transfers per source | structural, has tests |
| 6 | `perf(database)` throttle library query invalidations | Collapses a write burst into one re-query | reasoning |
| 7 | `perf(database)` drop two history indexes | Saves 1.3 MB, no query used them | measured |
| 8 | `perf(database)` aggregate only the entries returned | Up to 35x on browse-heavy databases | measured |
| 9 | `perf(database)` cache manga chapter aggregates | Roughly 11x on top of commit 8 at the tested sizes, at a write cost | measured |

Schema changes are confined to commits 7, 8 and 9. Everything else is app code.

## The library query

Upstream's `libraryView` aggregated every chapter row in the database and only filtered on `favorite` afterwards, using `UNION`, which also forced a dedupe pass over the whole result. There are two separate problems in that, with one commit each.

### Commit 8: chapters outside the library

1,000 library entries, varying browse history.

| chapters outside the library | old view (ms) | after commit 8 (ms) | after commit 9 (ms) |
|---:|---:|---:|---:|
| 0 | 46.8 | 47.8 | 3.1 |
| 100,000 | 134.0 | 48.2 | 3.4 |
| 500,000 | 510.7 | 50.5 | 3.3 |
| 2,000,000 | 2,182.2 | 62.2 | 3.4 |

Browsing inserts a row into `mangas` for every result, opening one fetches its chapters, and nothing removes either except Clear Database. The old query aggregated all of it. Commit 8 removes that work and is at parity when there is nothing outside the library.

### Commit 9: chapters inside the library

No browse history at all, so commit 8 has nothing to remove.

| library entries | library chapters | old view (ms) | after commit 8 (ms) | after commit 9 (ms) |
|---:|---:|---:|---:|---:|
| 1,000 | 59,160 | 51.9 | 47.9 | 4.3 |
| 5,000 | 299,140 | 292.2 | 275.1 | 24.4 |
| 10,000 | 597,240 | 571.3 | 597.9 | 54.4 |

The cost of commit 8 is proportional to the chapters it aggregates, and it only removes the ones outside the library. The cost of commit 9 is proportional to entries returned, because the aggregates already exist. At roughly 60 chapters per entry that works out to a flat 11x, holding at every library size.

### What commit 9 costs

Its write path. Commit 8 and master are identical here, so this is the cost of the 11 triggers.

| Operation | no stats (ms) | with commit 9 (ms) | ratio |
|---|---:|---:|---|
| `addAll` 500 chapters | 2.7 to 3.0 | 3.9 to 4.7 | 1.43-1.57x |
| mark-read 500 | 0.8 to 1.2 | 1.0 to 1.7 | 1.30-1.97x |
| history upsert 500 | 2.0 to 2.5 | 3.6 to 4.2 | 1.46-1.88x |
| delete 500 chapters | 0.3 to 0.6 | 0.8 to 1.7 | 2.1-3.0x |

`addAll` and mark-read are the relevant ones, since a library update runs them across hundreds of entries. No measurable storage increase was observed. Backfill is one-time: 41 ms at 60k chapters, 467 ms at 500k.

### Where the query runs

`GetLibraryManga.subscribe()` has one caller, `LibraryScreenModel.getFavoritesFlow()`, live while the library screen is open and re-running on every invalidation. During an update that's continuous, capped by commit 6's throttle. At 10,000 entries a cycle is 598+250 ms under commit 8 against 54+250 ms under commit 9, so the query occupies roughly 70% of a background thread instead of 18%.

`GetLibraryManga.await()` has six one-shot callers: `LibraryUpdateJob` and `MetadataUpdateJob` at the start of every update including scheduled ones, plus Stats, Upcoming, EH favorites sync and batch recommendation search.

<details>
<summary><b>Implementation detail for commit 8 and commit 9</b></summary>

#### Commit 8

Replaces the view with direct queries that:

- push the `favorite` filter into each branch
- restrict the aggregate subquery to the entries the query returns
- use `UNION ALL`, since the branches are disjoint by `source`
- drive the merged-entry aggregate from `merged` instead of scanning all of `chapters`

The second point does most of the work. Pushing down only the outer `WHERE` still leaves the subquery grouping every chapter in the database.

`library` expresses that restriction as `manga_id IN (SELECT _id FROM mangas WHERE favorite = 1)`, which SQLite runs as one materialised id list plus a bloom filter. A join works too but is slower at every size, and about 1.4x slower than the old query when almost every chapter already belongs to a library entry. `readMangaNonLibrary` keeps the join, because there the id list is every non-library entry and materialising it costs more than it saves (737 ms against 812 ms at 50k non-library entries).

No schema change apart from dropping the now-unused view.

---

#### Commit 9

Adds `manga_chapter_stats`, a per-entry aggregate table maintained by 11 triggers covering chapter insert/update/move/delete, history writes and scanlator exclusion changes. Bulk paths drop the cached rows, do the write, then rebuild once. Includes `MangaChapterStatsTest` and a debug function to rebuild the cache.

The table is read by exactly two queries, `library` and `readMangaNonLibrary`. Nothing else in the app uses it.

Caveat: the bulk drop-and-rebuild path in `removeChaptersWithIds` doesn't beat a plain delete in these measurements (0.9 against 0.8 ms, 1.1 against 1.2 ms). Deleting 500 chapters from one entry has to re-aggregate that entry afterwards, which costs about what the trigger firings did. It should pay off across many entries, but as measured it doesn't justify the extra code.

</details>

<details>
<summary><b>Commit 7: why those two indexes go</b></summary>

`history_history_chapter_id_index` duplicates the index SQLite already maintains for `chapter_id INTEGER NOT NULL UNIQUE`. Redundant since the table was added.

`idx_history_last_read` is unused. mihonapp/mihon#2950 added it as a plain index on `history(last_read)`, where it did serve the `last_read = 0` lookups. #1603 then converted it to partial on `last_read > 0`, which inverted its coverage, since the only queries filtering that column filter `= 0`.

Measured on 3,000 entries, 140k chapters, 64k history rows.

| query | no index | plain | partial (current) |
|---|---:|---:|---:|
| `removeResettedHistory` | 5.40 ms | 3.49 ms | 5.53 ms |
| `getMangaIdsWithResettedHistory` | 4.38 ms | 2.44 ms | 5.30 ms |

The partial form is the worst of the three: same read speed as having no index, but it still costs writes and storage. Restoring the plain form is a defensible alternative, but both beneficiaries run from Clear Database in advanced settings, so this drops it instead.

Verified unused by re-adding the index and explaining every generated statement at three points: `master` (152 statements), commit 8 (152), and the tip including what commit 9 adds (160). No plan references it at any of them. The few that don't parse standalone were checked by hand.

This is a minor cleanup rather than a meaningful performance change: about 1.3 MB saved on 55,000 history rows, or roughly 7.5% of the test database. It also removes a small amount of work from `upsertHistory`, but the runtime effect is negligible.

</details>

<details>
<summary><b>Commits 1 to 6: app-side changes</b></summary>

#### 1. `perf(browse): release off-screen database subscriptions`

`BrowseSourceScreenModel` created a `stateIn` per browse item tied to the screen model's IO scope, so every item scrolled past kept a live database subscription until the screen was destroyed. Now uses `SharingStarted.WhileSubscribed(5s)`.

The initial favorite state is loaded with `getManga.await` because the filter below it reads `.value` synchronously, and the non-suspending `stateIn` overload doesn't wait for the first emission.

Trade-off: an item off-screen for over 5 seconds stops collecting, so if its favorite state changes in that window, the first composition after it returns renders the cached value until the query lands. Lazy layout prefetch composes ahead of the viewport, so this mostly happens off-screen. Checked on a device, not noticeable.

---

#### 2. `perf(reader): avoid blocking database work`

`ReaderViewModel` called `runBlocking` from inside suspend contexts. `init()` used it for the merged-source lookups while already under `withIOContext`, and both chapter lists were `by lazy` blocks that queried the same way. Now suspend helpers: the filtered list is built during `init()` before it publishes state, the unfiltered one is cached behind a suspend accessor.

Two `getManga.await()` calls also moved out of `mutableState.update` blocks, which retry under contention. Same as commit 3. 

`init()` is serialized with a `Mutex`. `ReaderActivity` launches it with `launchNonCancellable`, so an activity recreated mid-init can get the same ViewModel, see `needsInit()`, and start a second one. The `lazy` blocks made that harmless, since `SYNCHRONIZED` built the list once; plain fields don't. The mutex rechecks `needsInit()` after acquiring, so a second caller returns once the first completes, and retries if the first failed before publishing state. On that path the chapter id claimed by the failed attempt is rolled back.

---

#### 3. `fix(manga): keep side effects out of state updates`

`MangaScreenModel` resolved values and launched fetches inside `updateState` blocks, which retry under contention, so the side effects could run more than once per update. Moved them out.

---

#### 4. `perf(source): bound related-manga search concurrency`

Related-manga search ran one `getSearchManga` per keyword with no limit, so one entry could fire dozens of simultaneous requests at a source. Added a per-source semaphore.

---

#### 5. `perf(coil): bound source image transfers`

Adds `SourceImageCallLimiter` to cap concurrent image transfers per source, used by `MangaCoverFetcher` and `PagePreviewFetcher`. Includes unit tests.

---

#### 6. `perf(database): throttle library query invalidations during write bursts`

`subscribeToList` takes an optional `throttleMillis`, and the library flow uses 250 ms. The library query is invalidated by writes to `mangas`, `chapters`, `history`, `mangas_categories`, `merged` or `excluded_scanlators`, so a library update re-runs it constantly. This collapses a burst into one re-query. Default is `0`, so no other caller changes.

</details>

## Migration notes

Two new migrations, taking the database from version 47 to 49.

| | |
|---|---|
| **47** | drops the two history indexes and the unused `libraryView` |
| **48** | creates `manga_chapter_stats`, backfills it, installs the triggers |

Checked on a device. Installed the `master` debug build to get a version 47 database, then upgraded in place. No errors, ended at version 49, and the schema matched a fresh install of the same build: 61 objects either way, no differences in any definition.

## Testing

- `:data:compileDebugKotlin` passes at commits 6, 7, 8 and 9 individually
- `:app:assembleDebug` passes at the tip
- `MangaChapterStatsTest` passes, 10 tests, covering max recovery on the delete path, scanlator exclusion, combined date and read updates, the bulk repository paths, and a randomised write sequence
- Migration verified on a device by upgrading a real version 47 database in place
- `library` and `readMangaNonLibrary` return identical result sets to the old `libraryView` at every size in the tables above

Benchmarks are desktop SQLite rather than on-device, median ms, full fetch, 400-char descriptions. The absolute numbers won't carry over to a device, but the scaling should.

Commits 7, 8 and 9 have measurements behind them. 1, 2, 4 and 5 are structural changes from unbounded to bounded and aren't individually benchmarked.

`verifySqlDelightMigration` doesn't run locally for me. sqlite-jdbc's native library fails to load, and it fails the same way on `master`, so it's unrelated to these changes.

### Benchmark environment

The database benchmarks were run against desktop SQLite, not on an Android device. The absolute timings therefore should not be treated as representative of device performance; the useful result is how each version scales as the database grows. Migration behavior and general functionality were also checked on a physical device.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Improve app and database performance by bounding concurrency for source operations, introducing cached chapter aggregates for the library, and reducing repeated heavy queries and subscriptions during write bursts and browsing.

New Features:
- Cache per-manga chapter aggregates and expose debug tooling to rebuild them for repair.
- Add per-source image request limiting for covers and page previews to cap concurrent transfers.
- Introduce throttling support for database list subscriptions to collapse invalidations during write bursts.

Bug Fixes:
- Prevent duplicate side effects and blocking work inside retrying state updates in reader and manga screens.
- Avoid orphaned or stale cached chapter aggregate rows when chapters or history are deleted or reset via repository and clear-database flows.

Enhancements:
- Refactor reader initialization to avoid runBlocking in suspend contexts and serialize init with a mutex while caching chapter lists.
- Limit concurrent related-manga search requests per source to reduce load from keyword-based searches.
- Release browse item database subscriptions after items leave the screen using lifecycle-aware sharing.
- Adjust library mapping types to use integer aggregates instead of floating SUM results for counts.

Build:
- Add JDBC SQLite driver and test libraries for SQLDelight-based database tests, including chapter aggregate verification.

Tests:
- Add comprehensive tests validating cached manga chapter aggregates against recomputation and covering edge cases for deletes, history resets, and scanlator exclusion.
- Add tests for the source image call limiter to ensure permits are released on body consumption, close, and concurrency limits.