### PR TITLE
feat(MangaDex): Support TachiyomiX 1.6

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
@@ -52,9 +52,12 @@ import tachiyomi.core.common.util.lang.runAsObservable
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
+import kotlin.collections.HashMap
 import kotlin.reflect.KClass
 import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.full.superclasses
+import kotlin.reflect.jvm.isAccessible
 
 @Suppress("OverridingDeprecatedMember")
 class MangaDex(delegate: HttpSource, val context: Context) :
@@ -142,6 +145,27 @@ class MangaDex(delegate: HttpSource, val context: Context) :
         )
     }
 
+    private val komikkuGetSearchManga by lazy {
+        delegate::class.memberFunctions.find { it.name == "komikkuGetSearchManga" }
+    }
+
+    private val komikkuGetLatestUpdates by lazy {
+        delegate::class.memberFunctions.find { it.name == "komikkuGetLatestUpdates" }
+    }
+
+    private val tokenTracker: HashMap<String, Long>? by lazy {
+        val helperCallable = delegate::class.members.find { it.name == "helper" }
+            ?: delegate::class.superclasses.first().members.find { it.name == "helper" }
+            ?: return@lazy null
+        helperCallable.isAccessible = true
+        val helper = helperCallable.call(delegate) ?: return@lazy null
+
+        val tokenTrackerCallable = helper::class.members.find { it.name == "tokenTracker" } ?: return@lazy null
+        tokenTrackerCallable.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        tokenTrackerCallable.call(helper) as? HashMap<String, Long>
+    }
+
     // UrlImportableSource methods
     override suspend fun mapUrlToMangaUrl(uri: Uri): String? {
         val lcFirstPathSegment = uri.pathSegments.firstOrNull()?.lowercase() ?: return null
@@ -167,22 +191,29 @@ class MangaDex(delegate: HttpSource, val context: Context) :
     @Deprecated("Use the suspend API instead", replaceWith = ReplaceWith("getSearchManga"))
     @Suppress("DEPRECATION")
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
-        return delegate::class.memberFunctions.find { it.name == "komikkuGetSearchManga" }?.let {
-            runAsObservable { it.callSuspend(delegate, page) as MangasPage }
+        return komikkuGetSearchManga?.let {
+            runAsObservable {
+                it.callSuspend(delegate, page) as? MangasPage
+                    ?: throw Exception("komikkuGetSearchManga did not return a MangasPage instance")
+            }
         } ?: delegate.fetchSearchManga(page, query, filters)
     }
 
     override suspend fun getSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
-        return delegate::class.memberFunctions.find { it.name == "komikkuGetSearchManga" }?.let {
-            it.callSuspend(delegate, page) as MangasPage
+        return komikkuGetSearchManga?.let {
+            it.callSuspend(delegate, page) as? MangasPage
+                ?: throw Exception("komikkuGetSearchManga did not return a MangasPage instance")
         } ?: delegate.getSearchManga(page, query, filters)
     }
 
     @Deprecated("Use the suspend API instead", replaceWith = ReplaceWith("getLatestUpdates"))
     @Suppress("DEPRECATION")
     override fun fetchLatestUpdates(page: Int): Observable<MangasPage> {
-        delegate::class.memberFunctions.find { it.name == "komikkuGetLatestUpdates" }?.let {
-            return runAsObservable { it.callSuspend(delegate, page) as MangasPage }
+        komikkuGetLatestUpdates?.let {
+            return runAsObservable {
+                it.callSuspend(delegate, page) as? MangasPage
+                    ?: throw Exception("komikkuGetLatestUpdates did not return a MangasPage instance")
+            }
         }
         val request = delegate.latestUpdatesRequest(page)
         val url = request.url.newBuilder()
@@ -197,8 +228,9 @@ class MangaDex(delegate: HttpSource, val context: Context) :
 
     @Suppress("DEPRECATION")
     override suspend fun getLatestUpdates(page: Int): MangasPage {
-        delegate::class.memberFunctions.find { it.name == "komikkuGetLatestUpdates" }?.let {
-            return it.callSuspend(delegate, page) as MangasPage
+        komikkuGetLatestUpdates?.let {
+            return it.callSuspend(delegate, page) as? MangasPage
+                ?: throw Exception("komikkuGetLatestUpdates did not return a MangasPage instance")
         }
         val request = delegate.latestUpdatesRequest(page)
         val url = request.url.newBuilder()
@@ -258,11 +290,11 @@ class MangaDex(delegate: HttpSource, val context: Context) :
 
     @Deprecated("Use the suspend API instead", replaceWith = ReplaceWith("getPageList"))
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
-        return runAsObservable { pageHandler.fetchPageList(chapter, usePort443Only(), dataSaver(), delegate) }
+        return runAsObservable { pageHandler.fetchPageList(chapter, usePort443Only(), dataSaver(), tokenTracker) }
     }
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        return pageHandler.fetchPageList(chapter, usePort443Only(), dataSaver(), delegate)
+        return pageHandler.fetchPageList(chapter, usePort443Only(), dataSaver(), tokenTracker)
     }
 
     override suspend fun getImage(page: Page): Response {

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
@@ -55,6 +55,7 @@ import uy.kohesive.injekt.injectLazy
 import kotlin.collections.HashMap
 import kotlin.reflect.KClass
 import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.memberFunctions
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.isAccessible
@@ -123,7 +124,7 @@ class MangaDex(delegate: HttpSource, val context: Context) :
     private val bilibiliHandler by lazy {
         BilibiliHandler(network.client)
     }
-    private val azukHandler by lazy {
+    private val azukiHandler by lazy {
         AzukiHandler(network.client, network.defaultUserAgentProvider())
     }
     private val mangaHotHandler by lazy {
@@ -139,31 +140,53 @@ class MangaDex(delegate: HttpSource, val context: Context) :
             mangaPlusHandler,
             comikeyHandler,
             bilibiliHandler,
-            azukHandler,
+            azukiHandler,
             mangaHotHandler,
             namicomiHandler,
         )
     }
 
+    /**
+     * Signature:
+     *
+     * ```kotlin
+     * @Suppress(names = ["unused"])
+     * public final suspend fun komikkuGetSearchManga(
+     *     page: Int,
+     *     query: String,
+     *     filters: FilterList
+     * ): MangasPage
+     * ```
+     */
     private val komikkuGetSearchManga by lazy {
         delegate::class.memberFunctions.find { it.name == "komikkuGetSearchManga" }
     }
 
+    /**
+     * Signature:
+     *
+     * ```kotlin
+     * @Suppress(names = ["unused"])
+     * public final suspend fun komikkuGetLatestUpdates(
+     *     page: Int
+     * ): MangasPage
+     * ```
+     */
     private val komikkuGetLatestUpdates by lazy {
         delegate::class.memberFunctions.find { it.name == "komikkuGetLatestUpdates" }
     }
 
     private val tokenTracker: HashMap<String, Long>? by lazy {
-        val helperCallable = delegate::class.members.find { it.name == "helper" }
-            ?: delegate::class.superclasses.first().members.find { it.name == "helper" }
+        val helperProperty = delegate::class.declaredMemberProperties.find { it.name == "helper" }
+            ?: delegate::class.superclasses.asSequence().flatMap { it.declaredMemberProperties }.find { it.name == "helper" }
             ?: return@lazy null
-        helperCallable.isAccessible = true
-        val helper = helperCallable.call(delegate) ?: return@lazy null
+        helperProperty.isAccessible = true
+        val helper = helperProperty.call(delegate) ?: return@lazy null
 
-        val tokenTrackerCallable = helper::class.members.find { it.name == "tokenTracker" } ?: return@lazy null
-        tokenTrackerCallable.isAccessible = true
+        val tokenTrackerProperty = helper::class.declaredMemberProperties.find { it.name == "tokenTracker" } ?: return@lazy null
+        tokenTrackerProperty.isAccessible = true
         @Suppress("UNCHECKED_CAST")
-        tokenTrackerCallable.call(helper) as? HashMap<String, Long>
+        tokenTrackerProperty.call(helper) as? HashMap<String, Long>
     }
 
     // UrlImportableSource methods
@@ -193,16 +216,18 @@ class MangaDex(delegate: HttpSource, val context: Context) :
     override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
         return komikkuGetSearchManga?.let {
             runAsObservable {
-                it.callSuspend(delegate, page) as? MangasPage
-                    ?: throw Exception("komikkuGetSearchManga did not return a MangasPage instance")
+                val result = it.callSuspend(delegate, page, query, filters)
+                result as? MangasPage
+                    ?: throw Exception("komikkuGetSearchManga returned $result instead of a MangasPage instance")
             }
         } ?: delegate.fetchSearchManga(page, query, filters)
     }
 
     override suspend fun getSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
         return komikkuGetSearchManga?.let {
-            it.callSuspend(delegate, page) as? MangasPage
-                ?: throw Exception("komikkuGetSearchManga did not return a MangasPage instance")
+            val result = it.callSuspend(delegate, page, query, filters)
+            result as? MangasPage
+                ?: throw Exception("komikkuGetSearchManga returned $result instead of a MangasPage instance")
         } ?: delegate.getSearchManga(page, query, filters)
     }
 
@@ -211,8 +236,9 @@ class MangaDex(delegate: HttpSource, val context: Context) :
     override fun fetchLatestUpdates(page: Int): Observable<MangasPage> {
         komikkuGetLatestUpdates?.let {
             return runAsObservable {
-                it.callSuspend(delegate, page) as? MangasPage
-                    ?: throw Exception("komikkuGetLatestUpdates did not return a MangasPage instance")
+                val result = it.callSuspend(delegate, page)
+                result as? MangasPage
+                    ?: throw Exception("komikkuGetLatestUpdates returned $result instead of a MangasPage instance")
             }
         }
         val request = delegate.latestUpdatesRequest(page)
@@ -229,8 +255,9 @@ class MangaDex(delegate: HttpSource, val context: Context) :
     @Suppress("DEPRECATION")
     override suspend fun getLatestUpdates(page: Int): MangasPage {
         komikkuGetLatestUpdates?.let {
-            return it.callSuspend(delegate, page) as? MangasPage
-                ?: throw Exception("komikkuGetLatestUpdates did not return a MangasPage instance")
+            val result = it.callSuspend(delegate, page)
+            return result as? MangasPage
+                ?: throw Exception("komikkuGetLatestUpdates returned $result instead of a MangasPage instance")
         }
         val request = delegate.latestUpdatesRequest(page)
         val url = request.url.newBuilder()

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.data.track.mdlist.MdList
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
@@ -52,6 +53,8 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import kotlin.reflect.KClass
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.memberFunctions
 
 @Suppress("OverridingDeprecatedMember")
 class MangaDex(delegate: HttpSource, val context: Context) :
@@ -161,8 +164,26 @@ class MangaDex(delegate: HttpSource, val context: Context) :
         return mangaHandler.getMangaFromChapterId(id)?.let { MdUtil.buildMangaUrl(it) }
     }
 
+    @Deprecated("Use the suspend API instead", replaceWith = ReplaceWith("getSearchManga"))
+    @Suppress("DEPRECATION")
+    override fun fetchSearchManga(page: Int, query: String, filters: FilterList): Observable<MangasPage> {
+        return delegate::class.memberFunctions.find { it.name == "komikkuGetSearchManga" }?.let {
+            runAsObservable { it.callSuspend(delegate, page) as MangasPage }
+        } ?: delegate.fetchSearchManga(page, query, filters)
+    }
+
+    override suspend fun getSearchManga(page: Int, query: String, filters: FilterList): MangasPage {
+        return delegate::class.memberFunctions.find { it.name == "komikkuGetSearchManga" }?.let {
+            it.callSuspend(delegate, page) as MangasPage
+        } ?: delegate.getSearchManga(page, query, filters)
+    }
+
     @Deprecated("Use the suspend API instead", replaceWith = ReplaceWith("getLatestUpdates"))
+    @Suppress("DEPRECATION")
     override fun fetchLatestUpdates(page: Int): Observable<MangasPage> {
+        delegate::class.memberFunctions.find { it.name == "komikkuGetLatestUpdates" }?.let {
+            return runAsObservable { it.callSuspend(delegate, page) as MangasPage }
+        }
         val request = delegate.latestUpdatesRequest(page)
         val url = request.url.newBuilder()
             .removeAllQueryParameters("includeFutureUpdates")
@@ -174,7 +195,11 @@ class MangaDex(delegate: HttpSource, val context: Context) :
             }
     }
 
+    @Suppress("DEPRECATION")
     override suspend fun getLatestUpdates(page: Int): MangasPage {
+        delegate::class.memberFunctions.find { it.name == "komikkuGetLatestUpdates" }?.let {
+            return it.callSuspend(delegate, page) as MangasPage
+        }
         val request = delegate.latestUpdatesRequest(page)
         val url = request.url.newBuilder()
             .removeAllQueryParameters("includeFutureUpdates")

--- a/app/src/main/java/exh/md/handlers/PageHandler.kt
+++ b/app/src/main/java/exh/md/handlers/PageHandler.kt
@@ -75,9 +75,9 @@ class PageHandler(
 
     @Suppress("UNCHECKED_CAST")
     private fun updateExtensionVariable(mangadex: Source, atHomeRequestUrl: String) {
-        val mangadexSuperclass = mangadex::class.superclasses.first()
-
-        val helperCallable = mangadexSuperclass.members.find { it.name == "helper" } ?: return
+        val helperCallable = mangadex::class.members.find { it.name == "helper" }
+            ?: mangadex::class.superclasses.first().members.find { it.name == "helper" }
+            ?: return
         helperCallable.isAccessible = true
         val helper = helperCallable.call(mangadex) ?: return
 

--- a/app/src/main/java/exh/md/handlers/PageHandler.kt
+++ b/app/src/main/java/exh/md/handlers/PageHandler.kt
@@ -2,7 +2,6 @@ package exh.md.handlers
 
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.newCachelessCallWithProgress
-import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import exh.log.xLogD
@@ -14,8 +13,6 @@ import okhttp3.Call
 import okhttp3.Headers
 import rx.Observable
 import tachiyomi.core.common.util.lang.withIOContext
-import kotlin.reflect.full.superclasses
-import kotlin.reflect.jvm.isAccessible
 
 class PageHandler(
     private val headers: Headers,
@@ -28,7 +25,12 @@ class PageHandler(
     private val namicomiHandler: NamicomiHandler,
 ) {
 
-    suspend fun fetchPageList(chapter: SChapter, usePort443Only: Boolean, dataSaver: Boolean, mangadex: Source): List<Page> {
+    suspend fun fetchPageList(
+        chapter: SChapter,
+        usePort443Only: Boolean,
+        dataSaver: Boolean,
+        tokenTracker: HashMap<String, Long>?,
+    ): List<Page> {
         return withIOContext {
             val chapterResponse = service.viewChapter(MdUtil.getChapterId(chapter.url))
 
@@ -64,7 +66,7 @@ class PageHandler(
                     "${MdApi.atHomeServer}/${MdUtil.getChapterId(chapter.url)}"
                 }
 
-                updateExtensionVariable(mangadex, atHomeRequestUrl)
+                tokenTracker?.let{ updateExtensionVariable(it, atHomeRequestUrl) }
 
                 val atHomeResponse = service.getAtHomeServer(atHomeRequestUrl, headers)
 
@@ -73,17 +75,7 @@ class PageHandler(
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun updateExtensionVariable(mangadex: Source, atHomeRequestUrl: String) {
-        val helperCallable = mangadex::class.members.find { it.name == "helper" }
-            ?: mangadex::class.superclasses.first().members.find { it.name == "helper" }
-            ?: return
-        helperCallable.isAccessible = true
-        val helper = helperCallable.call(mangadex) ?: return
-
-        val tokenTrackerCallable = helper::class.members.find { it.name == "tokenTracker" } ?: return
-        tokenTrackerCallable.isAccessible = true
-        val tokenTracker = tokenTrackerCallable.call(helper) as? HashMap<String, Long> ?: return
+    private fun updateExtensionVariable(tokenTracker: HashMap<String, Long>, atHomeRequestUrl: String) {
         tokenTracker[atHomeRequestUrl] = System.currentTimeMillis()
     }
 


### PR DESCRIPTION
Allows MangaDex source to update to TachiyomiX 1.6.

Based on keiyoushi/extensions-source#18124

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Add support hooks in MangaDex for TachiyomiX 1.6 while simplifying token tracking integration with the page handler.

New Features:
- Integrate optional komikkuSearch and latest updates APIs in MangaDex to support TachiyomiX 1.6 search and latest update flows.

Enhancements:
- Expose the MangaDex token tracker via a helper property and pass it directly to the page handler instead of using reflection on the source object.
- Rename the Azuki handler field in MangaDex to align with the underlying AzukiHandler naming.