### PR TITLE
feat(kitsu): Use the rating system configured on the account

### DIFF
--- a/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
@@ -3,6 +3,7 @@ package eu.kanade.domain.track.service
 import eu.kanade.domain.track.model.AutoTrackState
 import eu.kanade.tachiyomi.data.track.Tracker
 import eu.kanade.tachiyomi.data.track.anilist.Anilist
+import eu.kanade.tachiyomi.data.track.kitsu.Kitsu
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
@@ -35,6 +36,10 @@ class TrackPreferences(
     fun trackToken(tracker: Tracker) = preferenceStore.getString(Preference.privateKey("track_token_${tracker.id}"), "")
 
     fun anilistScoreType() = preferenceStore.getString("anilist_score_type", Anilist.POINT_10)
+
+    // KMK -->
+    fun kitsuScoreType() = preferenceStore.getString("kitsu_score_type", Kitsu.ADVANCED)
+    // KMK <--
 
     fun autoUpdateTrack() = preferenceStore.getBoolean("pref_auto_update_manga_sync_key", true)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/Kitsu.kt
@@ -9,11 +9,9 @@ import eu.kanade.tachiyomi.data.track.kitsu.dto.KitsuOAuth
 import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.serialization.json.Json
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.injectLazy
-import java.text.DecimalFormat
 import tachiyomi.domain.track.model.Track as DomainTrack
 
 class Kitsu(id: Long) : BaseTracker(id, "Kitsu"), DeletableTracker {
@@ -24,6 +22,12 @@ class Kitsu(id: Long) : BaseTracker(id, "Kitsu"), DeletableTracker {
         const val ON_HOLD = 3L
         const val DROPPED = 4L
         const val PLAN_TO_READ = 5L
+
+        // KMK -->
+        const val SIMPLE = "simple"
+        const val REGULAR = "regular"
+        const val ADVANCED = "advanced"
+        // KMK <--
     }
 
     override val supportsReadingDates: Boolean = true
@@ -35,6 +39,10 @@ class Kitsu(id: Long) : BaseTracker(id, "Kitsu"), DeletableTracker {
     private val interceptor by lazy { KitsuInterceptor(this) }
 
     private val api by lazy { KitsuApi(client, interceptor) }
+
+    // KMK -->
+    private val scorePreference = trackPreferences.kitsuScoreType()
+    // KMK <--
 
     override fun getLogo() = R.drawable.brand_kitsu
 
@@ -57,19 +65,14 @@ class Kitsu(id: Long) : BaseTracker(id, "Kitsu"), DeletableTracker {
 
     override fun getCompletionStatus(): Long = COMPLETED
 
-    override fun getScoreList(): ImmutableList<String> {
-        val df = DecimalFormat("0.#")
-        return (listOf("0") + IntRange(2, 20).map { df.format(it / 2f) }).toImmutableList()
-    }
+    // KMK -->
+    override fun getScoreList(): ImmutableList<String> = kitsuScoreList(scorePreference.get())
 
-    override fun indexToScore(index: Int): Double {
-        return if (index > 0) (index + 1) / 2.0 else 0.0
-    }
+    override fun indexToScore(index: Int): Double = kitsuIndexToScore(scorePreference.get(), index)
 
-    override fun displayScore(track: DomainTrack): String {
-        val df = DecimalFormat("0.#")
-        return df.format(track.score)
-    }
+    override fun displayScore(track: DomainTrack): String =
+        kitsuDisplayScore(scorePreference.get(), track.score)
+    // KMK <--
 
     private suspend fun add(track: Track): Track {
         return api.addLibManga(track, getUserId())
@@ -130,7 +133,10 @@ class Kitsu(id: Long) : BaseTracker(id, "Kitsu"), DeletableTracker {
     override suspend fun login(username: String, password: String) {
         val token = api.login(username, password)
         interceptor.newAuth(token)
-        val userId = api.getCurrentUser()
+        // KMK -->
+        val (userId, ratingSystem) = api.getCurrentUser()
+        scorePreference.set(ratingSystem)
+        // KMK <--
         saveCredentials(username, userId)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuApi.kt
@@ -230,7 +230,14 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
         }
     }
 
-    suspend fun getCurrentUser(): String {
+    // KMK -->
+    /**
+     * Returns the user's id paired with the rating system configured on their Kitsu account.
+     *
+     * `ratingSystem` is only exposed to the authenticated user, so it falls back to
+     * [Kitsu.ADVANCED] — the scale the app used unconditionally before — when absent.
+     */
+    suspend fun getCurrentUser(): Pair<String, String> {
         return withIOContext {
             val url = "${BASE_URL}users".toUri().buildUpon()
                 .encodedQuery("filter[self]=true")
@@ -240,10 +247,11 @@ class KitsuApi(private val client: OkHttpClient, interceptor: KitsuInterceptor) 
                     .awaitSuccess()
                     .parseAs<KitsuCurrentUserResult>()
                     .data[0]
-                    .id
+                    .let { it.id to (it.attributes?.ratingSystem ?: Kitsu.ADVANCED) }
             }
         }
     }
+    // KMK <--
 
     suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
         return withIOContext {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuUtils.kt
@@ -1,6 +1,10 @@
 package eu.kanade.tachiyomi.data.track.kitsu
 
 import eu.kanade.tachiyomi.data.database.models.Track
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import java.text.DecimalFormat
 
 fun Track.toApiStatus() = when (status) {
     Kitsu.READING -> "current"
@@ -14,3 +18,57 @@ fun Track.toApiStatus() = when (status) {
 fun Track.toApiScore(): String? {
     return if (score > 0) (score * 2).toInt().toString() else null
 }
+
+// KMK -->
+private const val AWFUL = "Awful"
+private const val MEH = "Meh"
+private const val GOOD = "Good"
+private const val GREAT = "Great"
+
+// DecimalFormat is not thread safe, so build one where it is used rather than sharing an instance.
+private fun formatScore(score: Number): String = DecimalFormat("0.#").format(score)
+
+/**
+ * A track's score is Kitsu's `ratingTwenty` halved, so all three rating systems fit in it and only
+ * the presentation differs.
+ *
+ * The three functions below must stay in lockstep: [kitsuDisplayScore] has to return an element of
+ * [kitsuScoreList], and [kitsuIndexToScore] has to be the inverse of a position in that list.
+ * `BaseTracker.setRemoteScore` resolves a picked string with `getScoreList().indexOf(...)`, so a
+ * mismatch yields -1, which maps to a score of 0 and silently wipes the rating on the user's
+ * account.
+ */
+fun kitsuScoreList(ratingSystem: String): ImmutableList<String> = when (ratingSystem) {
+    // ratingTwenty 2, 8, 14, 20
+    Kitsu.SIMPLE -> persistentListOf("-", AWFUL, MEH, GOOD, GREAT)
+    // ratingTwenty in increments of 2, shown as 5 stars in 0.5 steps
+    Kitsu.REGULAR -> (listOf("0") + IntRange(1, 10).map { "${formatScore(it / 2f)} ★" })
+        .toImmutableList()
+    // ratingTwenty in increments of 1, shown as 1-10 in 0.5 steps
+    else -> (listOf("0") + IntRange(2, 20).map { formatScore(it / 2f) }).toImmutableList()
+}
+
+fun kitsuIndexToScore(ratingSystem: String, index: Int): Double = when {
+    index <= 0 -> 0.0
+    ratingSystem == Kitsu.SIMPLE -> when (index) {
+        1 -> 1.0
+        2 -> 4.0
+        3 -> 7.0
+        else -> 10.0
+    }
+    ratingSystem == Kitsu.REGULAR -> index.toDouble()
+    else -> (index + 1) / 2.0
+}
+
+fun kitsuDisplayScore(ratingSystem: String, score: Double): String = when (ratingSystem) {
+    Kitsu.SIMPLE -> when {
+        score <= 0.0 -> "-"
+        score < 3.0 -> AWFUL
+        score < 5.0 -> MEH
+        score < 8.0 -> GOOD
+        else -> GREAT
+    }
+    Kitsu.REGULAR -> if (score <= 0.0) "0" else "${formatScore(score / 2)} ★"
+    else -> formatScore(score)
+}
+// KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuUser.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kitsu/dto/KitsuUser.kt
@@ -10,4 +10,15 @@ data class KitsuCurrentUserResult(
 @Serializable
 data class KitsuUser(
     val id: String,
+    // KMK -->
+    val attributes: KitsuUserAttributes? = null,
+    // KMK <--
 )
+
+// KMK -->
+@Serializable
+data class KitsuUserAttributes(
+    // One of `simple`, `regular` or `advanced`; only returned for the authenticated user.
+    val ratingSystem: String? = null,
+)
+// KMK <--

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuScoreTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/kitsu/KitsuScoreTest.kt
@@ -1,0 +1,123 @@
+package eu.kanade.tachiyomi.data.track.kitsu
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The score list, the index -> score mapping and the displayed score have to agree with each other.
+ * `BaseTracker.setRemoteScore` looks a picked string up with `getScoreList().indexOf(...)`, so if
+ * `displayScore` ever returns something outside the list the lookup yields -1, which maps to 0.0
+ * and clears the rating on the user's Kitsu account without any error.
+ */
+class KitsuScoreTest {
+
+    private val ratingSystems = listOf(Kitsu.SIMPLE, Kitsu.REGULAR, Kitsu.ADVANCED)
+
+    @Test
+    fun `every score in the list survives a round trip`() {
+        ratingSystems.forEach { ratingSystem ->
+            val scoreList = kitsuScoreList(ratingSystem)
+            scoreList.forEachIndexed { index, entry ->
+                val score = kitsuIndexToScore(ratingSystem, index)
+                assertEquals(
+                    entry,
+                    kitsuDisplayScore(ratingSystem, score),
+                    "$ratingSystem index $index did not round trip",
+                )
+                assertEquals(
+                    index,
+                    scoreList.indexOf(kitsuDisplayScore(ratingSystem, score)),
+                    "$ratingSystem index $index does not resolve back to its own position",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `unrated resolves to zero for every rating system`() {
+        ratingSystems.forEach { ratingSystem ->
+            assertEquals(0.0, kitsuIndexToScore(ratingSystem, 0))
+            assertEquals(
+                kitsuScoreList(ratingSystem).first(),
+                kitsuDisplayScore(ratingSystem, 0.0),
+                "$ratingSystem should display an unrated entry as its first list item",
+            )
+        }
+    }
+
+    @Test
+    fun `an unknown rating system falls back to advanced`() {
+        assertEquals(kitsuScoreList(Kitsu.ADVANCED), kitsuScoreList("something-new"))
+        assertEquals(kitsuIndexToScore(Kitsu.ADVANCED, 7), kitsuIndexToScore("something-new", 7))
+        assertEquals(kitsuDisplayScore(Kitsu.ADVANCED, 4.5), kitsuDisplayScore("something-new", 4.5))
+    }
+
+    @Test
+    fun `simple maps to Kitsu's four labels`() {
+        assertEquals(listOf("-", "Awful", "Meh", "Good", "Great"), kitsuScoreList(Kitsu.SIMPLE))
+
+        // Stored score is ratingTwenty / 2, and Kitsu writes 2, 8, 14 and 20 for the four labels.
+        assertEquals(1.0, kitsuIndexToScore(Kitsu.SIMPLE, 1))
+        assertEquals(4.0, kitsuIndexToScore(Kitsu.SIMPLE, 2))
+        assertEquals(7.0, kitsuIndexToScore(Kitsu.SIMPLE, 3))
+        assertEquals(10.0, kitsuIndexToScore(Kitsu.SIMPLE, 4))
+    }
+
+    @Test
+    fun `simple buckets scores on Kitsu's thresholds`() {
+        // Kitsu buckets ratingTwenty as < 6, < 10, < 16 and the rest.
+        assertEquals("Awful", kitsuDisplayScore(Kitsu.SIMPLE, 2.5)) // ratingTwenty 5
+        assertEquals("Meh", kitsuDisplayScore(Kitsu.SIMPLE, 3.0)) // ratingTwenty 6
+        assertEquals("Meh", kitsuDisplayScore(Kitsu.SIMPLE, 4.5)) // ratingTwenty 9
+        assertEquals("Good", kitsuDisplayScore(Kitsu.SIMPLE, 5.0)) // ratingTwenty 10
+        assertEquals("Good", kitsuDisplayScore(Kitsu.SIMPLE, 7.5)) // ratingTwenty 15
+        assertEquals("Great", kitsuDisplayScore(Kitsu.SIMPLE, 8.0)) // ratingTwenty 16
+    }
+
+    @Test
+    fun `regular maps to half stars up to five`() {
+        assertEquals("0.5 ★", kitsuScoreList(Kitsu.REGULAR)[1])
+        assertEquals("5 ★", kitsuScoreList(Kitsu.REGULAR).last())
+        assertEquals(11, kitsuScoreList(Kitsu.REGULAR).size)
+
+        // ratingTwenty goes up in steps of 2, so the stored score is a whole number.
+        assertEquals(1.0, kitsuIndexToScore(Kitsu.REGULAR, 1))
+        assertEquals(10.0, kitsuIndexToScore(Kitsu.REGULAR, 10))
+        assertEquals("2.5 ★", kitsuDisplayScore(Kitsu.REGULAR, 5.0))
+    }
+
+    @Test
+    fun `advanced keeps the existing one to ten scale`() {
+        val scoreList = kitsuScoreList(Kitsu.ADVANCED)
+        assertEquals(20, scoreList.size)
+        assertEquals("0", scoreList.first())
+        assertEquals("1", scoreList[1])
+        assertEquals("1.5", scoreList[2])
+        assertEquals("10", scoreList.last())
+
+        assertEquals(1.0, kitsuIndexToScore(Kitsu.ADVANCED, 1))
+        assertEquals(10.0, kitsuIndexToScore(Kitsu.ADVANCED, 19))
+        assertEquals("7.5", kitsuDisplayScore(Kitsu.ADVANCED, 7.5))
+    }
+
+    @Test
+    fun `scores stay within the range Kitsu accepts`() {
+        ratingSystems.forEach { ratingSystem ->
+            kitsuScoreList(ratingSystem).indices.forEach { index ->
+                val score = kitsuIndexToScore(ratingSystem, index)
+                // toApiScore sends (score * 2), which Kitsu accepts as ratingTwenty 1..20.
+                val ratingTwenty = score * 2
+                assertTrue(
+                    ratingTwenty >= 0 && ratingTwenty <= 20,
+                    "$ratingSystem index $index produced ratingTwenty $ratingTwenty",
+                )
+                assertEquals(
+                    ratingTwenty,
+                    ratingTwenty.toInt().toDouble(),
+                    "$ratingSystem index $index produced a fractional ratingTwenty",
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1608.

Kitsu lets each account choose how ratings are displayed — simple (Awful/Meh/Good/Great), regular (0.5–5 stars) or advanced (1–10 in 0.5 steps) — but the tracker hardcoded the advanced scale. Anyone whose account is set to simple or regular got a score picker that didn't match what Kitsu shows them.

The issue suggests showing Kitsu's labels directly. I went slightly wider: the labels are only Kitsu's *simple* system, so hardcoding them would fix the reporter's case while breaking it for accounts set to regular or advanced. Reading the account's own setting covers all three, and advanced accounts see no change.

This reads `ratingSystem` off the authenticated user during login and stores it in a preference — the same shape Anilist already uses via `anilistScoreType()`.

The score functions live in `KitsuUtils.kt` rather than inline in `Kitsu.kt` the way Anilist's are, so they can be tested without standing up Injekt. They have to stay in lockstep: `BaseTracker.setRemoteScore` resolves a picked string with `getScoreList().indexOf(...)`, so if `displayScore` returns anything outside the list the lookup yields -1, which maps to a score of 0 and silently wipes the rating on the user's Kitsu account. `KitsuScoreTest` is mostly there to pin that down.

### Verification

Unit tests: 8/8 pass. I checked they aren't vacuous by mutating the simple index mapping (`2 -> 4.0` into `2 -> 5.0`) — two tests fail, as intended.

Manually tested on an API 36 emulator against a live Kitsu account set to **simple**:

- After login the stored preference reads `simple`, confirming `attributes.ratingSystem` deserializes rather than silently falling back.
- The picker shows `-, Awful, Meh, Good, Great` instead of `0, 1, 1.5 … 10`.
- Round trip: set **Meh** in the app → stored score `4.0` → `PATCH /api/edge/library-entries/…` returns 200 → kitsu.app shows **MEH**. This is the only check that the simple bucket thresholds match Kitsu's real behaviour rather than just being self-consistent.

### Known limitations

The preference is only written during `login()`, so changing the rating system on kitsu.io won't take effect until the user logs out and back in. The alternative — refetching the user on every score interaction — costs a request per dialog open for a setting that almost never changes. Happy to do it differently if you'd rather.

Existing users default to `advanced`, which is the current behaviour, so no migration is needed.

Only simple is verified end to end; regular and advanced are covered by unit tests but I haven't seen their pickers against a real account. Likewise only one point on the simple scale (`ratingTwenty` 8 → MEH) is confirmed against Kitsu directly — the other boundaries come from the documented cutoffs and are asserted in tests, not observed.

### Images

| Score picker, account set to simple | Same rating on kitsu.app |
| --- | --- |
| <img width="260" alt="Komikku score picker showing Awful, Meh, Good" src="https://github.com/user-attachments/assets/2ff887a5-4a31-4089-87ac-3067b8fa8d00" /> | <img width="360" alt="kitsu.app library entry showing MEH" src="https://github.com/user-attachments/assets/cf4a2226-49af-4177-8db0-a78d6a550164" /> |

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Respect the Kitsu account’s configured rating system for scores and align the app’s picker and display with Kitsu’s three scales while ensuring safe round-tripping of ratings.

New Features:
- Persist the Kitsu rating system (simple, regular, advanced) as a user preference and use it to drive score selection and display.
- Support Kitsu’s simple label-based ratings and regular half-star ratings alongside the existing advanced 1–10 scale.

Bug Fixes:
- Prevent Kitsu ratings from being silently cleared by ensuring displayed scores always map back to a valid entry in the score list.

Enhancements:
- Centralize Kitsu score list generation, index mapping, and display logic in a shared utility that handles all rating systems.
- Extend Kitsu’s user API handling to read the authenticated user’s ratingSystem attribute, defaulting to the previous advanced behavior when absent.

Tests:
- Add KitsuScoreTest to verify round-tripping between score list, index-to-score mapping, displayed scores, and Kitsu’s accepted ratingTwenty range across all rating systems.