### PR TITLE
fix(MangaDex): Fix page handlers

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
@@ -34,6 +34,7 @@ import exh.md.handlers.KMangaHandler
 import exh.md.handlers.MangaHandler
 import exh.md.handlers.MangaHotHandler
 import exh.md.handlers.MangaPlusHandler
+import exh.md.handlers.MangaUpHandler
 import exh.md.handlers.NamicomiHandler
 import exh.md.handlers.PageHandler
 import exh.md.network.MangaDexLoginHelper
@@ -130,6 +131,9 @@ class MangaDex(delegate: HttpSource, val context: Context) :
     private val kMangaHandler by lazy {
         KMangaHandler(network.client)
     }
+    private val mangaUpHandler by lazy {
+        MangaUpHandler(network.client)
+    }
     private val pageHandler by lazy {
         PageHandler(
             delegate,
@@ -142,6 +146,7 @@ class MangaDex(delegate: HttpSource, val context: Context) :
             mangaHotHandler,
             namicomiHandler,
             kMangaHandler,
+            mangaUpHandler,
         )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/online/all/MangaDex.kt
@@ -30,6 +30,7 @@ import exh.md.handlers.AzukiHandler
 import exh.md.handlers.BilibiliHandler
 import exh.md.handlers.ComikeyHandler
 import exh.md.handlers.FollowsHandler
+import exh.md.handlers.KMangaHandler
 import exh.md.handlers.MangaHandler
 import exh.md.handlers.MangaHotHandler
 import exh.md.handlers.MangaPlusHandler
@@ -126,8 +127,12 @@ class MangaDex(delegate: HttpSource, val context: Context) :
     private val namicomiHandler by lazy {
         NamicomiHandler(network.client, network.defaultUserAgentProvider())
     }
+    private val kMangaHandler by lazy {
+        KMangaHandler(network.client)
+    }
     private val pageHandler by lazy {
         PageHandler(
+            delegate,
             headers,
             mangadexService,
             mangaPlusHandler,
@@ -136,6 +141,7 @@ class MangaDex(delegate: HttpSource, val context: Context) :
             azukHandler,
             mangaHotHandler,
             namicomiHandler,
+            kMangaHandler,
         )
     }
 
@@ -233,11 +239,11 @@ class MangaDex(delegate: HttpSource, val context: Context) :
 
     @Deprecated("Use the suspend API instead", replaceWith = ReplaceWith("getPageList"))
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
-        return runAsObservable { pageHandler.fetchPageList(chapter, usePort443Only(), dataSaver(), delegate) }
+        return runAsObservable { pageHandler.fetchPageList(chapter, usePort443Only(), dataSaver()) }
     }
 
     override suspend fun getPageList(chapter: SChapter): List<Page> {
-        return pageHandler.fetchPageList(chapter, usePort443Only(), dataSaver(), delegate)
+        return pageHandler.fetchPageList(chapter, usePort443Only(), dataSaver())
     }
 
     override suspend fun getImage(page: Page): Response {

--- a/app/src/main/java/exh/md/dto/AzukiDto.kt
+++ b/app/src/main/java/exh/md/dto/AzukiDto.kt
@@ -1,0 +1,29 @@
+package exh.md.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AzukiPageListDto(
+    val data: AzukiPageDataDto,
+)
+
+@Serializable
+data class AzukiPageDataDto(
+    val pages: List<AzukiPageDto>,
+)
+
+@Serializable
+data class AzukiPageDto(
+    val image: Image,
+)
+
+@Serializable
+data class Image(
+    val webp: List<Webp>,
+)
+
+@Serializable
+data class Webp(
+    val url: String,
+    val width: Int,
+)

--- a/app/src/main/java/exh/md/dto/KMangaDto.kt
+++ b/app/src/main/java/exh/md/dto/KMangaDto.kt
@@ -1,0 +1,29 @@
+package exh.md.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ViewerApiResponse(
+    @SerialName("page_list") val pageList: List<String>,
+    @SerialName("scramble_seed") val scrambleSeed: String,
+    @SerialName("title_id") val titleId: Int,
+    @SerialName("episode_id") val episodeId: Int,
+)
+
+@Serializable
+data class BirthdayCookie(
+    val value: String,
+    val expires: Long,
+)
+
+@Serializable
+data class LocalStorageAccount(
+    val isLoggedIn: Boolean?,
+    val checkedTicketExpiredList: List<CheckedTicketExpired>?,
+)
+
+@Serializable
+data class CheckedTicketExpired(
+    val userId: Int,
+)

--- a/app/src/main/java/exh/md/dto/MangaHotDto.kt
+++ b/app/src/main/java/exh/md/dto/MangaHotDto.kt
@@ -1,0 +1,9 @@
+package exh.md.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MangaHotPageList(val content: MangaHotContent)
+
+@Serializable
+data class MangaHotContent(val contentUrls: List<String>)

--- a/app/src/main/java/exh/md/dto/MangaPlusDto.kt
+++ b/app/src/main/java/exh/md/dto/MangaPlusDto.kt
@@ -1,27 +1,58 @@
 package exh.md.dto
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
 @Serializable
 data class MangaPlusResponse(
-    val success: SuccessResult? = null,
+    @ProtoNumber(1) val success: SuccessResult? = null,
+    @ProtoNumber(2) val error: ErrorResult? = null,
+)
+
+@Serializable
+data class ErrorResult(
+    @ProtoNumber(2) val englishPopup: Popup? = null,
+    @ProtoNumber(3) val spanishPopup: Popup? = null,
+) {
+    fun langPopup(langCode: Int): Popup? = when (langCode) {
+        LANGUAGE_SPANISH -> spanishPopup ?: englishPopup
+        else -> englishPopup
+    }
+}
+
+@Serializable
+data class Popup(
+    @ProtoNumber(2) val body: String = "",
 )
 
 @Serializable
 data class SuccessResult(
-    val mangaViewer: MangaViewer? = null,
+    @ProtoNumber(10) val mangaViewer: MangaViewer? = null,
 )
 
 @Serializable
-data class MangaViewer(val pages: List<MangaPlusPage> = emptyList())
+data class MangaViewer(
+    @ProtoNumber(1) val pages: List<MangaPlusPage> = emptyList(),
+    @ProtoNumber(19) val viewToken: String? = null,
+)
 
 @Serializable
-data class MangaPlusPage(val mangaPage: MangaPage? = null)
+data class MangaPlusPage(
+    @ProtoNumber(1) val mangaPage: MangaPage? = null,
+)
 
 @Serializable
 data class MangaPage(
-    val imageUrl: String,
-    val width: Int,
-    val height: Int,
-    val encryptionKey: String? = null,
+    @ProtoNumber(1) val imageUrl: String,
+    @ProtoNumber(5) val encryptionKey: String? = null,
 )
+
+const val LANGUAGE_ENGLISH = 0
+const val LANGUAGE_SPANISH = 1
+const val LANGUAGE_FRENCH = 2
+const val LANGUAGE_INDONESIAN = 3
+const val LANGUAGE_PORTUGUESE_BR = 4
+const val LANGUAGE_RUSSIAN = 5
+const val LANGUAGE_THAI = 6
+const val LANGUAGE_GERMAN = 7
+const val LANGUAGE_VIETNAMESE = 9

--- a/app/src/main/java/exh/md/dto/MangaPlusDto.kt
+++ b/app/src/main/java/exh/md/dto/MangaPlusDto.kt
@@ -14,8 +14,8 @@ data class ErrorResult(
     @ProtoNumber(2) val englishPopup: Popup? = null,
     @ProtoNumber(3) val spanishPopup: Popup? = null,
 ) {
-    fun langPopup(langCode: Int): Popup? = when (langCode) {
-        LANGUAGE_SPANISH -> spanishPopup ?: englishPopup
+    fun langPopup(lang: MangaPlusLanguage): Popup? = when (lang) {
+        MangaPlusLanguage.SPANISH -> spanishPopup ?: englishPopup
         else -> englishPopup
     }
 }
@@ -47,12 +47,27 @@ data class MangaPage(
     @ProtoNumber(5) val encryptionKey: String? = null,
 )
 
-const val LANGUAGE_ENGLISH = 0
-const val LANGUAGE_SPANISH = 1
-const val LANGUAGE_FRENCH = 2
-const val LANGUAGE_INDONESIAN = 3
-const val LANGUAGE_PORTUGUESE_BR = 4
-const val LANGUAGE_RUSSIAN = 5
-const val LANGUAGE_THAI = 6
-const val LANGUAGE_GERMAN = 7
-const val LANGUAGE_VIETNAMESE = 9
+enum class MangaPlusLanguage(val code: Int, val clang: String) {
+    ENGLISH(0, "eng"),
+    SPANISH(1, "esp"),
+    FRENCH(2, "fra"),
+    INDONESIAN(3, "ind"),
+    PORTUGESE_BR(4, "ptb"),
+    RUSSIAN(5, "rus"),
+    THAI(6, "tha"),
+    GERMAN(7, "deu"),
+    VIETNAMESE(9, "vie"),
+}
+
+fun String.toMangaPlusLanguage(): MangaPlusLanguage = when (this) {
+    "en" -> MangaPlusLanguage.ENGLISH
+    "es" -> MangaPlusLanguage.SPANISH
+    "fr" -> MangaPlusLanguage.FRENCH
+    "id" -> MangaPlusLanguage.INDONESIAN
+    "pt-BR" -> MangaPlusLanguage.PORTUGESE_BR
+    "ru" -> MangaPlusLanguage.RUSSIAN
+    "th" -> MangaPlusLanguage.THAI
+    "de" -> MangaPlusLanguage.GERMAN
+    "vi" -> MangaPlusLanguage.VIETNAMESE
+    else -> throw IllegalStateException("Unsupported lang: $this")
+}

--- a/app/src/main/java/exh/md/dto/MangaPlusDto.kt
+++ b/app/src/main/java/exh/md/dto/MangaPlusDto.kt
@@ -69,5 +69,6 @@ fun String.toMangaPlusLanguage(): MangaPlusLanguage = when (this) {
     "th" -> MangaPlusLanguage.THAI
     "de" -> MangaPlusLanguage.GERMAN
     "vi" -> MangaPlusLanguage.VIETNAMESE
-    else -> throw IllegalStateException("Unsupported lang: $this")
+    // Default to English
+    else -> MangaPlusLanguage.ENGLISH
 }

--- a/app/src/main/java/exh/md/dto/MangaUpDto.kt
+++ b/app/src/main/java/exh/md/dto/MangaUpDto.kt
@@ -1,0 +1,21 @@
+package exh.md.dto
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
+
+@Serializable
+class MangaUpViewerResponse(
+    @ProtoNumber(3) val pageBlocks: List<MangaUpPageBlock>,
+)
+
+@Serializable
+class MangaUpPageBlock(
+    @ProtoNumber(3) val pages: List<MangaUpMangaPage>,
+)
+
+@Serializable
+class MangaUpMangaPage(
+    @ProtoNumber(1) val url: String,
+    @ProtoNumber(5) val key: String?,
+    @ProtoNumber(6) val iv: String?,
+)

--- a/app/src/main/java/exh/md/dto/NamicomiDto.kt
+++ b/app/src/main/java/exh/md/dto/NamicomiDto.kt
@@ -1,0 +1,24 @@
+package exh.md.dto
+
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class NamicomiPageListDto(
+    val result: String,
+    val type: String,
+    val data: NamicomiPageDataDto? = null,
+)
+
+@Serializable
+data class NamicomiPageDataDto(
+    val baseUrl: String,
+    val hash: String,
+    val low: List<NamicomiImageDto>,
+    val source: List<NamicomiImageDto>,
+)
+
+@Serializable
+data class NamicomiImageDto(
+    val filename: String,
+)

--- a/app/src/main/java/exh/md/dto/NamicomiDto.kt
+++ b/app/src/main/java/exh/md/dto/NamicomiDto.kt
@@ -2,7 +2,6 @@ package exh.md.dto
 
 import kotlinx.serialization.Serializable
 
-
 @Serializable
 data class NamicomiPageListDto(
     val result: String,

--- a/app/src/main/java/exh/md/handlers/AzukiHandler.kt
+++ b/app/src/main/java/exh/md/handlers/AzukiHandler.kt
@@ -37,7 +37,7 @@ class AzukiHandler(currentClient: OkHttpClient, userAgent: String) {
 
     fun pageListParse(response: Response): List<Page> {
         return Json.decodeFromString<AzukiPageListDto>(response.body.string()).data.pages.mapIndexed { i, page ->
-            val highRes = page.image.webp.maxBy { it.width }
+            val highRes = page.image.webp.maxByOrNull { it.width } ?: throw Exception("No image urls found for page $i")
             // This will give the highest possible resolution even if x2400 image doesn't exist.
             val highResUrl = highRes.url.replace("""/\d+_""".toRegex(), "/2400_")
             Page(i, imageUrl = "$highResUrl?drm=1")

--- a/app/src/main/java/exh/md/handlers/AzukiHandler.kt
+++ b/app/src/main/java/exh/md/handlers/AzukiHandler.kt
@@ -3,20 +3,20 @@ package exh.md.handlers
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.source.model.Page
+import exh.md.dto.AzukiPageListDto
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 
 class AzukiHandler(currentClient: OkHttpClient, userAgent: String) {
-    val baseUrl = "https://www.azuki.co"
+    val baseUrl = "https://www.omoi.com"
     private val apiUrl = "https://production.api.azuki.co"
     val headers = Headers.Builder()
         .add("User-Agent", userAgent)
+        .add("azuki-organization-key", "199e5a19-a236-49f5-81f4-43d4a541748a")
         .build()
 
     val client: OkHttpClient = currentClient
@@ -28,15 +28,19 @@ class AzukiHandler(currentClient: OkHttpClient, userAgent: String) {
     }
 
     private fun pageListRequest(chapterId: String): Request {
-        return GET("$apiUrl/chapter/$chapterId/pages/v0", headers)
+        val token = client.cookieJar.loadForRequest(baseUrl.toHttpUrl())
+            .firstOrNull { it.name == "idToken" }?.value
+        return GET("$apiUrl/chapter/$chapterId/pages/v1", token?.let {
+            headers.newBuilder().add("x-user-token", token).build()
+        } ?: headers)
     }
 
     fun pageListParse(response: Response): List<Page> {
-        return Json.parseToJsonElement(response.body.string())
-            .jsonObject["pages"]!!
-            .jsonArray.mapIndexed { index, element ->
-                val url = element.jsonObject["image_wm"]!!.jsonObject["webp"]!!.jsonArray[1].jsonObject["url"]!!.jsonPrimitive.content
-                Page(index, url, url)
-            }
+        return Json.decodeFromString<AzukiPageListDto>(response.body.string()).data.pages.mapIndexed { i, page ->
+            val highRes = page.image.webp.maxBy { it.width }
+            // This will give the highest possible resolution even if x2400 image doesn't exist.
+            val highResUrl = highRes.url.replace("""/\d+_""".toRegex(), "/2400_")
+            Page(i, imageUrl = "$highResUrl?drm=1")
+        }
     }
 }

--- a/app/src/main/java/exh/md/handlers/AzukiHandler.kt
+++ b/app/src/main/java/exh/md/handlers/AzukiHandler.kt
@@ -2,6 +2,7 @@ package exh.md.handlers
 
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.parseAs
 import eu.kanade.tachiyomi.source.model.Page
 import exh.md.dto.AzukiPageListDto
 import kotlinx.serialization.json.Json
@@ -10,8 +11,11 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import uy.kohesive.injekt.injectLazy
+import kotlin.getValue
 
 class AzukiHandler(currentClient: OkHttpClient, userAgent: String) {
+    private val json by injectLazy<Json>()
     val baseUrl = "https://www.omoi.com"
     private val apiUrl = "https://production.api.azuki.co"
     val headers = Headers.Builder()
@@ -39,7 +43,7 @@ class AzukiHandler(currentClient: OkHttpClient, userAgent: String) {
     }
 
     fun pageListParse(response: Response): List<Page> {
-        return Json.decodeFromString<AzukiPageListDto>(response.body.string()).data.pages.mapIndexed { i, page ->
+        return with(json) { response.parseAs<AzukiPageListDto>() }.data.pages.mapIndexed { i, page ->
             val highRes = page.image.webp.maxByOrNull { it.width } ?: throw Exception("No image urls found for page $i")
             // This will give the highest possible resolution even if x2400 image doesn't exist.
             val highResUrl = highRes.url.replace("""/\d+_""".toRegex(), "/2400_")

--- a/app/src/main/java/exh/md/handlers/AzukiHandler.kt
+++ b/app/src/main/java/exh/md/handlers/AzukiHandler.kt
@@ -30,9 +30,12 @@ class AzukiHandler(currentClient: OkHttpClient, userAgent: String) {
     private fun pageListRequest(chapterId: String): Request {
         val token = client.cookieJar.loadForRequest(baseUrl.toHttpUrl())
             .firstOrNull { it.name == "idToken" }?.value
-        return GET("$apiUrl/chapter/$chapterId/pages/v1", token?.let {
-            headers.newBuilder().add("x-user-token", token).build()
-        } ?: headers)
+        return GET(
+            "$apiUrl/chapter/$chapterId/pages/v1",
+            token?.let {
+                headers.newBuilder().add("x-user-token", token).build()
+            } ?: headers,
+        )
     }
 
     fun pageListParse(response: Response): List<Page> {

--- a/app/src/main/java/exh/md/handlers/KMangaHandler.kt
+++ b/app/src/main/java/exh/md/handlers/KMangaHandler.kt
@@ -18,6 +18,8 @@ import eu.kanade.tachiyomi.source.model.Page
 import exh.md.dto.BirthdayCookie
 import exh.md.dto.LocalStorageAccount
 import exh.md.dto.ViewerApiResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody
 import okhttp3.Headers
@@ -49,11 +51,11 @@ class KMangaHandler(currentClient: OkHttpClient) {
 
     private var reloadUserId = false
 
-    private val baseUrl = "https://kmanga.kodansha.com"
-
     private val app = Injekt.get<Application>()
 
     private val executor = ContextCompat.getMainExecutor(app)
+
+    val baseUrl = "https://kmanga.kodansha.com"
 
     val headers = Headers.Builder()
         .add("Origin", baseUrl)
@@ -63,7 +65,7 @@ class KMangaHandler(currentClient: OkHttpClient) {
 
     val client = currentClient
         .newBuilder()
-        .addInterceptor(ImageInterceptor)
+        .addInterceptor(KMangaImageInterceptor)
         .addInterceptor { chain ->
             val request = chain.request()
             val response = chain.proceed(request)
@@ -158,7 +160,7 @@ class KMangaHandler(currentClient: OkHttpClient) {
         return "${keyHash}_$valueHash"
     }
 
-    private fun setUserId() {
+    private suspend fun setUserId() {
         reloadUserId = false
         val latch = CountDownLatch(1)
         var webView: WebView? = null
@@ -189,7 +191,7 @@ class KMangaHandler(currentClient: OkHttpClient) {
             view.loadDataWithBaseURL(baseUrl, "", "text/html", "UTF-8", null)
         }
 
-        latch.await(10, TimeUnit.SECONDS)
+        withContext(Dispatchers.IO) { latch.await(10, TimeUnit.SECONDS) }
 
         executor.execute { webView?.destroy() }
 
@@ -207,7 +209,7 @@ class KMangaHandler(currentClient: OkHttpClient) {
     }
 }
 
-private object ImageInterceptor : Interceptor {
+private object KMangaImageInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val response = chain.proceed(request)

--- a/app/src/main/java/exh/md/handlers/KMangaHandler.kt
+++ b/app/src/main/java/exh/md/handlers/KMangaHandler.kt
@@ -261,7 +261,7 @@ private object ImageInterceptor : Interceptor {
         }
 
         // The final 32-bit seed is xor'd against the sum of titleId and episodeId
-        var seed32 = parsedInt.toUInt() xor (titleId.toUInt() + episodeId.toUInt())
+        var seed32 = parsedInt.toUInt() xor titleId.toUInt() + episodeId.toUInt()
 
         val pairs = mutableListOf<Pair<UInt, Int>>()
 
@@ -287,8 +287,8 @@ private object ImageInterceptor : Interceptor {
         val result = createBitmap(width, height)
         val canvas = Canvas(result)
 
-        val blockWidth = (width / 8 * 8) / 4
-        val blockHeight = (height / 8 * 8) / 4
+        val blockWidth = (width and -8) / 4
+        val blockHeight = (height and -8) / 4
         val srcRect = Rect()
         val dstRect = Rect()
 

--- a/app/src/main/java/exh/md/handlers/KMangaHandler.kt
+++ b/app/src/main/java/exh/md/handlers/KMangaHandler.kt
@@ -1,0 +1,326 @@
+package exh.md.handlers
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Rect
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.createBitmap
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.parseAs
+import eu.kanade.tachiyomi.source.model.Page
+import exh.md.dto.BirthdayCookie
+import exh.md.dto.LocalStorageAccount
+import exh.md.dto.ViewerApiResponse
+import kotlinx.serialization.json.Json
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okio.Buffer
+import okio.ByteString.Companion.encodeUtf8
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import uy.kohesive.injekt.injectLazy
+import java.io.IOException
+import java.net.URLDecoder
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.getValue
+
+/**
+ * Adapted from https://github.com/keiyoushi/extensions-source/tree/main/src/en/kmanga
+ */
+class KMangaHandler(currentClient: OkHttpClient) {
+    private val json by injectLazy<Json>()
+
+    private var userId: Int? = null
+
+    private var reloadUserId = false
+
+    private val baseUrl = "https://kmanga.kodansha.com"
+
+    private val app = Injekt.get<Application>()
+
+    private val executor = ContextCompat.getMainExecutor(app)
+
+    val headers = Headers.Builder()
+        .add("Origin", baseUrl)
+        .add("Referer", "$baseUrl/")
+        .add("X-Kmanga-Platform", "3")
+        .build()
+
+    val client = currentClient
+        .newBuilder()
+        .addInterceptor(ImageInterceptor)
+        .addInterceptor { chain ->
+            val request = chain.request()
+            val response = chain.proceed(request)
+            if (response.code == 400) {
+                response.close()
+                val error = if (request.url.pathSegments.last().contains("viewer")) {
+                    "Log in via WebView and rent or purchase this chapter to read."
+                } else {
+                    reloadUserId = true
+                    "Open WebView and retry"
+                }
+
+                throw IOException(error)
+            }
+            response
+        }
+        .build()
+
+    suspend fun fetchPageList(externalUrl: String): List<Page> {
+        val episodeId = externalUrl.toHttpUrl().pathSegments.last()
+        val url = "$API_URL/web/episode/viewer".toHttpUrl().newBuilder()
+            .addQueryParameter("episode_id", episodeId)
+            .build()
+
+        val result = with(json) { hashedReq(url).parseAs<ViewerApiResponse>() }
+        return result.pageList.mapIndexed { index, page ->
+            Page(index, imageUrl = "$page#${result.scrambleSeed}:${result.titleId}:${result.episodeId}")
+        }
+    }
+
+    private suspend fun hashedReq(url: HttpUrl, body: FormBody? = null): Response {
+        if (reloadUserId || userId == null) setUserId()
+
+        val (birthday, expires) = getBirthdayCookie(url)
+        val params = if (body != null) {
+            (0 until body.size).associate { body.name(it) to body.value(it) }
+        } else {
+            url.queryParameterNames.associateWith {
+                url.queryParameter(it)!!
+            }
+        }
+
+        val hash = generateHash(params, birthday, expires)
+        val newHeaders = headers.newBuilder()
+            .add("x-kmanga-client-id", "0")
+            .add("x-kmanga-is-crawler", "false")
+            .add("X-Kmanga-Hash", hash)
+            .build()
+
+        return if (body != null) {
+            client.newCall(POST(url.toString(), newHeaders, body)).awaitSuccess()
+        } else {
+            client.newCall(GET(url, newHeaders)).awaitSuccess()
+        }
+    }
+
+    private fun getBirthdayCookie(url: HttpUrl): Pair<String, String> {
+        val cookies = client.cookieJar.loadForRequest(url)
+        val birthdayCookie = cookies.firstOrNull { it.name == "birthday" }?.value
+
+        return if (birthdayCookie != null) {
+            try {
+                val decoded = URLDecoder.decode(birthdayCookie, "UTF-8")
+                val cookieData = json.decodeFromString<BirthdayCookie>(decoded)
+                cookieData.value to cookieData.expires.toString()
+            } catch (_: Exception) {
+                // Fallback to default if cookie is malformed
+                "2000-01" to (System.currentTimeMillis() / 1000 + 315360000).toString()
+            }
+        } else {
+            // Default for logged-out users or users without the cookie to bypass age restrictions
+            "2000-01" to (System.currentTimeMillis() / 1000 + 315360000).toString()
+        }
+    }
+
+    // https://kmanga.kodansha.com/_nuxt/vl9so/entry-CSwIbMdW.js
+    private fun generateHash(params: Map<String, String>, birthday: String, expires: String): String {
+        val paramStrings = params.toSortedMap().map { (key, value) ->
+            getHashedParam(key, value)
+        }
+
+        val joinedParams = paramStrings.joinToString(",")
+        val hash1 = joinedParams.encodeUtf8().sha256().hex()
+        val cookieHash = getHashedParam(birthday, expires)
+        val finalString = "$hash1$cookieHash"
+        return finalString.encodeUtf8().sha512().hex()
+    }
+
+    private fun getHashedParam(key: String, value: String): String {
+        val keyHash = key.encodeUtf8().sha256().hex()
+        val valueHash = value.encodeUtf8().sha512().hex()
+        return "${keyHash}_$valueHash"
+    }
+
+    private fun setUserId() {
+        reloadUserId = false
+        val latch = CountDownLatch(1)
+        var webView: WebView? = null
+        var accountStr: String? = null
+
+        executor.execute {
+            val view = WebView(app)
+            webView = view
+
+            @SuppressLint("SetJavaScriptEnabled")
+            view.settings.apply {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                blockNetworkImage = false
+                useWideViewPort = false
+                loadWithOverviewMode = false
+            }
+
+            view.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    view?.evaluateJavascript("localStorage.getItem('account')") {
+                        accountStr = json.decodeFromString<String?>(it)
+                        latch.countDown()
+                    }
+                }
+            }
+
+            view.loadDataWithBaseURL(baseUrl, "", "text/html", "UTF-8", null)
+        }
+
+        latch.await(10, TimeUnit.SECONDS)
+
+        executor.execute { webView?.destroy() }
+
+        val account: LocalStorageAccount? = accountStr?.let(json::decodeFromString)
+
+        userId = if (account?.isLoggedIn == true) {
+            account.checkedTicketExpiredList?.firstOrNull()?.userId ?: 0
+        } else {
+            0
+        }
+    }
+
+    companion object {
+        private const val API_URL = "https://api.kmanga.kodansha.com"
+    }
+}
+
+private object ImageInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+        val fragment = request.url.fragment
+
+        if (!response.isSuccessful || fragment.isNullOrEmpty() || !fragment.contains(":")) {
+            return response
+        }
+
+        val (seed, titleId, episodeId) = fragment.split(":")
+        val bitmap = BitmapFactory.decodeStream(response.body.byteStream())
+        val result = unscramble(bitmap, seed, titleId.toInt(), episodeId.toInt())
+
+        bitmap.recycle()
+        val buffer = Buffer()
+        result.compress(Bitmap.CompressFormat.JPEG, 90, buffer.outputStream())
+        result.recycle()
+        val body = buffer.asResponseBody(MEDIA_TYPE, buffer.size)
+
+        return response.newBuilder()
+            .body(body)
+            .build()
+    }
+
+    private class Coord(val x: Int, val y: Int)
+    private class CoordPair(val source: Coord, val dest: Coord)
+
+    private fun UInt.xorshift32(): UInt {
+        var n = this
+        n = n xor (n shl 13)
+        n = n xor (n shr 17)
+        n = n xor (n shl 5)
+        return n
+    }
+
+    private fun getUnscrambledCoords(seed: String, titleId: Int, episodeId: Int): List<CoordPair> {
+        // WASM decrypts two 10-byte arrays to use as substitution charsets.
+        // Selects the charset based on titleId % 2
+        val charset = if (titleId % 2 == 0) CHARSET_EVEN else CHARSET_ODD
+
+        var parsedInt = 0UL
+
+        // Maps the string into a base-10 number using the selected charset
+        for (char in seed) {
+            val index = charset.indexOf(char)
+            if (index != -1) {
+                parsedInt = parsedInt * 10UL + index.toULong()
+            } else {
+                break
+            }
+        }
+
+        // The final 32-bit seed is xor'd against the sum of titleId and episodeId
+        var seed32 = parsedInt.toUInt() xor (titleId.toUInt() + episodeId.toUInt())
+
+        val pairs = mutableListOf<Pair<UInt, Int>>()
+
+        for (i in 0 until 16) {
+            seed32 = seed32.xorshift32()
+            pairs.add(seed32 to i)
+        }
+
+        pairs.sortBy { it.first }
+
+        return pairs.mapIndexed { destIndex, (_, sourceIndex) ->
+            CoordPair(
+                source = Coord(x = sourceIndex % GRID_SIZE, y = sourceIndex / GRID_SIZE),
+                dest = Coord(x = destIndex % GRID_SIZE, y = destIndex / GRID_SIZE),
+            )
+        }
+    }
+
+    private fun unscramble(image: Bitmap, seed: String, titleId: Int, episodeId: Int): Bitmap {
+        val unscrambledCoords = getUnscrambledCoords(seed, titleId, episodeId)
+        val width = image.width
+        val height = image.height
+        val result = createBitmap(width, height)
+        val canvas = Canvas(result)
+
+        val blockWidth = (width / 8 * 8) / 4
+        val blockHeight = (height / 8 * 8) / 4
+        val srcRect = Rect()
+        val dstRect = Rect()
+
+        unscrambledCoords.forEach {
+            val srcX = it.source.x * blockWidth
+            val srcY = it.source.y * blockHeight
+            val dstX = it.dest.x * blockWidth
+            val dstY = it.dest.y * blockHeight
+
+            srcRect.set(srcX, srcY, srcX + blockWidth, srcY + blockHeight)
+            dstRect.set(dstX, dstY, dstX + blockWidth, dstY + blockHeight)
+
+            canvas.drawBitmap(image, srcRect, dstRect, null)
+        }
+
+        val processedWidth = blockWidth * GRID_SIZE
+        val processedHeight = blockHeight * GRID_SIZE
+
+        if (width > processedWidth) {
+            srcRect.set(processedWidth, 0, width, height)
+            canvas.drawBitmap(image, srcRect, srcRect, null)
+        }
+        if (height > processedHeight) {
+            srcRect.set(0, processedHeight, processedWidth, height)
+            canvas.drawBitmap(image, srcRect, srcRect, null)
+        }
+
+        return result
+    }
+
+    private val MEDIA_TYPE = "image/jpeg".toMediaType()
+    private const val GRID_SIZE = 4
+    private const val CHARSET_EVEN = "we7ru3ty8i"
+    private const val CHARSET_ODD = "h4xm9bqz1p"
+}

--- a/app/src/main/java/exh/md/handlers/MangaHotHandler.kt
+++ b/app/src/main/java/exh/md/handlers/MangaHotHandler.kt
@@ -2,16 +2,18 @@ package exh.md.handlers
 
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.parseAs
 import eu.kanade.tachiyomi.source.model.Page
+import exh.md.dto.MangaHotPageList
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Response
+import uy.kohesive.injekt.injectLazy
+import kotlin.getValue
 
 class MangaHotHandler(currentClient: OkHttpClient, userAgent: String) {
+    private val json by injectLazy<Json>()
     val baseUrl = "https://mangahot.jp"
     private val apiUrl = "https://api.mangahot.jp"
     val headers = Headers.Builder()
@@ -32,11 +34,9 @@ class MangaHotHandler(currentClient: OkHttpClient, userAgent: String) {
     }
 
     fun pageListParse(response: Response): List<Page> {
-        return Json.parseToJsonElement(response.body.string())
-            .jsonObject["content"]!!.jsonObject["contentUrls"]!!
-            .jsonArray.mapIndexed { index, element ->
-                val url = element.jsonPrimitive.content
-                Page(index, url, url)
-            }
+        return with(json) { response.parseAs<MangaHotPageList>() }
+            .content
+            .contentUrls
+            .mapIndexed { index, url -> Page(index, url, url) }
     }
 }

--- a/app/src/main/java/exh/md/handlers/MangaPlusHandler.kt
+++ b/app/src/main/java/exh/md/handlers/MangaPlusHandler.kt
@@ -4,17 +4,9 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.source.model.Page
-import exh.md.dto.LANGUAGE_ENGLISH
-import exh.md.dto.LANGUAGE_FRENCH
-import exh.md.dto.LANGUAGE_GERMAN
-import exh.md.dto.LANGUAGE_INDONESIAN
-import exh.md.dto.LANGUAGE_PORTUGUESE_BR
-import exh.md.dto.LANGUAGE_RUSSIAN
-import exh.md.dto.LANGUAGE_SPANISH
-import exh.md.dto.LANGUAGE_THAI
-import exh.md.dto.LANGUAGE_VIETNAMESE
 import exh.md.dto.MangaPlusPage
 import exh.md.dto.MangaPlusResponse
+import exh.md.dto.toMangaPlusLanguage
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.protobuf.ProtoBuf
 import okhttp3.Headers
@@ -61,18 +53,7 @@ class MangaPlusHandler(currentClient: OkHttpClient) {
                     "super_high"
                 },
             )
-            .addQueryParameter("clang", when (lang) {
-                "en" -> "eng"
-                "es" -> "esp"
-                "fr" -> "fra"
-                "id" -> "ind"
-                "pt-BR" -> "ptb"
-                "ru" -> "rus"
-                "th" -> "tha"
-                "de" -> "deu"
-                "vi" -> "vie"
-                else -> throw IllegalStateException("Unsupported lang: $lang")
-            })
+            .addQueryParameter("clang", lang.toMangaPlusLanguage().clang)
             .toString()
 
         return GET(url, newHeaders)
@@ -82,21 +63,10 @@ class MangaPlusHandler(currentClient: OkHttpClient) {
         val result = ProtoBuf.decodeFromByteArray<MangaPlusResponse>(response.body.bytes())
 
         if (result.success == null) {
-            throw Exception(result.error?.langPopup(when (lang) {
-                "en" -> LANGUAGE_ENGLISH
-                "es" -> LANGUAGE_SPANISH
-                "fr" -> LANGUAGE_FRENCH
-                "id" -> LANGUAGE_INDONESIAN
-                "pt-BR" -> LANGUAGE_PORTUGUESE_BR
-                "ru" -> LANGUAGE_RUSSIAN
-                "th" -> LANGUAGE_THAI
-                "de" -> LANGUAGE_GERMAN
-                "vi" -> LANGUAGE_VIETNAMESE
-                else -> throw IllegalStateException("Unsupported lang: $lang")
-            })?.body ?: "error getting images")
+            throw Exception(result.error?.langPopup(lang.toMangaPlusLanguage())?.body ?: "error getting images")
         }
 
-        val viewer = result.success.mangaViewer!!
+        val viewer = result.success.mangaViewer ?: throw Exception("mangaViewer missing from page list response")
 
         return viewer.pages
             .mapNotNull(MangaPlusPage::mangaPage)

--- a/app/src/main/java/exh/md/handlers/MangaPlusHandler.kt
+++ b/app/src/main/java/exh/md/handlers/MangaPlusHandler.kt
@@ -4,9 +4,19 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.interceptor.rateLimitHost
 import eu.kanade.tachiyomi.source.model.Page
+import exh.md.dto.LANGUAGE_ENGLISH
+import exh.md.dto.LANGUAGE_FRENCH
+import exh.md.dto.LANGUAGE_GERMAN
+import exh.md.dto.LANGUAGE_INDONESIAN
+import exh.md.dto.LANGUAGE_PORTUGUESE_BR
+import exh.md.dto.LANGUAGE_RUSSIAN
+import exh.md.dto.LANGUAGE_SPANISH
+import exh.md.dto.LANGUAGE_THAI
+import exh.md.dto.LANGUAGE_VIETNAMESE
 import exh.md.dto.MangaPlusPage
 import exh.md.dto.MangaPlusResponse
-import kotlinx.serialization.json.Json
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
@@ -15,12 +25,9 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
-import uy.kohesive.injekt.injectLazy
 import java.util.UUID
 
 class MangaPlusHandler(currentClient: OkHttpClient) {
-    val json: Json by injectLazy()
-
     val headers = Headers.Builder()
         .add("Origin", WEB_URL)
         .add("Referer", WEB_URL)
@@ -33,17 +40,17 @@ class MangaPlusHandler(currentClient: OkHttpClient) {
         .rateLimitHost(WEB_URL.toHttpUrl(), 2)
         .build()
 
-    suspend fun fetchPageList(chapterId: String, dataSaver: Boolean): List<Page> {
-        val response = client.newCall(pageListRequest(chapterId.substringAfterLast("/"), dataSaver)).awaitSuccess()
-        return pageListParse(response)
+    suspend fun fetchPageList(chapterId: String, dataSaver: Boolean, lang: String): List<Page> {
+        val response = client.newCall(pageListRequest(chapterId.substringAfterLast("/"), dataSaver, lang)).awaitSuccess()
+        return pageListParse(response, lang)
     }
 
-    private fun pageListRequest(chapterId: String, dataSaver: Boolean): Request {
+    private fun pageListRequest(chapterId: String, dataSaver: Boolean, lang: String): Request {
         val newHeaders = headers.newBuilder()
             .set("Referer", "$WEB_URL/viewer/$chapterId")
             .build()
 
-        val url = "$API_URL/manga_viewer".toHttpUrl().newBuilder()
+        val url = "$API_URL/manga_viewer_v3".toHttpUrl().newBuilder()
             .addQueryParameter("chapter_id", chapterId)
             .addQueryParameter("split", "yes")
             .addQueryParameter(
@@ -54,26 +61,48 @@ class MangaPlusHandler(currentClient: OkHttpClient) {
                     "super_high"
                 },
             )
-            .addQueryParameter("format", "json")
+            .addQueryParameter("clang", when (lang) {
+                "en" -> "eng"
+                "es" -> "esp"
+                "fr" -> "fra"
+                "id" -> "ind"
+                "pt-BR" -> "ptb"
+                "ru" -> "rus"
+                "th" -> "tha"
+                "de" -> "deu"
+                "vi" -> "vie"
+                else -> throw IllegalStateException("Unsupported lang: $lang")
+            })
             .toString()
 
         return GET(url, newHeaders)
     }
 
-    private fun pageListParse(response: Response): List<Page> {
-        val result = json.decodeFromString<MangaPlusResponse>(response.body.string())
+    private fun pageListParse(response: Response, lang: String): List<Page> {
+        val result = ProtoBuf.decodeFromByteArray<MangaPlusResponse>(response.body.bytes())
 
         if (result.success == null) {
-            throw Exception("error getting images")
+            throw Exception(result.error?.langPopup(when (lang) {
+                "en" -> LANGUAGE_ENGLISH
+                "es" -> LANGUAGE_SPANISH
+                "fr" -> LANGUAGE_FRENCH
+                "id" -> LANGUAGE_INDONESIAN
+                "pt-BR" -> LANGUAGE_PORTUGUESE_BR
+                "ru" -> LANGUAGE_RUSSIAN
+                "th" -> LANGUAGE_THAI
+                "de" -> LANGUAGE_GERMAN
+                "vi" -> LANGUAGE_VIETNAMESE
+                else -> throw IllegalStateException("Unsupported lang: $lang")
+            })?.body ?: "error getting images")
         }
 
-        val referer = response.request.header("Referer")!!
+        val viewer = result.success.mangaViewer!!
 
-        return result.success.mangaViewer!!.pages
+        return viewer.pages
             .mapNotNull(MangaPlusPage::mangaPage)
             .mapIndexed { i, page ->
                 val encryptionKey = if (page.encryptionKey == null) "" else "#${page.encryptionKey}"
-                Page(i, referer, page.imageUrl + encryptionKey)
+                Page(i, viewer.viewToken.orEmpty(), page.imageUrl + encryptionKey)
             }
     }
 

--- a/app/src/main/java/exh/md/handlers/MangaPlusHandler.kt
+++ b/app/src/main/java/exh/md/handlers/MangaPlusHandler.kt
@@ -60,7 +60,7 @@ class MangaPlusHandler(currentClient: OkHttpClient) {
     }
 
     private fun pageListParse(response: Response, lang: String): List<Page> {
-        val result = ProtoBuf.decodeFromByteArray<MangaPlusResponse>(response.body.bytes())
+        val result = response.use { ProtoBuf.decodeFromByteArray<MangaPlusResponse>(it.body.bytes()) }
 
         if (result.success == null) {
             throw Exception(result.error?.langPopup(lang.toMangaPlusLanguage())?.body ?: "error getting images")

--- a/app/src/main/java/exh/md/handlers/MangaUpHandler.kt
+++ b/app/src/main/java/exh/md/handlers/MangaUpHandler.kt
@@ -1,0 +1,258 @@
+package exh.md.handlers
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.core.content.ContextCompat
+import eu.kanade.tachiyomi.network.POST
+import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.source.model.Page
+import exh.md.dto.MangaUpViewerResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okio.buffer
+import okio.cipherSource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Adapted from https://github.com/keiyoushi/extensions-source/tree/main/src/all/mangaup
+ */
+class MangaUpHandler(currentClient: OkHttpClient) {
+    private val domain = "manga-up.com"
+    private val apiUrl = "https://global-api.$domain/api"
+    private val imgUrl = "https://global-img.$domain"
+
+    private val app = Injekt.get<Application>()
+
+    private val executor = ContextCompat.getMainExecutor(app)
+
+    private var secret: String? = null
+    private val secretMutex = Mutex()
+
+    val baseUrl = "https://global.$domain"
+
+    val headers = Headers.Builder()
+        .add("Origin", baseUrl)
+        .add("Referer", "$baseUrl/")
+        .build()
+
+    val client = currentClient.newBuilder()
+        .addInterceptor(MangaUpImageInterceptor)
+        .addInterceptor { chain ->
+            val request = chain.request()
+            val response = chain.proceed(request)
+
+            // 410: expired secret -> device got removed OR more than 3 secrets/devices active, oldest one expires
+            // 401: invalid secret -> login was aborted; UA mismatch from previous login
+            if (response.code == 410 || response.code == 401) {
+                response.close()
+
+                val failedSecret = request.url.queryParameter("secret")
+
+                if (failedSecret != null) {
+                    flushSecret(failedSecret)
+
+                    runBlocking {
+                        secretMutex.withLock {
+                            if (secret == failedSecret) {
+                                secret = null
+                            }
+                        }
+                    }
+                }
+
+                val newSecret = runBlocking { fetchSecret() }
+                val isMyPage = request.url.pathSegments.lastOrNull() == "my_page"
+                val isSecretValid = !newSecret.isNullOrEmpty() && newSecret != failedSecret
+
+                if (!isSecretValid && isMyPage) {
+                    val target = request.url.fragment
+                    throw IOException("Log in via WebView to access your $target")
+                }
+
+                val newUrl = request.url.newBuilder()
+
+                if (isSecretValid) {
+                    newUrl.setQueryParameter("secret", newSecret)
+                } else {
+                    newUrl.removeAllQueryParameters("secret")
+
+                    runBlocking {
+                        secretMutex.withLock {
+                            if (secret == newSecret) {
+                                secret = null
+                            }
+                        }
+                    }
+                }
+
+                val newRequest = request.newBuilder()
+                    .url(newUrl.build())
+                    .build()
+
+                return@addInterceptor chain.proceed(newRequest)
+            }
+            response
+        }
+        .build()
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private suspend fun fetchSecret(): String? = secretMutex.withLock {
+        if (secret != null) return secret
+
+        val latch = CountDownLatch(1)
+        var token: String? = null
+
+        executor.execute {
+            val webView = WebView(Injekt.get<Application>())
+            with(webView.settings) {
+                javaScriptEnabled = true
+                domStorageEnabled = true
+                databaseEnabled = true
+                blockNetworkImage = true
+            }
+            webView.webViewClient = object : WebViewClient() {
+                override fun onPageFinished(view: WebView, url: String?) {
+                    view.evaluateJavascript("window.localStorage.getItem('secret')") { value ->
+                        token = value?.trim('"')
+                        if (token == "null" || token.isNullOrBlank()) token = null
+
+                        latch.countDown()
+                        view.stopLoading()
+                        view.destroy()
+                    }
+                }
+            }
+            webView.loadDataWithBaseURL("$baseUrl/", " ", "text/html", "utf-8", null)
+        }
+
+        withContext(Dispatchers.IO) { latch.await(10, TimeUnit.SECONDS) }
+
+        secret = token
+        return secret
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun flushSecret(target: String) = executor.execute {
+        val webView = WebView(Injekt.get<Application>())
+        with(webView.settings) {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            databaseEnabled = true
+            blockNetworkImage = true
+        }
+        webView.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView, url: String?) {
+                val script = "if(window.localStorage.getItem('secret')==='$target'){window.localStorage.removeItem('secret');}"
+                view.evaluateJavascript(script) {
+                    view.stopLoading()
+                    view.destroy()
+                }
+            }
+        }
+        webView.loadDataWithBaseURL("$baseUrl/", " ", "text/html", "utf-8", null)
+    }
+
+    suspend fun fetchPageList(externalUrl: String, lang: String): List<Page> {
+        val chapterId = externalUrl.substringAfterLast("/")
+        val url = "$apiUrl/manga/viewer_v2".toHttpUrl().newBuilder()
+            .apply {
+                fetchSecret()?.let { addQueryParameter("secret", it) }
+            }
+            .addQueryParameter("app_ver", "0")
+            .addQueryParameter("os_ver", "0")
+            .addQueryParameter("chapter_id", chapterId)
+            .addQueryParameter("quality", "high")
+            .addQueryParameter("lang", lang)
+            .build()
+            .toString()
+
+        val response = client.newCall(POST(url, headers)).awaitSuccess()
+        val result = response.use { ProtoBuf.decodeFromByteArray<MangaUpViewerResponse>(it.body.bytes()) }
+        val pages = result.pageBlocks.flatMap { it.pages }
+            .filter { !it.url.contains("tutorial") }
+
+        if (pages.isEmpty()) {
+            throw Exception("Log in via WebView and purchase this chapter")
+        }
+
+        return pages.mapIndexed { i, page ->
+            val img = imgUrl + page.url + "#key=${page.key}#iv=${page.iv}"
+            Page(i, imageUrl = img)
+        }
+    }
+}
+
+private object MangaUpImageInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val url = request.url
+        val fragment = url.fragment
+
+        if (fragment.isNullOrEmpty()) {
+            return chain.proceed(request)
+        }
+
+        val parts = fragment.split("#")
+        val key = parts.getOrNull(0)?.removePrefix("key=")
+        val iv = parts.getOrNull(1)?.removePrefix("iv=")
+
+        if (key.isNullOrEmpty() || iv.isNullOrEmpty()) {
+            return chain.proceed(request)
+        }
+
+        val response = chain.proceed(request)
+
+        if (!response.isSuccessful) return response
+
+        val secretKey = SecretKeySpec(key.decodeHex(), "AES")
+        val ivSpec = IvParameterSpec(iv.decodeHex())
+        val cipher = Cipher.getInstance("AES/CBC/PKCS5Padding")
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, ivSpec)
+        val body = response.body.source().cipherSource(cipher).buffer().asResponseBody(response.body.contentType())
+
+        return response.newBuilder()
+            .body(body)
+            .build()
+    }
+
+    private fun String.decodeHex(): ByteArray {
+        require(length % 2 == 0) { "Unexpected hex string: $this" }
+
+        val result = ByteArray(length / 2)
+        for (i in result.indices) {
+            val d1 = decodeHexDigit(this[i * 2]) shl 4
+            val d2 = decodeHexDigit(this[i * 2 + 1])
+            result[i] = (d1 + d2).toByte()
+        }
+        return result
+    }
+
+    private fun decodeHexDigit(c: Char): Int {
+        return when (c) {
+            in '0'..'9' -> c - '0'
+            in 'a'..'f' -> c - 'a' + 10
+            in 'A'..'F' -> c - 'A' + 10
+            else -> throw IllegalArgumentException("Unexpected hex digit: $c")
+        }
+    }
+}

--- a/app/src/main/java/exh/md/handlers/MangaUpHandler.kt
+++ b/app/src/main/java/exh/md/handlers/MangaUpHandler.kt
@@ -41,11 +41,12 @@ class MangaUpHandler(currentClient: OkHttpClient) {
     private val apiUrl = "https://global-api.$domain/api"
     private val imgUrl = "https://global-img.$domain"
 
-    private val app = Injekt.get<Application>()
+    private val context = Injekt.get<Application>()
 
-    private val executor = ContextCompat.getMainExecutor(app)
+    private val executor = ContextCompat.getMainExecutor(context)
 
     private var secret: String? = null
+
     private val secretMutex = Mutex()
 
     val baseUrl = "https://global.$domain"
@@ -123,13 +124,16 @@ class MangaUpHandler(currentClient: OkHttpClient) {
         var token: String? = null
 
         executor.execute {
-            val webView = WebView(Injekt.get<Application>())
+            val webView = WebView(context)
+
+            @Suppress("DEPRECATION")
             with(webView.settings) {
                 javaScriptEnabled = true
                 domStorageEnabled = true
                 databaseEnabled = true
                 blockNetworkImage = true
             }
+
             webView.webViewClient = object : WebViewClient() {
                 override fun onPageFinished(view: WebView, url: String?) {
                     view.evaluateJavascript("window.localStorage.getItem('secret')") { value ->
@@ -142,6 +146,7 @@ class MangaUpHandler(currentClient: OkHttpClient) {
                     }
                 }
             }
+
             webView.loadDataWithBaseURL("$baseUrl/", " ", "text/html", "utf-8", null)
         }
 
@@ -153,13 +158,16 @@ class MangaUpHandler(currentClient: OkHttpClient) {
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun flushSecret(target: String) = executor.execute {
-        val webView = WebView(Injekt.get<Application>())
+        val webView = WebView(context)
+
+        @Suppress("DEPRECATION")
         with(webView.settings) {
             javaScriptEnabled = true
             domStorageEnabled = true
             databaseEnabled = true
             blockNetworkImage = true
         }
+
         webView.webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView, url: String?) {
                 val script = "if(window.localStorage.getItem('secret')==='$target'){window.localStorage.removeItem('secret');}"
@@ -169,6 +177,7 @@ class MangaUpHandler(currentClient: OkHttpClient) {
                 }
             }
         }
+
         webView.loadDataWithBaseURL("$baseUrl/", " ", "text/html", "utf-8", null)
     }
 

--- a/app/src/main/java/exh/md/handlers/NamicomiHandler.kt
+++ b/app/src/main/java/exh/md/handlers/NamicomiHandler.kt
@@ -3,15 +3,20 @@ package exh.md.handlers
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.source.model.Page
+import exh.md.dto.NamicomiPageListDto
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Response
 
 class NamicomiHandler(currentClient: OkHttpClient, userAgent: String) {
+    private val json by lazy {
+        Json {
+            encodeDefaults = true
+            ignoreUnknownKeys = true
+        }
+    }
+
     private val apiUrl = "https://api.namicomi.com"
 
     private val headers = Headers.Builder()
@@ -31,19 +36,15 @@ class NamicomiHandler(currentClient: OkHttpClient, userAgent: String) {
     }
 
     private fun pageListParse(response: Response, chapterId: String, dataSaver: Boolean): List<Page> {
-        val data = Json.parseToJsonElement(response.body.string()).jsonObject["data"]!!
-        val baseUrl = data.jsonObject["baseUrl"]!!.jsonPrimitive.content
-        val hash = data.jsonObject["hash"]!!.jsonPrimitive.content
+        val data = json.decodeFromString<NamicomiPageListDto>(response.body.string()).data
+            ?: throw Exception("error getting images")
 
         /* Available quality levels: source, high, medium, low */
-        val quality = if (dataSaver) "low" else "high"
+        val prefix = "${data.baseUrl}/chapter/$chapterId/${data.hash}/${if (dataSaver) "low" else "source"}/"
 
-        return data
-            .jsonObject[quality]!!
-            .jsonArray.mapIndexed { index, element ->
-                val fileName = element.jsonObject["filename"]!!.jsonPrimitive.content
-                val url = "$baseUrl/chapter/$chapterId/$hash/$quality/$fileName"
-                Page(index, url, url)
-            }
+        return (if (dataSaver) data.low else data.source).mapIndexed { index, element ->
+            val url = prefix + element.filename
+            Page(index, url, url)
+        }
     }
 }

--- a/app/src/main/java/exh/md/handlers/NamicomiHandler.kt
+++ b/app/src/main/java/exh/md/handlers/NamicomiHandler.kt
@@ -19,7 +19,7 @@ class NamicomiHandler(currentClient: OkHttpClient, userAgent: String) {
 
     private val apiUrl = "https://api.namicomi.com"
 
-    private val headers = Headers.Builder()
+    val headers = Headers.Builder()
         .add("User-Agent", userAgent)
         .build()
 

--- a/app/src/main/java/exh/md/handlers/PageHandler.kt
+++ b/app/src/main/java/exh/md/handlers/PageHandler.kt
@@ -14,6 +14,7 @@ import okhttp3.Call
 import okhttp3.Headers
 import rx.Observable
 import tachiyomi.core.common.util.lang.withIOContext
+import kotlin.collections.set
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.isAccessible
 
@@ -37,6 +38,7 @@ class PageHandler(
                     chapter.scanlator.equals("mangaplus", true) -> mangaPlusHandler.fetchPageList(
                         chapterResponse.data.attributes.externalUrl,
                         dataSaver = dataSaver,
+                        mangadex.lang,
                     )
                     /*chapter.scanlator.equals("comikey", true) -> comikeyHandler.fetchPageList(
                         chapterResponse.data.attributes.externalUrl
@@ -108,8 +110,11 @@ class PageHandler(
     fun getImageCall(page: Page): Call? {
         xLogD(page.imageUrl)
         return when {
-            page.imageUrl?.contains("mangaplus", true) == true -> {
-                mangaPlusHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, headers), page)
+            page.imageUrl?.contains("tokyo-cdn.com", true) == true -> {
+                mangaPlusHandler.client.newCachelessCallWithProgress(GET(
+                    page.imageUrl!!,
+                    mangaPlusHandler.headers.newBuilder().add("Plus-Vw-Token", page.url).build(),
+                ), page)
             }
             page.imageUrl?.contains("comikey", true) == true -> {
                 comikeyHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, comikeyHandler.headers), page)

--- a/app/src/main/java/exh/md/handlers/PageHandler.kt
+++ b/app/src/main/java/exh/md/handlers/PageHandler.kt
@@ -113,7 +113,11 @@ class PageHandler(
             page.imageUrl?.contains("tokyo-cdn.com", true) == true -> {
                 mangaPlusHandler.client.newCachelessCallWithProgress(GET(
                     page.imageUrl!!,
-                    mangaPlusHandler.headers.newBuilder().add("Plus-Vw-Token", page.url).build(),
+                    if (page.url.isEmpty()) {
+                        mangaPlusHandler.headers
+                    } else {
+                        mangaPlusHandler.headers.newBuilder().add("Plus-Vw-Token", page.url).build()
+                    },
                 ), page)
             }
             page.imageUrl?.contains("comikey", true) == true -> {

--- a/app/src/main/java/exh/md/handlers/PageHandler.kt
+++ b/app/src/main/java/exh/md/handlers/PageHandler.kt
@@ -31,6 +31,7 @@ class PageHandler(
     private val mangaHotHandler: MangaHotHandler,
     private val namicomiHandler: NamicomiHandler,
     private val kMangaHandler: KMangaHandler,
+    private val mangaUpHandler: MangaUpHandler,
 ) {
 
     suspend fun fetchPageList(chapter: SChapter, usePort443Only: Boolean, dataSaver: Boolean): List<Page> {
@@ -63,6 +64,10 @@ class PageHandler(
                     )
                     chapter.scanlator.equals("K Manga", true) -> kMangaHandler.fetchPageList(
                         chapterResponse.data.attributes.externalUrl,
+                    )
+                    chapter.scanlator.equals("Manga UP!", true) -> mangaUpHandler.fetchPageList(
+                        chapterResponse.data.attributes.externalUrl,
+                        mangadex.lang,
                     )
                     else -> throw Exception("${chapter.scanlator} not supported")
                 }
@@ -152,6 +157,9 @@ class PageHandler(
             }
             page.imageUrl?.contains("kmanga", true) == true -> {
                 kMangaHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, kMangaHandler.headers), page)
+            }
+            page.imageUrl?.contains("manga-up", true) == true -> {
+                mangaUpHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, mangaUpHandler.headers), page)
             }
             else -> null
         }

--- a/app/src/main/java/exh/md/handlers/PageHandler.kt
+++ b/app/src/main/java/exh/md/handlers/PageHandler.kt
@@ -15,10 +15,13 @@ import okhttp3.Headers
 import rx.Observable
 import tachiyomi.core.common.util.lang.withIOContext
 import kotlin.collections.set
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.superclasses
 import kotlin.reflect.jvm.isAccessible
 
 class PageHandler(
+    private val mangadex: Source,
     private val headers: Headers,
     private val service: MangaDexService,
     private val mangaPlusHandler: MangaPlusHandler,
@@ -27,9 +30,10 @@ class PageHandler(
     private val azukiHandler: AzukiHandler,
     private val mangaHotHandler: MangaHotHandler,
     private val namicomiHandler: NamicomiHandler,
+    private val kMangaHandler: KMangaHandler,
 ) {
 
-    suspend fun fetchPageList(chapter: SChapter, usePort443Only: Boolean, dataSaver: Boolean, mangadex: Source): List<Page> {
+    suspend fun fetchPageList(chapter: SChapter, usePort443Only: Boolean, dataSaver: Boolean): List<Page> {
         return withIOContext {
             val chapterResponse = service.viewChapter(MdUtil.getChapterId(chapter.url))
 
@@ -57,6 +61,9 @@ class PageHandler(
                         chapterResponse.data.attributes.externalUrl,
                         dataSaver = dataSaver,
                     )
+                    chapter.scanlator.equals("K Manga", true) -> kMangaHandler.fetchPageList(
+                        chapterResponse.data.attributes.externalUrl,
+                    )
                     else -> throw Exception("${chapter.scanlator} not supported")
                 }
             } else {
@@ -66,7 +73,7 @@ class PageHandler(
                     "${MdApi.atHomeServer}/${MdUtil.getChapterId(chapter.url)}"
                 }
 
-                updateExtensionVariable(mangadex, atHomeRequestUrl)
+                updateExtensionVariable(atHomeRequestUrl)
 
                 val atHomeResponse = service.getAtHomeServer(atHomeRequestUrl, headers)
 
@@ -76,17 +83,22 @@ class PageHandler(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private fun updateExtensionVariable(mangadex: Source, atHomeRequestUrl: String) {
-        val mangadexSuperclass = mangadex::class.superclasses.first()
+    private val tokenTracker: HashMap<String, Long>? by lazy {
+        // The helper property now appears in the current class
+        val helperProperty = mangadex::class.declaredMemberProperties.find { it.name == "helper" }
+            ?: mangadex::class.superclasses.first().declaredMemberProperties.find { it.name == "helper" }
+            ?: return@lazy null
+        helperProperty.isAccessible = true
+        val helper = helperProperty.call(mangadex) ?: return@lazy null
 
-        val helperCallable = mangadexSuperclass.members.find { it.name == "helper" } ?: return
-        helperCallable.isAccessible = true
-        val helper = helperCallable.call(mangadex) ?: return
+        val tokenTrackerProperty = helper::class.declaredMemberProperties.find { it.name == "tokenTracker" }
+            ?: return@lazy null
+        tokenTrackerProperty.isAccessible = true
+        tokenTrackerProperty.call(helper) as? HashMap<String, Long>
+    }
 
-        val tokenTrackerCallable = helper::class.members.find { it.name == "tokenTracker" } ?: return
-        tokenTrackerCallable.isAccessible = true
-        val tokenTracker = tokenTrackerCallable.call(helper) as? HashMap<String, Long> ?: return
-        tokenTracker[atHomeRequestUrl] = System.currentTimeMillis()
+    private fun updateExtensionVariable(atHomeRequestUrl: String) {
+        tokenTracker?.set(atHomeRequestUrl, System.currentTimeMillis())
     }
 
     private fun pageListParse(
@@ -111,14 +123,17 @@ class PageHandler(
         xLogD(page.imageUrl)
         return when {
             page.imageUrl?.contains("tokyo-cdn.com", true) == true -> {
-                mangaPlusHandler.client.newCachelessCallWithProgress(GET(
-                    page.imageUrl!!,
-                    if (page.url.isEmpty()) {
-                        mangaPlusHandler.headers
-                    } else {
-                        mangaPlusHandler.headers.newBuilder().add("Plus-Vw-Token", page.url).build()
-                    },
-                ), page)
+                mangaPlusHandler.client.newCachelessCallWithProgress(
+                    GET(
+                        page.imageUrl!!,
+                        if (page.url.isEmpty()) {
+                            mangaPlusHandler.headers
+                        } else {
+                            mangaPlusHandler.headers.newBuilder().add("Plus-Vw-Token", page.url).build()
+                        },
+                    ),
+                    page,
+                )
             }
             page.imageUrl?.contains("comikey", true) == true -> {
                 comikeyHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, comikeyHandler.headers), page)
@@ -133,7 +148,10 @@ class PageHandler(
                 mangaHotHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, mangaHotHandler.headers), page)
             }
             page.imageUrl?.contains("namicomi", true) == true -> {
-                mangaHotHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, mangaHotHandler.headers), page)
+                namicomiHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, namicomiHandler.headers), page)
+            }
+            page.imageUrl?.contains("kmanga", true) == true -> {
+                kMangaHandler.client.newCachelessCallWithProgress(GET(page.imageUrl!!, kMangaHandler.headers), page)
             }
             else -> null
         }


### PR DESCRIPTION
Fix page handlers for Omoi (formerly Azuki), MANGA Plus, and NamiComi.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Update MangaDex page handlers to restore external reader support and add K Manga and Manga UP! integration.

New Features:
- Add page handling support for K Manga and Manga UP! chapters.

Bug Fixes:
- Fix page retrieval for Omoi, MANGA Plus, and NamiComi, including updated response formats and image delivery requirements.

Enhancements:
- Improve MangaDex page routing and image request handling across external chapter providers.