### PR TITLE
feat(reader): add half-screen padding for solo pages

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -272,7 +272,20 @@ class PagerPageHolder(
     private fun mergePages(imageSource: BufferedSource, imageSource2: BufferedSource?): BufferedSource {
         // Handle adding a center margin to wide images if requested
         if (imageSource2 == null) {
-            return handleWideImage(imageSource)
+            // KMK -->
+            val wideImage = handleWideImage(imageSource)
+            // Solo portrait page in double-paged mode: position on half screen
+            if (viewer.config.doublePages && !ImageUtil.isAnimatedAndSupported(wideImage) &&
+                !ImageUtil.isWideImage(wideImage)
+            ) {
+                return ImageUtil.addSoloPagePadding(
+                    wideImage,
+                    drawOnLeft = shouldDrawSoloPageOnLeft(),
+                    viewer.config.pageCanvasColor,
+                )
+            }
+            // KMK <--
+            return wideImage
         }
 
         if (page.fullPage) return imageSource
@@ -333,6 +346,25 @@ class PagerPageHolder(
             updateProgress(it)
         }
     }
+
+    // KMK -->
+    private fun shouldDrawSoloPageOnLeft(): Boolean {
+        val isBaseLTR = viewer is R2LPagerViewer
+        val isViewerLTR = if (viewer.config.invertDoublePages) {
+            !isBaseLTR
+        } else {
+            isBaseLTR
+        }
+
+        val isPageFirstInSpread = page.index == 0
+
+        return if (isViewerLTR) {
+            isPageFirstInSpread
+        } else {
+            !isPageFirstInSpread
+        }
+    }
+    // KMK <--
 
     private fun handleWideImage(imageSource: BufferedSource): BufferedSource {
         return if (

--- a/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/util/system/ImageUtil.kt
@@ -37,6 +37,7 @@ import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 object ImageUtil {
 
@@ -153,6 +154,45 @@ object ImageUtil {
 
         return output
     }
+
+    // KMK -->
+    /**
+     * Creates a new image with canvas padding so the original occupies exactly one half
+     * of the result. Used for solo pages in double-paged mode so they appear on the
+     * correct side of the screen (matching the reading direction).
+     */
+    fun addSoloPagePadding(
+        imageSource: BufferedSource,
+        drawOnLeft: Boolean,
+        @ColorInt background: Int = Color.WHITE,
+    ): BufferedSource {
+        // Buffer the content first so we don't exhaust the source on a failed decode.
+        val buffer = Buffer()
+        buffer.readFrom(imageSource.inputStream())
+
+        val imageBitmap = BitmapFactory.decodeStream(buffer.inputStream())
+            ?: return Buffer().also { it.writeAll(buffer) }
+        val height = imageBitmap.height
+        val width = imageBitmap.width
+
+        val result = createBitmap(width * 2, height)
+        val canvas = Canvas(result)
+        canvas.drawColor(background)
+
+        val dest = if (drawOnLeft) {
+            Rect(0, 0, width, height)
+        } else {
+            Rect(width, 0, width * 2, height)
+        }
+        canvas.drawBitmap(imageBitmap, imageBitmap.rect, dest, null)
+        imageBitmap.recycle()
+
+        val output = Buffer()
+        result.compress(Bitmap.CompressFormat.JPEG, 100, output.outputStream())
+        result.recycle()
+        return output
+    }
+    // KMK <--
 
     fun rotateImage(imageSource: BufferedSource, degrees: Float): BufferedSource {
         val imageBitmap = BitmapFactory.decodeStream(imageSource.inputStream())
@@ -766,33 +806,23 @@ object ImageUtil {
         @ColorInt background: Int = Color.WHITE,
         progressCallback: ((Int) -> Unit)? = null,
     ): BufferedSource {
-        val height = imageBitmap.height
-        val width = imageBitmap.width
-        val height2 = imageBitmap2.height
-        val width2 = imageBitmap2.width
+        // KMK -->
+        val maxHeight = max(imageBitmap.height, imageBitmap2.height)
+        val scaledW1 = (imageBitmap.width * maxHeight.toFloat() / imageBitmap.height).roundToInt()
+        val scaledW2 = (imageBitmap2.width * maxHeight.toFloat() / imageBitmap2.height).roundToInt()
+        val halfWidth = max(scaledW1, scaledW2)
 
-        val maxHeight = max(height, height2)
-
-        val result = createBitmap(width + width2 + centerMargin, max(height, height2))
-        val canvas = Canvas(result)
-        canvas.drawColor(background)
-        val upperPart = Rect(
-            if (isLTR) 0 else width2 + centerMargin,
-            (maxHeight - height) / 2,
-            (if (isLTR) 0 else width2 + centerMargin) + width,
-            height + (maxHeight - height) / 2,
-        )
-
-        canvas.drawBitmap(imageBitmap, imageBitmap.rect, upperPart, null)
-        progressCallback?.invoke(98)
-        val bottomPart = Rect(
-            if (!isLTR) 0 else width + centerMargin,
-            (maxHeight - height2) / 2,
-            (if (!isLTR) 0 else width + centerMargin) + width2,
-            height2 + (maxHeight - height2) / 2,
-        )
-
-        canvas.drawBitmap(imageBitmap2, imageBitmap2.rect, bottomPart, null)
+        val result = createBitmap(halfWidth * 2 + centerMargin, maxHeight)
+        result.applyCanvas {
+            drawColor(background)
+            val (leftPage, rightPage) = if (isLTR) imageBitmap to imageBitmap2 else imageBitmap2 to imageBitmap
+            val (leftW, rightW) = if (isLTR) scaledW1 to scaledW2 else scaledW2 to scaledW1
+            drawBitmap(leftPage, leftPage.rect, Rect(halfWidth - leftW, 0, halfWidth, maxHeight), null)
+            progressCallback?.invoke(97)
+            drawBitmap(rightPage, rightPage.rect, Rect(halfWidth + centerMargin, 0, halfWidth + centerMargin + rightW, maxHeight), null)
+            progressCallback?.invoke(98)
+        }
+        // KMK <--
         progressCallback?.invoke(99)
 
         val output = Buffer()


### PR DESCRIPTION
Offsets pages to be on either the left-half or right-half of the screen based on the reading mode. Right-to-left reading will start on the left-half of the screen; left-to-right reading will start on the right-half of the screen. This gives the comic a uniform reading where a page does not suddenly occupy larger screen real estate in the center of the screen. It gives a more natural flow as you focus on the side of the page you are reading as you flip through a chapter.

A secondary change was to normalize the height of each page when rendering dual pages. It would happen often (particularly with credit pages) where the final page would have a drastically different size from the rest of the chapter. This would cause the credit to appear disproportionally small and illegible. Pages will now be scaled to occupy exactly half of the screen.

Resolves #1823 

### Images

*Taken on a Samsung Tab S9+*

| Before | After |
| ------- | ------- |
| <img width="2800" height="1752" alt="Screenshot_20260730_215745_Komikku" src="https://github.com/user-attachments/assets/21a606b9-d934-49ba-af44-921a37e6ea38" /> | <img width="2800" height="1752" alt="Screenshot_20260730_215813_Komikku" src="https://github.com/user-attachments/assets/ccc15278-4ec1-4a44-ad92-431679374e67" /> |
| <img width="2800" height="1752" alt="Screenshot_20260730_215754_Komikku" src="https://github.com/user-attachments/assets/aca6ad0c-ba5c-4ccc-ac08-db4290182bed" /> | <img width="2800" height="1752" alt="Screenshot_20260730_215825_Komikku" src="https://github.com/user-attachments/assets/e7e45479-1ceb-4999-8284-c04d0f590e8f" /> |

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Adjust reader image layout for solo and dual pages to provide consistent half-screen positioning and sizing.

New Features:
- Add support for padding solo portrait pages in double-page mode so they occupy a single half of the screen based on reading direction.

Enhancements:
- Normalize dual-page rendering by scaling each page to the same height and centering them within fixed half-screen widths, respecting reading order.