### PR TITLE
feat(app): add chapter tags and filtering

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -167,7 +167,9 @@ class DomainModule : InjektModule {
         addFactory { UpdateChapter(get()) }
         addFactory { SetReadStatus(get(), get(), get(), get(), get()) }
         addFactory { ShouldUpdateDbChapter() }
-        addFactory { SyncChaptersWithSource(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
+        addFactory {
+            SyncChaptersWithSource(get(), get(), get(), get(), get(), get(), get(), get(), get(), /* KMK --> */ get() /* KMK <-- */)
+        }
         addFactory { GetAvailableScanlators(get()) }
         addFactory { FilterChaptersForDownload(get(), get(), get(), get()) }
 

--- a/app/src/main/java/eu/kanade/domain/KMKDomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/KMKDomainModule.kt
@@ -1,8 +1,18 @@
 package eu.kanade.domain
 
+import tachiyomi.data.chapterTag.ChapterTagRepositoryImpl
 import tachiyomi.data.libraryUpdateError.LibraryUpdateErrorRepositoryImpl
 import tachiyomi.data.libraryUpdateError.LibraryUpdateErrorWithRelationsRepositoryImpl
 import tachiyomi.data.libraryUpdateErrorMessage.LibraryUpdateErrorMessageRepositoryImpl
+import tachiyomi.domain.chapterTag.interactor.CreateChapterTagWithName
+import tachiyomi.domain.chapterTag.interactor.DeleteChapterTag
+import tachiyomi.domain.chapterTag.interactor.GetChapterTagFilter
+import tachiyomi.domain.chapterTag.interactor.GetChapterTags
+import tachiyomi.domain.chapterTag.interactor.GetChapterTagsPerManga
+import tachiyomi.domain.chapterTag.interactor.RenameChapterTag
+import tachiyomi.domain.chapterTag.interactor.SetChapterTagFilter
+import tachiyomi.domain.chapterTag.interactor.SetChapterTags
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
 import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors
 import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrorWithRelations
 import tachiyomi.domain.libraryUpdateError.interactor.GetLibraryUpdateErrors
@@ -36,5 +46,15 @@ class KMKDomainModule : InjektModule {
         addFactory { GetLibraryUpdateErrors(get()) }
         addFactory { DeleteLibraryUpdateErrors(get()) }
         addFactory { InsertLibraryUpdateErrors(get()) }
+
+        addSingletonFactory<ChapterTagRepository> { ChapterTagRepositoryImpl(get()) }
+        addFactory { GetChapterTags(get()) }
+        addFactory { GetChapterTagsPerManga(get()) }
+        addFactory { CreateChapterTagWithName(get()) }
+        addFactory { RenameChapterTag(get()) }
+        addFactory { DeleteChapterTag(get(), get()) }
+        addFactory { SetChapterTags(get()) }
+        addFactory { GetChapterTagFilter(get()) }
+        addFactory { SetChapterTagFilter(get()) }
     }
 }

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -20,6 +20,7 @@ import tachiyomi.domain.chapter.model.NoChaptersException
 import tachiyomi.domain.chapter.model.toChapterUpdate
 import tachiyomi.domain.chapter.repository.ChapterRepository
 import tachiyomi.domain.chapter.service.ChapterRecognition
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.source.local.isLocal
@@ -37,6 +38,9 @@ class SyncChaptersWithSource(
     private val getChaptersByMangaId: GetChaptersByMangaId,
     private val getExcludedScanlators: GetExcludedScanlators,
     private val libraryPreferences: LibraryPreferences,
+    // KMK -->
+    private val chapterTagRepository: ChapterTagRepository,
+    // KMK <--
 ) {
 
     /**
@@ -178,6 +182,20 @@ class SyncChaptersWithSource(
             deletedChapterNumbers.add(chapter.chapterNumber)
         }
 
+        // KMK -->
+        val deletedChapterTagIds: Map<Double, List<Long>> = if (removedChapters.isEmpty()) {
+            emptyMap()
+        } else {
+            val tagIdsByChapterId = chapterTagRepository.getTagIdsByChapterIds(removedChapters.map { it.id })
+            removedChapters
+                .filter { it.isRecognizedNumber }
+                .mapNotNull { chapter ->
+                    tagIdsByChapterId[chapter.id]?.takeIf { it.isNotEmpty() }?.let { chapter.chapterNumber to it }
+                }
+                .toMap()
+        }
+        // KMK <--
+
         val deletedChapterNumberDateFetchMap = removedChapters.sortedByDescending { it.dateFetch }
             .associate { it.chapterNumber to it.dateFetch }
 
@@ -238,6 +256,17 @@ class SyncChaptersWithSource(
         if (updatedToAdd.isNotEmpty()) {
             updatedToAdd = chapterRepository.addAll(updatedToAdd)
         }
+
+        // KMK -->
+        if (deletedChapterTagIds.isNotEmpty()) {
+            updatedToAdd.forEach { chapter ->
+                if (!chapter.isRecognizedNumber) return@forEach
+                deletedChapterTagIds[chapter.chapterNumber]?.let { tagIds ->
+                    chapterTagRepository.setChapterTags(chapter.id, tagIds)
+                }
+            }
+        }
+        // KMK <--
 
         if (updatedChapters.isNotEmpty()) {
             val chapterUpdates = updatedChapters.map { it.toChapterUpdate() }

--- a/app/src/main/java/eu/kanade/presentation/chapterTag/ChapterTagsScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/chapterTag/ChapterTagsScreen.kt
@@ -1,0 +1,79 @@
+package eu.kanade.presentation.chapterTag
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import eu.kanade.presentation.category.components.CategoryFloatingActionButton
+import eu.kanade.presentation.chapterTag.components.ChapterTagListItem
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.tachiyomi.ui.chapterTag.ChapterTagsScreenState
+import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.components.material.topSmallPaddingValues
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.EmptyScreen
+import tachiyomi.presentation.core.util.plus
+
+@Composable
+fun ChapterTagsScreen(
+    state: ChapterTagsScreenState.Success,
+    onClickCreate: () -> Unit,
+    onClickRename: (ChapterTag) -> Unit,
+    onClickDelete: (ChapterTag) -> Unit,
+    navigateUp: () -> Unit,
+) {
+    val lazyListState = rememberLazyListState()
+    Scaffold(
+        topBar = { scrollBehavior ->
+            AppBar(
+                title = stringResource(KMR.strings.chapter_tags),
+                navigateUp = navigateUp,
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        floatingActionButton = {
+            CategoryFloatingActionButton(
+                lazyListState = lazyListState,
+                onCreate = onClickCreate,
+            )
+        },
+    ) { paddingValues ->
+        if (state.isEmpty) {
+            EmptyScreen(
+                stringRes = KMR.strings.information_empty_chapter_tags,
+                modifier = Modifier.padding(paddingValues),
+            )
+            return@Scaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = lazyListState,
+            contentPadding = paddingValues +
+                topSmallPaddingValues +
+                PaddingValues(horizontal = MaterialTheme.padding.medium),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+        ) {
+            items(
+                items = state.chapterTags,
+                key = { chapterTag -> "chapter-tag-${chapterTag.id}" },
+            ) { chapterTag ->
+                ChapterTagListItem(
+                    modifier = Modifier.animateItem(),
+                    chapterTag = chapterTag,
+                    onRename = { onClickRename(chapterTag) },
+                    onDelete = { onClickDelete(chapterTag) },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/chapterTag/components/ChapterTagDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/chapterTag/components/ChapterTagDialogs.kt
@@ -1,0 +1,85 @@
+package eu.kanade.presentation.chapterTag.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.delay
+import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.i18n.stringResource
+import kotlin.time.Duration.Companion.seconds
+
+@Composable
+fun ChapterTagRenameDialog(
+    onDismissRequest: () -> Unit,
+    onRename: (String) -> Unit,
+    chapterTags: ImmutableList<String>,
+    chapterTag: String,
+) {
+    var name by remember { mutableStateOf(chapterTag) }
+    var valueHasChanged by remember { mutableStateOf(false) }
+
+    val focusRequester = remember { FocusRequester() }
+    val nameAlreadyExists = remember(name) { chapterTags.contains(name) }
+
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(
+                enabled = valueHasChanged && !nameAlreadyExists,
+                onClick = {
+                    onRename(name)
+                    onDismissRequest()
+                },
+            ) {
+                Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+        title = {
+            Text(text = stringResource(KMR.strings.action_rename_chapter_tag))
+        },
+        text = {
+            OutlinedTextField(
+                modifier = Modifier.focusRequester(focusRequester),
+                value = name,
+                onValueChange = {
+                    valueHasChanged = name != it
+                    name = it
+                },
+                label = { Text(text = stringResource(MR.strings.name)) },
+                supportingText = {
+                    val msgRes = if (valueHasChanged && nameAlreadyExists) {
+                        KMR.strings.error_chapter_tag_exists
+                    } else {
+                        MR.strings.information_required_plain
+                    }
+                    Text(text = stringResource(msgRes))
+                },
+                isError = valueHasChanged && nameAlreadyExists,
+                singleLine = true,
+            )
+        },
+    )
+
+    LaunchedEffect(focusRequester) {
+        // TODO: https://issuetracker.google.com/issues/204502668
+        delay(0.1.seconds)
+        focusRequester.requestFocus()
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/chapterTag/components/ChapterTagDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/chapterTag/components/ChapterTagDialogs.kt
@@ -45,10 +45,11 @@ fun ChapterTagRenameDialog(
     chapterTag: String,
 ) {
     var name by remember { mutableStateOf(chapterTag) }
-    var valueHasChanged by remember { mutableStateOf(false) }
+    val valueHasChanged = name != chapterTag
 
     val focusRequester = remember { FocusRequester() }
-    val nameAlreadyExists = remember(name) { chapterTags.contains(name) }
+    // The tag being renamed is in the list, so only a *different* tag counts as a conflict.
+    val nameAlreadyExists = remember(name) { name != chapterTag && chapterTags.contains(name) }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -75,27 +76,24 @@ fun ChapterTagRenameDialog(
             OutlinedTextField(
                 modifier = Modifier.focusRequester(focusRequester),
                 value = name,
-                onValueChange = {
-                    valueHasChanged = name != it
-                    name = it
-                },
+                onValueChange = { name = it },
                 label = { Text(text = stringResource(MR.strings.name)) },
                 supportingText = {
-                    val msgRes = if (valueHasChanged && nameAlreadyExists) {
+                    val msgRes = if (nameAlreadyExists) {
                         KMR.strings.error_chapter_tag_exists
                     } else {
                         MR.strings.information_required_plain
                     }
                     Text(text = stringResource(msgRes))
                 },
-                isError = valueHasChanged && nameAlreadyExists,
+                isError = nameAlreadyExists,
                 singleLine = true,
             )
         },
     )
 
     LaunchedEffect(focusRequester) {
-        // TODO: https://issuetracker.google.com/issues/204502668
+        // Workaround for https://issuetracker.google.com/issues/204502668
         delay(0.1.seconds)
         focusRequester.requestFocus()
     }

--- a/app/src/main/java/eu/kanade/presentation/chapterTag/components/ChapterTagDialogs.kt
+++ b/app/src/main/java/eu/kanade/presentation/chapterTag/components/ChapterTagDialogs.kt
@@ -1,22 +1,39 @@
 package eu.kanade.presentation.chapterTag.components
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TriStateCheckbox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import eu.kanade.core.preference.asToggleableState
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
+import tachiyomi.core.common.preference.CheckboxState
+import tachiyomi.domain.chapterTag.model.ChapterTag
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import kotlin.time.Duration.Companion.seconds
 
@@ -82,4 +99,113 @@ fun ChapterTagRenameDialog(
         delay(0.1.seconds)
         focusRequester.requestFocus()
     }
+}
+
+@Composable
+fun ChangeChapterTagsDialog(
+    initialSelection: ImmutableList<CheckboxState<ChapterTag>>,
+    onDismissRequest: () -> Unit,
+    onEditChapterTags: () -> Unit,
+    onConfirm: (List<Long>, List<Long>) -> Unit,
+) {
+    if (initialSelection.isEmpty()) {
+        AlertDialog(
+            onDismissRequest = onDismissRequest,
+            confirmButton = {
+                tachiyomi.presentation.core.components.material.TextButton(
+                    onClick = {
+                        onDismissRequest()
+                        onEditChapterTags()
+                    },
+                ) {
+                    Text(text = stringResource(KMR.strings.chapter_tags))
+                }
+            },
+            title = {
+                Text(text = stringResource(KMR.strings.action_edit_chapter_tags))
+            },
+            text = {
+                Text(text = stringResource(KMR.strings.information_empty_chapter_tags_dialog))
+            },
+        )
+        return
+    }
+    var selection by remember { mutableStateOf(initialSelection) }
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            Row {
+                tachiyomi.presentation.core.components.material.TextButton(onClick = {
+                    onDismissRequest()
+                    onEditChapterTags()
+                }) {
+                    Text(text = stringResource(MR.strings.action_edit))
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                tachiyomi.presentation.core.components.material.TextButton(onClick = onDismissRequest) {
+                    Text(text = stringResource(MR.strings.action_cancel))
+                }
+                tachiyomi.presentation.core.components.material.TextButton(
+                    onClick = {
+                        onDismissRequest()
+                        onConfirm(
+                            selection
+                                .filter { it is CheckboxState.State.Checked || it is CheckboxState.TriState.Include }
+                                .map { it.value.id },
+                            selection
+                                .filter { it is CheckboxState.State.None || it is CheckboxState.TriState.None }
+                                .map { it.value.id },
+                        )
+                    },
+                ) {
+                    Text(text = stringResource(MR.strings.action_ok))
+                }
+            }
+        },
+        title = {
+            Text(text = stringResource(KMR.strings.action_edit_chapter_tags))
+        },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+            ) {
+                selection.forEach { checkbox ->
+                    val onChange: (CheckboxState<ChapterTag>) -> Unit = {
+                        val index = selection.indexOf(it)
+                        if (index != -1) {
+                            val mutableList = selection.toMutableList()
+                            mutableList[index] = it.next()
+                            selection = mutableList.toList().toImmutableList()
+                        }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onChange(checkbox) },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        when (checkbox) {
+                            is CheckboxState.TriState -> {
+                                TriStateCheckbox(
+                                    state = checkbox.asToggleableState(),
+                                    onClick = { onChange(checkbox) },
+                                )
+                            }
+                            is CheckboxState.State -> {
+                                Checkbox(
+                                    checked = checkbox.isChecked,
+                                    onCheckedChange = { onChange(checkbox) },
+                                )
+                            }
+                        }
+
+                        Text(
+                            text = checkbox.value.name,
+                            modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
+                        )
+                    }
+                }
+            }
+        },
+    )
 }

--- a/app/src/main/java/eu/kanade/presentation/chapterTag/components/ChapterTagListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/chapterTag/components/ChapterTagListItem.kt
@@ -1,0 +1,58 @@
+package eu.kanade.presentation.chapterTag.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+fun ChapterTagListItem(
+    chapterTag: ChapterTag,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ElevatedCard(modifier = modifier) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onRename)
+                .padding(vertical = MaterialTheme.padding.small)
+                .padding(start = MaterialTheme.padding.medium, end = MaterialTheme.padding.medium),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = chapterTag.name,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = onRename) {
+                Icon(
+                    imageVector = Icons.Outlined.Edit,
+                    contentDescription = stringResource(KMR.strings.action_rename_chapter_tag),
+                )
+            }
+            IconButton(onClick = onDelete) {
+                Icon(
+                    imageVector = Icons.Outlined.Delete,
+                    contentDescription = stringResource(MR.strings.action_delete),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/LibrarySettingsDialog.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.map
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.core.common.preference.toggle
 import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.chapterTag.model.ChapterTag
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.model.LibraryGroup
 import tachiyomi.domain.library.model.LibrarySort
@@ -184,6 +185,12 @@ private fun ColumnScope.FilterPage(
     CategoriesFilter(
         libraryPreferences = screenModel.libraryPreferences,
         categories = categories,
+    )
+
+    val chapterTags by screenModel.chapterTagsFlow.collectAsState()
+    ChapterTagsFilter(
+        libraryPreferences = screenModel.libraryPreferences,
+        chapterTags = chapterTags,
     )
     // KMK <--
 
@@ -514,6 +521,59 @@ private fun CategoriesFilter(
         )
         Spacer(Modifier.weight(1f))
         TextButton(onClick = { showCategoriesDialog = true }) {
+            Text(stringResource(MR.strings.action_edit))
+        }
+    }
+}
+
+@Composable
+private fun ChapterTagsFilter(
+    libraryPreferences: LibraryPreferences,
+    chapterTags: List<ChapterTag>,
+) {
+    val filterChapterTags by libraryPreferences.filterChapterTags().collectAsState()
+
+    val filterChapterTagsInclude = libraryPreferences.filterChapterTagsInclude()
+    val filterChapterTagsExclude = libraryPreferences.filterChapterTagsExclude()
+    val included by filterChapterTagsInclude.collectAsState()
+    val excluded by filterChapterTagsExclude.collectAsState()
+
+    var showChapterTagsDialog by rememberSaveable { mutableStateOf(false) }
+    if (showChapterTagsDialog) {
+        TriStateListDialog(
+            title = stringResource(KMR.strings.chapter_tags),
+            message = stringResource(KMR.strings.pref_library_filter_chapter_tags_details),
+            items = chapterTags,
+            initialChecked = included.mapNotNull { id -> chapterTags.find { it.id.toString() == id } },
+            initialInversed = excluded.mapNotNull { id -> chapterTags.find { it.id.toString() == id } },
+            itemLabel = { it.name },
+            onDismissRequest = { showChapterTagsDialog = false },
+            onValueChanged = { newIncluded, newExcluded ->
+                filterChapterTagsInclude.set(newIncluded.map { it.id.toString() }.toSet())
+                filterChapterTagsExclude.set(newExcluded.map { it.id.toString() }.toSet())
+                showChapterTagsDialog = false
+            },
+        )
+    }
+
+    Row(
+        modifier = Modifier
+            .clickable(onClick = { libraryPreferences.filterChapterTags().toggle() })
+            .fillMaxWidth()
+            .padding(horizontal = SettingsItemsPaddings.Horizontal),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Checkbox(
+            checked = filterChapterTags,
+            onCheckedChange = null,
+        )
+        Text(
+            text = stringResource(KMR.strings.chapter_tags),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Spacer(Modifier.weight(1f))
+        TextButton(onClick = { showChapterTagsDialog = true }) {
             Text(stringResource(MR.strings.action_edit))
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Label
 import androidx.compose.material.icons.outlined.PeopleAlt
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
@@ -35,6 +36,7 @@ import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
 import tachiyomi.presentation.core.components.LabeledCheckbox
 import tachiyomi.presentation.core.components.RadioItem
 import tachiyomi.presentation.core.components.SortItem
@@ -53,6 +55,10 @@ fun ChapterSettingsDialog(
     onBookmarkedFilterChanged: (TriState) -> Unit,
     scanlatorFilterActive: Boolean,
     onScanlatorFilterClicked: () -> Unit,
+    // KMK -->
+    chapterTagFilterActive: Boolean,
+    onChapterTagFilterClicked: () -> Unit,
+    // KMK <--
     onSortModeChanged: (Long) -> Unit,
     onDisplayModeChanged: (Long) -> Unit,
     onSetAsDefault: (applyToExistingManga: Boolean) -> Unit,
@@ -109,6 +115,10 @@ fun ChapterSettingsDialog(
                         onBookmarkedFilterChanged = onBookmarkedFilterChanged,
                         scanlatorFilterActive = scanlatorFilterActive,
                         onScanlatorFilterClicked = onScanlatorFilterClicked,
+                        // KMK -->
+                        chapterTagFilterActive = chapterTagFilterActive,
+                        onChapterTagFilterClicked = onChapterTagFilterClicked,
+                        // KMK <--
                     )
                 }
                 1 -> {
@@ -139,6 +149,10 @@ private fun ColumnScope.FilterPage(
     onBookmarkedFilterChanged: (TriState) -> Unit,
     scanlatorFilterActive: Boolean,
     onScanlatorFilterClicked: () -> Unit,
+    // KMK -->
+    chapterTagFilterActive: Boolean,
+    onChapterTagFilterClicked: () -> Unit,
+    // KMK <--
 ) {
     TriStateItem(
         label = stringResource(MR.strings.label_downloaded),
@@ -159,6 +173,12 @@ private fun ColumnScope.FilterPage(
         active = scanlatorFilterActive,
         onClick = onScanlatorFilterClicked,
     )
+    // KMK -->
+    ChapterTagFilterItem(
+        active = chapterTagFilterActive,
+        onClick = onChapterTagFilterClicked,
+    )
+    // KMK <--
 }
 
 @Composable
@@ -189,6 +209,37 @@ fun ScanlatorFilterItem(
         )
     }
 }
+
+// KMK -->
+@Composable
+fun ChapterTagFilterItem(
+    active: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .fillMaxWidth()
+            .padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(24.dp),
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.Label,
+            contentDescription = null,
+            tint = if (active) {
+                MaterialTheme.colorScheme.active
+            } else {
+                LocalContentColor.current
+            },
+        )
+        Text(
+            text = stringResource(KMR.strings.chapter_tags),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+// KMK <--
 
 @Composable
 private fun ColumnScope.SortPage(

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -185,6 +185,9 @@ fun MangaScreen(
     onMultiMarkAsReadClicked: (List<Chapter>, markAsRead: Boolean) -> Unit,
     onMarkPreviousAsReadClicked: (Chapter) -> Unit,
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
+    // KMK -->
+    onMultiEditTagsClicked: (List<Chapter>) -> Unit,
+    // KMK <--
 
     // For chapter swipe
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
@@ -259,6 +262,9 @@ fun MangaScreen(
             onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
             onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
             onMultiDeleteClicked = onMultiDeleteClicked,
+            // KMK -->
+            onMultiEditTagsClicked = onMultiEditTagsClicked,
+            // KMK <--
             onChapterSwipe = onChapterSwipe,
             onChapterSelected = onChapterSelected,
             onAllChapterSelected = onAllChapterSelected,
@@ -321,6 +327,9 @@ fun MangaScreen(
             onMultiMarkAsReadClicked = onMultiMarkAsReadClicked,
             onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
             onMultiDeleteClicked = onMultiDeleteClicked,
+            // KMK -->
+            onMultiEditTagsClicked = onMultiEditTagsClicked,
+            // KMK <--
             onChapterSwipe = onChapterSwipe,
             onChapterSelected = onChapterSelected,
             onAllChapterSelected = onAllChapterSelected,
@@ -395,6 +404,9 @@ private fun MangaScreenSmallImpl(
     onMultiMarkAsReadClicked: (List<Chapter>, markAsRead: Boolean) -> Unit,
     onMarkPreviousAsReadClicked: (Chapter) -> Unit,
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
+    // KMK -->
+    onMultiEditTagsClicked: (List<Chapter>) -> Unit,
+    // KMK <--
 
     // For chapter swipe
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
@@ -525,6 +537,9 @@ private fun MangaScreenSmallImpl(
                 onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
                 onDownloadChapter = onDownloadChapter,
                 onMultiDeleteClicked = onMultiDeleteClicked,
+                // KMK -->
+                onMultiEditTagsClicked = onMultiEditTagsClicked,
+                // KMK <--
                 fillFraction = 1f,
             )
         },
@@ -859,6 +874,9 @@ private fun MangaScreenLargeImpl(
     onMultiMarkAsReadClicked: (List<Chapter>, markAsRead: Boolean) -> Unit,
     onMarkPreviousAsReadClicked: (Chapter) -> Unit,
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
+    // KMK -->
+    onMultiEditTagsClicked: (List<Chapter>) -> Unit,
+    // KMK <--
 
     // For swipe actions
     onChapterSwipe: (ChapterList.Item, LibraryPreferences.ChapterSwipeAction) -> Unit,
@@ -984,6 +1002,9 @@ private fun MangaScreenLargeImpl(
                     onMarkPreviousAsReadClicked = onMarkPreviousAsReadClicked,
                     onDownloadChapter = onDownloadChapter,
                     onMultiDeleteClicked = onMultiDeleteClicked,
+                    // KMK -->
+                    onMultiEditTagsClicked = onMultiEditTagsClicked,
+                    // KMK <--
                     fillFraction = 0.5f,
                 )
             }
@@ -1257,6 +1278,9 @@ private fun SharedMangaBottomActionMenu(
     onMarkPreviousAsReadClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
     onMultiDeleteClicked: (List<Chapter>) -> Unit,
+    // KMK -->
+    onMultiEditTagsClicked: (List<Chapter>) -> Unit,
+    // KMK <--
     fillFraction: Float,
     modifier: Modifier = Modifier,
 ) {
@@ -1288,6 +1312,11 @@ private fun SharedMangaBottomActionMenu(
         }.takeIf {
             selected.fastAny { it.downloadState == Download.State.DOWNLOADED }
         },
+        // KMK -->
+        onEditTagsClicked = {
+            onMultiEditTagsClicked(selected.fastMap { it.chapter })
+        },
+        // KMK <--
     )
 }
 
@@ -1362,6 +1391,9 @@ private fun LazyListScope.sharedChapterItems(
                     // SY -->
                     sourceName = item.sourceName,
                     // SY <--
+                    // KMK -->
+                    tags = item.tags.takeIf { it.isNotEmpty() }?.joinToString { it.name },
+                    // KMK <--
                     read = item.chapter.read,
                     bookmark = item.chapter.bookmark,
                     selected = item.selected,

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ChapterTagFilterDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ChapterTagFilterDialog.kt
@@ -1,137 +1,44 @@
 package eu.kanade.presentation.manga.components
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.CheckBox
-import androidx.compose.material.icons.rounded.CheckBoxOutlineBlank
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.toMutableStateList
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.DialogProperties
+import eu.kanade.presentation.more.settings.widget.TriStateListDialog
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.ImmutableSet
 import tachiyomi.domain.chapterTag.model.ChapterTag
-import tachiyomi.i18n.MR
+import tachiyomi.domain.chapterTag.model.ChapterTagFilter
 import tachiyomi.i18n.kmk.KMR
-import tachiyomi.presentation.core.components.material.TextButton
-import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 
+/**
+ * Per-manga chapter tag filter picker. Checked tags are required, inversed tags are excluded.
+ */
 @Composable
 fun ChapterTagFilterDialog(
     chapterTags: ImmutableList<ChapterTag>,
-    selectedTagIds: ImmutableSet<Long>,
+    filter: ChapterTagFilter,
     onDismissRequest: () -> Unit,
-    onConfirm: (Set<Long>) -> Unit,
+    onConfirm: (included: Set<Long>, excluded: Set<Long>) -> Unit,
 ) {
-    // Drop ids whose tag no longer exists so a stale selection can't be re-submitted.
-    val mutableSelected = remember(selectedTagIds, chapterTags) {
-        selectedTagIds.filter { id -> chapterTags.any { it.id == id } }.toMutableStateList()
-    }
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        title = { Text(text = stringResource(KMR.strings.action_filter_chapter_tags)) },
-        text = textFunc@{
+    TriStateListDialog(
+        title = stringResource(KMR.strings.action_filter_chapter_tags),
+        message = stringResource(
             if (chapterTags.isEmpty()) {
-                Text(text = stringResource(KMR.strings.information_empty_chapter_tags_filter))
-                return@textFunc
-            }
-            Box {
-                val state = rememberLazyListState()
-                LazyColumn(state = state) {
-                    items(
-                        items = chapterTags,
-                        contentType = { "item" },
-                        key = { it.id },
-                    ) { tag ->
-                        val isSelected = mutableSelected.contains(tag.id)
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier
-                                .clickable {
-                                    if (isSelected) {
-                                        mutableSelected.remove(tag.id)
-                                    } else {
-                                        mutableSelected.add(tag.id)
-                                    }
-                                }
-                                .minimumInteractiveComponentSize()
-                                .clip(MaterialTheme.shapes.small)
-                                .fillMaxWidth()
-                                .padding(horizontal = MaterialTheme.padding.small),
-                        ) {
-                            Icon(
-                                imageVector = if (isSelected) {
-                                    Icons.Rounded.CheckBox
-                                } else {
-                                    Icons.Rounded.CheckBoxOutlineBlank
-                                },
-                                tint = if (isSelected) {
-                                    MaterialTheme.colorScheme.primary
-                                } else {
-                                    LocalContentColor.current
-                                },
-                                contentDescription = null,
-                            )
-                            Text(
-                                text = tag.name,
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.padding(start = 24.dp),
-                            )
-                        }
-                    }
-                }
-                if (state.canScrollBackward) HorizontalDivider(modifier = Modifier.align(Alignment.TopCenter))
-                if (state.canScrollForward) HorizontalDivider(modifier = Modifier.align(Alignment.BottomCenter))
-            }
-        },
-        properties = DialogProperties(
-            usePlatformDefaultWidth = true,
-        ),
-        confirmButton = {
-            if (chapterTags.isEmpty()) {
-                TextButton(onClick = onDismissRequest) {
-                    Text(text = stringResource(MR.strings.action_cancel))
-                }
+                KMR.strings.information_empty_chapter_tags_filter
             } else {
-                FlowRow {
-                    TextButton(onClick = mutableSelected::clear) {
-                        Text(text = stringResource(MR.strings.action_reset))
-                    }
-                    Spacer(modifier = Modifier.weight(1f))
-                    TextButton(onClick = onDismissRequest) {
-                        Text(text = stringResource(MR.strings.action_cancel))
-                    }
-                    TextButton(
-                        onClick = {
-                            onConfirm(mutableSelected.toSet())
-                            onDismissRequest()
-                        },
-                    ) {
-                        Text(text = stringResource(MR.strings.action_ok))
-                    }
-                }
-            }
+                KMR.strings.pref_filter_chapter_tags_details
+            },
+        ),
+        items = chapterTags,
+        // Drop ids whose tag no longer exists so a stale selection can't be re-submitted.
+        initialChecked = chapterTags.filter { it.id in filter.included },
+        initialInversed = chapterTags.filter { it.id in filter.excluded },
+        itemLabel = { it.name },
+        onDismissRequest = onDismissRequest,
+        onValueChanged = { included, excluded ->
+            onConfirm(
+                included.mapTo(mutableSetOf()) { it.id },
+                excluded.mapTo(mutableSetOf()) { it.id },
+            )
+            onDismissRequest()
         },
     )
 }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ChapterTagFilterDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ChapterTagFilterDialog.kt
@@ -1,0 +1,134 @@
+package eu.kanade.presentation.manga.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckBox
+import androidx.compose.material.icons.rounded.CheckBoxOutlineBlank
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
+import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.i18n.MR
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.components.material.TextButton
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+fun ChapterTagFilterDialog(
+    chapterTags: ImmutableList<ChapterTag>,
+    selectedTagIds: ImmutableSet<Long>,
+    onDismissRequest: () -> Unit,
+    onConfirm: (Set<Long>) -> Unit,
+) {
+    val mutableSelected = remember(selectedTagIds) { selectedTagIds.toMutableStateList() }
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        title = { Text(text = stringResource(KMR.strings.action_filter_chapter_tags)) },
+        text = textFunc@{
+            if (chapterTags.isEmpty()) {
+                Text(text = stringResource(KMR.strings.information_empty_chapter_tags_dialog))
+                return@textFunc
+            }
+            Box {
+                val state = rememberLazyListState()
+                LazyColumn(state = state) {
+                    items(
+                        items = chapterTags,
+                        contentType = { "item" },
+                        key = { it.id },
+                    ) { tag ->
+                        val isSelected = mutableSelected.contains(tag.id)
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .clickable {
+                                    if (isSelected) {
+                                        mutableSelected.remove(tag.id)
+                                    } else {
+                                        mutableSelected.add(tag.id)
+                                    }
+                                }
+                                .minimumInteractiveComponentSize()
+                                .clip(MaterialTheme.shapes.small)
+                                .fillMaxWidth()
+                                .padding(horizontal = MaterialTheme.padding.small),
+                        ) {
+                            Icon(
+                                imageVector = if (isSelected) {
+                                    Icons.Rounded.CheckBox
+                                } else {
+                                    Icons.Rounded.CheckBoxOutlineBlank
+                                },
+                                tint = if (isSelected) {
+                                    MaterialTheme.colorScheme.primary
+                                } else {
+                                    LocalContentColor.current
+                                },
+                                contentDescription = null,
+                            )
+                            Text(
+                                text = tag.name,
+                                style = MaterialTheme.typography.bodyMedium,
+                                modifier = Modifier.padding(start = 24.dp),
+                            )
+                        }
+                    }
+                }
+                if (state.canScrollBackward) HorizontalDivider(modifier = Modifier.align(Alignment.TopCenter))
+                if (state.canScrollForward) HorizontalDivider(modifier = Modifier.align(Alignment.BottomCenter))
+            }
+        },
+        properties = DialogProperties(
+            usePlatformDefaultWidth = true,
+        ),
+        confirmButton = {
+            if (chapterTags.isEmpty()) {
+                TextButton(onClick = onDismissRequest) {
+                    Text(text = stringResource(MR.strings.action_cancel))
+                }
+            } else {
+                FlowRow {
+                    TextButton(onClick = mutableSelected::clear) {
+                        Text(text = stringResource(MR.strings.action_reset))
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    TextButton(onClick = onDismissRequest) {
+                        Text(text = stringResource(MR.strings.action_cancel))
+                    }
+                    TextButton(
+                        onClick = {
+                            onConfirm(mutableSelected.toSet())
+                            onDismissRequest()
+                        },
+                    ) {
+                        Text(text = stringResource(MR.strings.action_ok))
+                    }
+                }
+            }
+        },
+    )
+}

--- a/app/src/main/java/eu/kanade/presentation/manga/components/ChapterTagFilterDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/ChapterTagFilterDialog.kt
@@ -44,13 +44,16 @@ fun ChapterTagFilterDialog(
     onDismissRequest: () -> Unit,
     onConfirm: (Set<Long>) -> Unit,
 ) {
-    val mutableSelected = remember(selectedTagIds) { selectedTagIds.toMutableStateList() }
+    // Drop ids whose tag no longer exists so a stale selection can't be re-submitted.
+    val mutableSelected = remember(selectedTagIds, chapterTags) {
+        selectedTagIds.filter { id -> chapterTags.any { it.id == id } }.toMutableStateList()
+    }
     AlertDialog(
         onDismissRequest = onDismissRequest,
         title = { Text(text = stringResource(KMR.strings.action_filter_chapter_tags)) },
         text = textFunc@{
             if (chapterTags.isEmpty()) {
-                Text(text = stringResource(KMR.strings.information_empty_chapter_tags_dialog))
+                Text(text = stringResource(KMR.strings.information_empty_chapter_tags_filter))
                 return@textFunc
             }
             Box {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaBottomActionMenu.kt
@@ -83,6 +83,9 @@ fun MangaBottomActionMenu(
     onMarkPreviousAsReadClicked: (() -> Unit)? = null,
     onDownloadClicked: (() -> Unit)? = null,
     onDeleteClicked: (() -> Unit)? = null,
+    // KMK -->
+    onEditTagsClicked: (() -> Unit)? = null,
+    // KMK <--
 ) {
     AnimatedVisibility(
         visible = visible,
@@ -96,7 +99,9 @@ fun MangaBottomActionMenu(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
         ) {
             val haptic = LocalHapticFeedback.current
-            val confirm = remember { mutableStateListOf(false, false, false, false, false, false, false) }
+            val confirm = remember {
+                mutableStateListOf(false, false, false, false, false, false, false /* KMK --> */, false /* KMK <-- */)
+            }
             var resetJob by remember { mutableStateOf<Job?>(null) }
             val onLongClickItem: (Int) -> Unit = { toConfirmIndex ->
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
@@ -179,6 +184,17 @@ fun MangaBottomActionMenu(
                         onClick = onDeleteClicked,
                     )
                 }
+                // KMK -->
+                if (onEditTagsClicked != null) {
+                    Button(
+                        title = stringResource(KMR.strings.action_edit_chapter_tags),
+                        icon = Icons.AutoMirrored.Outlined.Label,
+                        toConfirm = confirm[7],
+                        onLongClick = { onLongClickItem(7) },
+                        onClick = onEditTagsClicked,
+                    )
+                }
+                // KMK <--
             }
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
@@ -55,6 +55,9 @@ fun MangaChapterListItem(
     // SY -->
     sourceName: String?,
     // SY <--
+    // KMK -->
+    tags: String? = null,
+    // KMK <--
     read: Boolean,
     bookmark: Boolean,
     selected: Boolean,
@@ -195,6 +198,18 @@ fun MangaChapterListItem(
                                 overflow = TextOverflow.Ellipsis,
                             )
                         }
+                        // KMK -->
+                        if (tags != null) {
+                            if (date != null || readProgress != null || sourceName != null || scanlator != null) {
+                                DotSeparatorText()
+                            }
+                            Text(
+                                text = tags,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        // KMK <--
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
@@ -199,16 +199,11 @@ fun MangaChapterListItem(
                             )
                         }
                         // KMK -->
-                        if (tags != null) {
-                            if (date != null || readProgress != null || sourceName != null || scanlator != null) {
-                                DotSeparatorText()
-                            }
-                            Text(
-                                text = tags,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
+                        ChapterTagsText(
+                            tags = tags,
+                            precededBySubtitle = listOfNotNull(date, readProgress, sourceName, scanlator)
+                                .isNotEmpty(),
+                        )
                         // KMK <--
                     }
                 }
@@ -224,6 +219,22 @@ fun MangaChapterListItem(
         }
     }
 }
+
+// KMK -->
+@Composable
+private fun ChapterTagsText(
+    tags: String?,
+    precededBySubtitle: Boolean,
+) {
+    if (tags == null) return
+    if (precededBySubtitle) DotSeparatorText()
+    Text(
+        text = tags,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+// KMK <--
 
 internal fun getSwipeAction(
     action: LibraryPreferences.ChapterSwipeAction,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -21,6 +21,7 @@ import eu.kanade.presentation.more.settings.widget.TriStateListDialog
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.category.genre.SortTagScreen
+import eu.kanade.tachiyomi.ui.chapterTag.ChapterTagsScreen
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
@@ -99,6 +100,13 @@ object SettingsLibraryScreen : SearchableSettings {
                     ),
                     onClick = { navigator.push(CategoryScreen()) },
                 ),
+                // KMK -->
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(KMR.strings.chapter_tags),
+                    subtitle = stringResource(KMR.strings.pref_chapter_tags_summary),
+                    onClick = { navigator.push(ChapterTagsScreen()) },
+                ),
+                // KMK <--
                 Preference.PreferenceItem.ListPreference(
                     preference = libraryPreferences.defaultCategory(),
                     entries = ids.zip(labels).toMap().toImmutableMap(),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
@@ -6,6 +6,7 @@ import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.data.backup.BackupFileValidator
 import eu.kanade.tachiyomi.data.backup.create.creators.CategoriesBackupCreator
+import eu.kanade.tachiyomi.data.backup.create.creators.ChapterTagsBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.ExtensionStoresBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.FeedBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.MangaBackupCreator
@@ -14,6 +15,7 @@ import eu.kanade.tachiyomi.data.backup.create.creators.SavedSearchBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.SourcesBackupCreator
 import eu.kanade.tachiyomi.data.backup.models.Backup
 import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupChapterTag
 import eu.kanade.tachiyomi.data.backup.models.BackupExtensionStore
 import eu.kanade.tachiyomi.data.backup.models.BackupFeed
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
@@ -58,6 +60,7 @@ class BackupCreator(
     private val sourcesBackupCreator: SourcesBackupCreator = SourcesBackupCreator(),
     // KMK -->
     private val feedBackupCreator: FeedBackupCreator = FeedBackupCreator(),
+    private val chapterTagsBackupCreator: ChapterTagsBackupCreator = ChapterTagsBackupCreator(),
     // KMK <--
     // SY -->
     private val savedSearchBackupCreator: SavedSearchBackupCreator = SavedSearchBackupCreator(),
@@ -110,6 +113,7 @@ class BackupCreator(
 
                 // KMK -->
                 backupFeeds = backupFeeds(options),
+                backupChapterTags = backupChapterTags(options),
                 // KMK <--
             )
 
@@ -148,6 +152,14 @@ class BackupCreator(
 
         return categoriesBackupCreator()
     }
+
+    // KMK -->
+    suspend fun backupChapterTags(options: BackupOptions): List<BackupChapterTag> {
+        if (!options.chapters) return emptyList()
+
+        return chapterTagsBackupCreator()
+    }
+    // KMK <--
 
     suspend fun backupMangas(mangas: List<Manga>, options: BackupOptions): List<BackupManga> {
         if (!options.libraryEntries) return emptyList()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/ChapterTagsBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/ChapterTagsBackupCreator.kt
@@ -1,0 +1,22 @@
+package eu.kanade.tachiyomi.data.backup.create.creators
+
+import eu.kanade.tachiyomi.data.backup.models.BackupChapterTag
+import eu.kanade.tachiyomi.data.backup.models.backupChapterTagMapper
+import tachiyomi.domain.chapterTag.interactor.GetChapterTags
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+// KMK -->
+/**
+ * Backs up the chapter tag definitions. Tags with no assignments are included too, so an empty
+ * tag someone created ahead of time survives a restore.
+ */
+class ChapterTagsBackupCreator(
+    private val getChapterTags: GetChapterTags = Injekt.get(),
+) {
+
+    suspend operator fun invoke(): List<BackupChapterTag> {
+        return getChapterTags.await().map(backupChapterTagMapper)
+    }
+}
+// KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaBackupCreator.kt
@@ -87,6 +87,10 @@ class MangaBackupCreator(
             }
                 .takeUnless(List<BackupChapter>::isEmpty)
                 ?.let { mangaObject.chapters = it }
+
+            // KMK -->
+            backupChapterTags(manga.id, mangaObject.chapters)
+            // KMK <--
         }
 
         if (options.categories) {
@@ -119,6 +123,29 @@ class MangaBackupCreator(
 
         return mangaObject
     }
+
+    // KMK -->
+    /**
+     * Stamps each backed up chapter with the names of the tags assigned to it. Chapters are matched
+     * by url because [backupChapterMapper] drops the row id.
+     */
+    private suspend fun backupChapterTags(mangaId: Long, chapters: List<BackupChapter>) {
+        if (chapters.isEmpty()) return
+
+        val tagNamesByChapterUrl = handler.awaitList {
+            chapter_tagsQueries.getChapterTagNamesByMangaId(mangaId) { chapterUrl, tagName ->
+                chapterUrl to tagName
+            }
+        }
+            .groupBy({ it.first }, { it.second })
+
+        if (tagNamesByChapterUrl.isEmpty()) return
+
+        chapters.forEach { chapter ->
+            tagNamesByChapterUrl[chapter.url]?.let { chapter.chapterTags = it }
+        }
+    }
+    // KMK <--
 }
 
 private fun Manga.toBackupManga(/* SY --> */customMangaInfo: CustomMangaInfo?/* SY <-- */) =

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/Backup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/Backup.kt
@@ -17,5 +17,7 @@ data class Backup(
     // KMK -->
     // Global Popular/Latest feeds
     @ProtoNumber(610) var backupFeeds: List<BackupFeed> = emptyList(),
+    // Chapter tag definitions; per-chapter assignments live on BackupChapter
+    @ProtoNumber(611) var backupChapterTags: List<BackupChapterTag> = emptyList(),
     // KMK <--
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
@@ -26,6 +26,10 @@ class BackupChapter(
     @ProtoNumber(11) var lastModifiedAt: Long = 0,
     @ProtoNumber(12) var version: Long = 0,
     @ProtoNumber(13) var memo: ByteArray = JsonObjectEmptyBytes,
+    // KMK -->
+    // Chapter tag names, matched against existing tags by name on restore
+    @ProtoNumber(900) var chapterTags: List<String> = emptyList(),
+    // KMK <--
 ) {
     fun toChapterImpl(): Chapter {
         return Chapter.create().copy(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapterTag.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapterTag.kt
@@ -1,0 +1,20 @@
+package eu.kanade.tachiyomi.data.backup.models
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
+import tachiyomi.domain.chapterTag.model.ChapterTag
+
+// KMK -->
+/**
+ * A chapter tag definition. Only the name is carried: assignments reference tags by name too,
+ * so ids never have to survive a round trip between devices.
+ */
+@Serializable
+class BackupChapterTag(
+    @ProtoNumber(1) var name: String,
+)
+
+val backupChapterTagMapper = { tag: ChapterTag ->
+    BackupChapterTag(name = tag.name)
+}
+// KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.data.backup.models.BackupPreference
 import eu.kanade.tachiyomi.data.backup.models.BackupSavedSearch
 import eu.kanade.tachiyomi.data.backup.models.BackupSourcePreferences
 import eu.kanade.tachiyomi.data.backup.restore.restorers.CategoriesRestorer
+import eu.kanade.tachiyomi.data.backup.restore.restorers.ChapterTagsRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.ExtensionStoreRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.FeedRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaRestorer
@@ -45,6 +46,7 @@ class BackupRestorer(
     // SY <--
     // KMK -->
     private val feedRestorer: FeedRestorer = FeedRestorer(),
+    private val chapterTagsRestorer: ChapterTagsRestorer = ChapterTagsRestorer(),
     // KMK <--
 ) {
 
@@ -124,6 +126,10 @@ class BackupRestorer(
                 restoreSourcePreferences(backup.backupSourcePreferences)
             }
             if (options.libraryEntries) {
+                // KMK -->
+                // Tag definitions must exist before chapters reattach to them by name.
+                chapterTagsRestorer(backup.backupChapterTags)
+                // KMK <--
                 restoreManga(backup.backupManga, if (options.categories) backup.backupCategories else emptyList())
             }
             if (options.extensionStores) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/ChapterTagsRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/ChapterTagsRestorer.kt
@@ -1,0 +1,31 @@
+package eu.kanade.tachiyomi.data.backup.restore.restorers
+
+import eu.kanade.tachiyomi.data.backup.models.BackupChapterTag
+import tachiyomi.domain.chapterTag.interactor.CreateChapterTagWithName
+import tachiyomi.domain.chapterTag.interactor.GetChapterTags
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+// KMK -->
+/**
+ * Recreates the chapter tag definitions from a backup. Tags are matched against existing ones by
+ * exact name, the same uniqueness rule the tag management screen enforces, so restoring onto a
+ * device that already has a "Filler" tag reuses it instead of creating a duplicate.
+ */
+class ChapterTagsRestorer(
+    private val getChapterTags: GetChapterTags = Injekt.get(),
+    private val createChapterTagWithName: CreateChapterTagWithName = Injekt.get(),
+) {
+
+    suspend operator fun invoke(backupChapterTags: List<BackupChapterTag>) {
+        if (backupChapterTags.isEmpty()) return
+
+        val existingNames = getChapterTags.await().mapTo(mutableSetOf()) { it.name }
+
+        backupChapterTags
+            .distinctBy { it.name }
+            .filterNot { it.name in existingNames }
+            .forEach { createChapterTagWithName.await(it.name) }
+    }
+}
+// KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaRestorer.kt
@@ -18,6 +18,8 @@ import tachiyomi.data.manga.MergedMangaMapper
 import tachiyomi.domain.category.interactor.GetCategories
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.chapterTag.interactor.GetChapterTags
+import tachiyomi.domain.chapterTag.interactor.SetChapterTags
 import tachiyomi.domain.manga.interactor.FetchInterval
 import tachiyomi.domain.manga.interactor.GetFlatMetadataById
 import tachiyomi.domain.manga.interactor.GetMangaByUrlAndSourceId
@@ -51,6 +53,10 @@ class MangaRestorer(
     private val insertFlatMetadata: InsertFlatMetadata = Injekt.get(),
     private val getFlatMetadataById: GetFlatMetadataById = Injekt.get(),
     // SY <--
+    // KMK -->
+    private val getChapterTags: GetChapterTags = Injekt.get(),
+    private val setChapterTags: SetChapterTags = Injekt.get(),
+    // KMK <--
 ) {
     private var now = ZonedDateTime.now()
     private var currentFetchWindow = fetchInterval.getWindow(now)
@@ -204,7 +210,36 @@ class MangaRestorer(
 
         insertNewChapters(newChapters)
         updateExistingChapters(existingChapters)
+
+        // KMK -->
+        restoreChapterTags(manga, backupChapters)
+        // KMK <--
     }
+
+    // KMK -->
+    /**
+     * Reattaches chapter tags by name. Runs after the chapters themselves are written, and re-reads
+     * them so newly inserted rows have ids. Unchanged chapters are skipped by [restoreChapters], so
+     * their tags are restored here rather than on the insert/update paths.
+     */
+    private suspend fun restoreChapterTags(manga: Manga, backupChapters: List<BackupChapter>) {
+        val tagsByChapterUrl = backupChapters
+            .filter { it.chapterTags.isNotEmpty() }
+            .associate { it.url to it.chapterTags }
+        if (tagsByChapterUrl.isEmpty()) return
+
+        val tagIdsByName = getChapterTags.await().associate { it.name to it.id }
+        if (tagIdsByName.isEmpty()) return
+
+        getChaptersByMangaId.await(manga.id).forEach { chapter ->
+            val tagIds = tagsByChapterUrl[chapter.url]
+                ?.mapNotNull { tagIdsByName[it] }
+                ?.takeUnless { it.isEmpty() }
+                ?: return@forEach
+            setChapterTags.awaitAdd(chapter.id, tagIds)
+        }
+    }
+    // KMK <--
 
     private fun updateChapterBasedOnSyncState(chapter: Chapter, dbChapter: Chapter): Chapter {
         return if (isSync) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/chapterTag/ChapterTagsScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/chapterTag/ChapterTagsScreen.kt
@@ -1,0 +1,86 @@
+package eu.kanade.tachiyomi.ui.chapterTag
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.util.fastMap
+import cafe.adriel.voyager.core.model.rememberScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.category.components.CategoryCreateDialog
+import eu.kanade.presentation.category.components.CategoryDeleteDialog
+import eu.kanade.presentation.chapterTag.ChapterTagsScreen
+import eu.kanade.presentation.chapterTag.components.ChapterTagRenameDialog
+import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.collectLatest
+import tachiyomi.i18n.kmk.KMR
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.LoadingScreen
+
+class ChapterTagsScreen : Screen() {
+
+    @Composable
+    override fun Content() {
+        val context = LocalContext.current
+        val navigator = LocalNavigator.currentOrThrow
+        val screenModel = rememberScreenModel { ChapterTagsScreenModel() }
+
+        val state by screenModel.state.collectAsState()
+
+        if (state is ChapterTagsScreenState.Loading) {
+            LoadingScreen()
+            return
+        }
+
+        val successState = state as ChapterTagsScreenState.Success
+
+        ChapterTagsScreen(
+            state = successState,
+            onClickCreate = { screenModel.showDialog(ChapterTagDialog.Create) },
+            onClickRename = { screenModel.showDialog(ChapterTagDialog.Rename(it)) },
+            onClickDelete = { screenModel.showDialog(ChapterTagDialog.Delete(it)) },
+            navigateUp = navigator::pop,
+        )
+
+        when (val dialog = successState.dialog) {
+            null -> {}
+            ChapterTagDialog.Create -> {
+                CategoryCreateDialog(
+                    onDismissRequest = screenModel::dismissDialog,
+                    onCreate = screenModel::createChapterTag,
+                    categories = successState.chapterTags.fastMap { it.name }.toImmutableList(),
+                    title = stringResource(KMR.strings.action_add_chapter_tag),
+                    alreadyExistsError = KMR.strings.error_chapter_tag_exists,
+                )
+            }
+            is ChapterTagDialog.Rename -> {
+                ChapterTagRenameDialog(
+                    onDismissRequest = screenModel::dismissDialog,
+                    onRename = { screenModel.renameChapterTag(dialog.chapterTag, it) },
+                    chapterTags = successState.chapterTags.fastMap { it.name }.toImmutableList(),
+                    chapterTag = dialog.chapterTag.name,
+                )
+            }
+            is ChapterTagDialog.Delete -> {
+                CategoryDeleteDialog(
+                    onDismissRequest = screenModel::dismissDialog,
+                    onDelete = { screenModel.deleteChapterTag(dialog.chapterTag.id) },
+                    title = stringResource(KMR.strings.delete_chapter_tag),
+                    text = stringResource(KMR.strings.delete_chapter_tag_confirmation, dialog.chapterTag.name),
+                )
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            screenModel.events.collectLatest { event ->
+                if (event is ChapterTagsEvent.LocalizedMessage) {
+                    context.toast(event.stringRes)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/chapterTag/ChapterTagsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/chapterTag/ChapterTagsScreenModel.kt
@@ -1,0 +1,117 @@
+package eu.kanade.tachiyomi.ui.chapterTag
+
+import androidx.compose.runtime.Immutable
+import cafe.adriel.voyager.core.model.StateScreenModel
+import cafe.adriel.voyager.core.model.screenModelScope
+import dev.icerock.moko.resources.StringResource
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import tachiyomi.domain.chapterTag.interactor.CreateChapterTagWithName
+import tachiyomi.domain.chapterTag.interactor.DeleteChapterTag
+import tachiyomi.domain.chapterTag.interactor.GetChapterTags
+import tachiyomi.domain.chapterTag.interactor.RenameChapterTag
+import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class ChapterTagsScreenModel(
+    private val getChapterTags: GetChapterTags = Injekt.get(),
+    private val createChapterTagWithName: CreateChapterTagWithName = Injekt.get(),
+    private val renameChapterTag: RenameChapterTag = Injekt.get(),
+    private val deleteChapterTag: DeleteChapterTag = Injekt.get(),
+) : StateScreenModel<ChapterTagsScreenState>(ChapterTagsScreenState.Loading) {
+
+    private val _events: Channel<ChapterTagsEvent> = Channel()
+    val events = _events.receiveAsFlow()
+
+    init {
+        screenModelScope.launch {
+            getChapterTags.subscribe()
+                .collectLatest { chapterTags ->
+                    mutableState.update {
+                        ChapterTagsScreenState.Success(
+                            chapterTags = chapterTags.toImmutableList(),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun createChapterTag(name: String) {
+        screenModelScope.launch {
+            when (createChapterTagWithName.await(name)) {
+                is CreateChapterTagWithName.Result.InternalError -> _events.send(ChapterTagsEvent.InternalError)
+                else -> {}
+            }
+        }
+    }
+
+    fun renameChapterTag(chapterTag: ChapterTag, name: String) {
+        screenModelScope.launch {
+            when (renameChapterTag.await(chapterTag, name)) {
+                is RenameChapterTag.Result.InternalError -> _events.send(ChapterTagsEvent.InternalError)
+                else -> {}
+            }
+        }
+    }
+
+    fun deleteChapterTag(tagId: Long) {
+        screenModelScope.launch {
+            when (deleteChapterTag.await(tagId)) {
+                is DeleteChapterTag.Result.InternalError -> _events.send(ChapterTagsEvent.InternalError)
+                else -> {}
+            }
+        }
+    }
+
+    fun showDialog(dialog: ChapterTagDialog) {
+        mutableState.update {
+            when (it) {
+                ChapterTagsScreenState.Loading -> it
+                is ChapterTagsScreenState.Success -> it.copy(dialog = dialog)
+            }
+        }
+    }
+
+    fun dismissDialog() {
+        mutableState.update {
+            when (it) {
+                ChapterTagsScreenState.Loading -> it
+                is ChapterTagsScreenState.Success -> it.copy(dialog = null)
+            }
+        }
+    }
+}
+
+sealed interface ChapterTagDialog {
+    data object Create : ChapterTagDialog
+    data class Rename(val chapterTag: ChapterTag) : ChapterTagDialog
+    data class Delete(val chapterTag: ChapterTag) : ChapterTagDialog
+}
+
+sealed interface ChapterTagsEvent {
+    sealed class LocalizedMessage(val stringRes: StringResource) : ChapterTagsEvent
+    data object InternalError : LocalizedMessage(MR.strings.internal_error)
+}
+
+sealed interface ChapterTagsScreenState {
+
+    @Immutable
+    data object Loading : ChapterTagsScreenState
+
+    @Immutable
+    data class Success(
+        val chapterTags: ImmutableList<ChapterTag>,
+        val dialog: ChapterTagDialog? = null,
+    ) : ChapterTagsScreenState {
+
+        val isEmpty: Boolean
+            get() = chapterTags.isEmpty()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryScreenModel.kt
@@ -98,6 +98,7 @@ import tachiyomi.domain.chapter.interactor.GetBookmarkedChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.chapter.interactor.GetMergedChaptersByMangaId
 import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.chapterTag.interactor.GetChapterTagsPerManga
 import tachiyomi.domain.history.interactor.GetNextChapters
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.model.LibraryGroup
@@ -161,6 +162,7 @@ class LibraryScreenModel(
     // SY <--
     // KMK -->
     private val smartSearchMerge: SmartSearchMerge = Injekt.get(),
+    private val getChapterTagsPerManga: GetChapterTagsPerManga = Injekt.get(),
     // KMK <--
 ) : StateScreenModel<LibraryScreenModel.State>(State()) {
 
@@ -190,9 +192,23 @@ class LibraryScreenModel(
                     state.map { it.excludedCategories }.distinctUntilChanged(),
                     ::Pair,
                 ),
+                combine(
+                    state.map { it.includedChapterTags }.distinctUntilChanged(),
+                    state.map { it.excludedChapterTags }.distinctUntilChanged(),
+                    getChapterTagsPerManga.subscribe(),
+                    ::Triple,
+                ),
                 // KMK <--
                 getLibraryItemPreferencesFlow(),
-            ) { (searchQuery, categories, favorites), (tracksMap, trackingFilters), (includedCategories, excludedCategories), itemPreferences ->
+            ) {
+                    (searchQuery, categories, favorites),
+                    (tracksMap, trackingFilters),
+                    (includedCategories, excludedCategories),
+                    // KMK -->
+                    (includedChapterTags, excludedChapterTags, chapterTagsPerManga),
+                    // KMK <--
+                    itemPreferences,
+                ->
                 val filteredFavorites = favorites
                     .applyFilters(
                         tracksMap,
@@ -201,6 +217,9 @@ class LibraryScreenModel(
                         // KMK -->
                         includedCategories,
                         excludedCategories,
+                        includedChapterTags,
+                        excludedChapterTags,
+                        chapterTagsPerManga,
                         // KMK <--
                     )
                     .let {
@@ -348,7 +367,8 @@ class LibraryScreenModel(
             )
                 .fastAny { it != TriState.DISABLED } ||
                 // KMK -->
-                prefs.filterCategories
+                prefs.filterCategories ||
+                prefs.filterChapterTags
             // KMK <--
         }
             .distinctUntilChanged()
@@ -415,6 +435,29 @@ class LibraryScreenModel(
             }
             .launchIn(screenModelScope)
 
+        combine(
+            libraryPreferences.filterChapterTags().changes(),
+            libraryPreferences.filterChapterTagsInclude().changes(),
+            libraryPreferences.filterChapterTagsExclude().changes(),
+        ) { filter, included, excluded ->
+            Triple(
+                filter,
+                included.mapNotNull(String::toLongOrNull).toImmutableSet(),
+                excluded.mapNotNull(String::toLongOrNull).toImmutableSet(),
+            )
+        }
+            .distinctUntilChanged()
+            .onEach { (filter, included, excluded) ->
+                mutableState.update { state ->
+                    state.copy(
+                        filterChapterTag = filter,
+                        includedChapterTags = included,
+                        excludedChapterTags = excluded,
+                    )
+                }
+            }
+            .launchIn(screenModelScope)
+
         screenModelScope.launchIO {
             if (mangaDexDmcaUuids.isEmpty()) {
                 mangaDexDmcaUuids = loadMangaDexDmcaUuids(context = Injekt.get<Application>())
@@ -430,6 +473,9 @@ class LibraryScreenModel(
         // KMK -->
         includedCategories: ImmutableSet<Long>,
         excludedCategories: ImmutableSet<Long>,
+        includedChapterTags: ImmutableSet<Long>,
+        excludedChapterTags: ImmutableSet<Long>,
+        chapterTagsPerManga: Map<Long, Set<Long>>,
         // KMK <--
     ): List<LibraryItem> {
         val downloadedOnly = preferences.globalFilterDownloaded
@@ -441,6 +487,9 @@ class LibraryScreenModel(
         val filterCompleted = preferences.filterCompleted
         val filterIntervalCustom = preferences.filterIntervalCustom
         val filterCategories = preferences.filterCategories
+        // KMK -->
+        val filterChapterTags = preferences.filterChapterTags
+        // KMK <--
 
         val isNotLoggedInAnyTrack = trackingFilter.isEmpty()
 
@@ -528,6 +577,22 @@ class LibraryScreenModel(
 
             !isExcluded && isIncluded
         }
+
+        val filterFnChapterTags: (LibraryItem) -> Boolean = chapterTags@{ item ->
+            if (!filterChapterTags) return@chapterTags true
+
+            val mangaTags = chapterTagsPerManga[item.id].orEmpty()
+
+            // Early return
+            if (mangaTags.isEmpty()) {
+                return@chapterTags includedChapterTags.isEmpty()
+            }
+
+            val isExcluded = excludedChapterTags.any { it in mangaTags }
+            val isIncluded = includedChapterTags.isEmpty() || includedChapterTags.all { it in mangaTags }
+
+            !isExcluded && isIncluded
+        }
         // KMK <--
 
         return fastFilter {
@@ -542,7 +607,8 @@ class LibraryScreenModel(
                 filterFnLewd(it) &&
                 // SY <--
                 // KMK -->
-                filterFnCategories(it)
+                filterFnCategories(it) &&
+                filterFnChapterTags(it)
             // KMK <--
         }
     }
@@ -749,6 +815,7 @@ class LibraryScreenModel(
             libraryPreferences.sourceBadge().changes(),
             libraryPreferences.useLangIcon().changes(),
             libraryPreferences.filterCategories().changes(),
+            libraryPreferences.filterChapterTags().changes(),
             // KMK <--
         ) {
             ItemPreferences(
@@ -771,6 +838,7 @@ class LibraryScreenModel(
                 sourceBadge = it[13] as Boolean,
                 useLangIcon = it[14] as Boolean,
                 filterCategories = it[15] as Boolean,
+                filterChapterTags = it[16] as Boolean,
             )
         }
     }
@@ -1685,6 +1753,7 @@ class LibraryScreenModel(
         // SY <--
         // KMK -->
         val filterCategories: Boolean,
+        val filterChapterTags: Boolean,
         // KMK <--
     )
 
@@ -1725,6 +1794,9 @@ class LibraryScreenModel(
         val filterCategory: Boolean = false,
         val includedCategories: ImmutableSet<Long> = persistentSetOf(),
         val excludedCategories: ImmutableSet<Long> = persistentSetOf(),
+        val filterChapterTag: Boolean = false,
+        val includedChapterTags: ImmutableSet<Long> = persistentSetOf(),
+        val excludedChapterTags: ImmutableSet<Long> = persistentSetOf(),
         // KMK <--
     ) {
         /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySettingsScreenModel.kt
@@ -15,6 +15,7 @@ import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.domain.category.interactor.SetDisplayMode
 import tachiyomi.domain.category.interactor.SetSortModeForCategory
 import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.chapterTag.interactor.GetChapterTags
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.model.LibrarySort
 import tachiyomi.domain.library.service.LibraryPreferences
@@ -28,6 +29,9 @@ class LibrarySettingsScreenModel(
     private val setDisplayMode: SetDisplayMode = Injekt.get(),
     private val setSortModeForCategory: SetSortModeForCategory = Injekt.get(),
     trackerManager: TrackerManager = Injekt.get(),
+    // KMK -->
+    getChapterTags: GetChapterTags = Injekt.get(),
+    // KMK <--
 ) : ScreenModel {
 
     val trackersFlow = trackerManager.loggedInTrackersFlow()
@@ -36,6 +40,15 @@ class LibrarySettingsScreenModel(
             started = SharingStarted.WhileSubscribed(5.seconds.inWholeMilliseconds),
             initialValue = trackerManager.loggedInTrackers(),
         )
+
+    // KMK -->
+    val chapterTagsFlow = getChapterTags.subscribe()
+        .stateIn(
+            scope = screenModelScope,
+            started = SharingStarted.WhileSubscribed(5.seconds.inWholeMilliseconds),
+            initialValue = emptyList(),
+        )
+    // KMK <--
 
     // SY -->
     val grouping by libraryPreferences.groupLibraryBy().asState(screenModelScope)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -52,6 +52,7 @@ import eu.kanade.presentation.manga.ChapterSettingsDialog
 import eu.kanade.presentation.manga.DuplicateMangaDialog
 import eu.kanade.presentation.manga.EditCoverAction
 import eu.kanade.presentation.manga.MangaScreen
+import eu.kanade.presentation.manga.components.ChapterTagFilterDialog
 import eu.kanade.presentation.manga.components.ClearMangaDialog
 import eu.kanade.presentation.manga.components.DeleteChaptersDialog
 import eu.kanade.presentation.manga.components.MangaCoverDialog
@@ -471,6 +472,10 @@ class MangaScreen(
 
         var showScanlatorsDialog by remember { mutableStateOf(false) }
 
+        // KMK -->
+        var showChapterTagsFilterDialog by remember { mutableStateOf(false) }
+        // KMK <--
+
         val onDismissRequest = {
             screenModel.dismissDialog()
             // KMK -->
@@ -536,6 +541,10 @@ class MangaScreen(
                 onResetToDefault = screenModel::resetToDefaultSettings,
                 scanlatorFilterActive = successState.scanlatorFilterActive,
                 onScanlatorFilterClicked = { showScanlatorsDialog = true },
+                // KMK -->
+                chapterTagFilterActive = successState.chapterTagFilterActive,
+                onChapterTagFilterClicked = { showChapterTagsFilterDialog = true },
+                // KMK <--
             )
             MangaScreenModel.Dialog.TrackSheet -> {
                 NavigatorAdaptiveSheet(
@@ -667,6 +676,17 @@ class MangaScreen(
                 onConfirm = screenModel::setExcludedScanlators,
             )
         }
+
+        // KMK -->
+        if (showChapterTagsFilterDialog) {
+            ChapterTagFilterDialog(
+                chapterTags = successState.chapterTags,
+                selectedTagIds = successState.chapterTagFilter,
+                onDismissRequest = { showChapterTagsFilterDialog = false },
+                onConfirm = screenModel::setChapterTagFilter,
+            )
+        }
+        // KMK <--
     }
 
     private fun continueReading(context: Context, unreadChapter: Chapter?) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -681,7 +681,7 @@ class MangaScreen(
         if (showChapterTagsFilterDialog) {
             ChapterTagFilterDialog(
                 chapterTags = successState.chapterTags,
-                selectedTagIds = successState.chapterTagFilter,
+                filter = successState.chapterTagFilter,
                 onDismissRequest = { showChapterTagsFilterDialog = false },
                 onConfirm = screenModel::setChapterTagFilter,
             )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -46,6 +46,7 @@ import eu.kanade.domain.manga.model.hasCustomCover
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.presentation.browse.components.BulkFavoriteDialogs
 import eu.kanade.presentation.category.components.ChangeCategoryDialog
+import eu.kanade.presentation.chapterTag.components.ChangeChapterTagsDialog
 import eu.kanade.presentation.components.NavigatorAdaptiveSheet
 import eu.kanade.presentation.manga.ChapterSettingsDialog
 import eu.kanade.presentation.manga.DuplicateMangaDialog
@@ -73,6 +74,7 @@ import eu.kanade.tachiyomi.ui.browse.source.browse.BrowseSourceScreen
 import eu.kanade.tachiyomi.ui.browse.source.feed.SourceFeedScreen
 import eu.kanade.tachiyomi.ui.browse.source.globalsearch.GlobalSearchScreen
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
+import eu.kanade.tachiyomi.ui.chapterTag.ChapterTagsScreen
 import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.manga.merged.EditMergedSettingsDialog
 import eu.kanade.tachiyomi.ui.manga.notes.MangaNotesScreen
@@ -396,6 +398,9 @@ class MangaScreen(
             onMultiMarkAsReadClicked = screenModel::markChaptersRead,
             onMarkPreviousAsReadClicked = screenModel::markPreviousChapterRead,
             onMultiDeleteClicked = screenModel::showDeleteChapterDialog,
+            // KMK -->
+            onMultiEditTagsClicked = screenModel::showChangeChapterTagsDialog,
+            // KMK <--
             onChapterSwipe = screenModel::chapterSwipe,
             onChapterSelected = screenModel::toggleSelection,
             onAllChapterSelected = screenModel::toggleAllSelection,
@@ -639,6 +644,16 @@ class MangaScreen(
                 ClearMangaDialog(
                     onDismissRequest = onDismissRequest,
                     onConfirm = screenModel::clearManga,
+                )
+            }
+            is MangaScreenModel.Dialog.ChangeChapterTags -> {
+                ChangeChapterTagsDialog(
+                    initialSelection = dialog.initialSelection,
+                    onDismissRequest = onDismissRequest,
+                    onEditChapterTags = { navigator.push(ChapterTagsScreen()) },
+                    onConfirm = { include, exclude ->
+                        screenModel.setChapterTags(dialog.chapters, include, exclude)
+                    },
                 )
             }
             // KMK <--

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -483,6 +483,13 @@ class MangaScreenModel(
         screenModelScope.launchIO {
             val manga = getMangaAndChapters.awaitManga(mangaId)
 
+            // KMK -->
+            // Seed before the chapter list is mapped below: the tag subscriptions above can't reach
+            // the state while it is still Loading, and their tables never change on their own, so a
+            // dropped first emission would never be re-delivered.
+            chapterTagsByChapterId = getChapterTags.awaitByMangaId(mangaId)
+            // KMK <--
+
             // SY -->
             val mergedData = getMergedReferencesById.await(mangaId).takeIf { it.isNotEmpty() }?.let { references ->
                 MergedMangaData(
@@ -526,6 +533,10 @@ class MangaScreenModel(
                     }.toImmutableSet(),
                     // SY <--
                     excludedScanlators = getExcludedScanlators.await(mangaId).toImmutableSet(),
+                    // KMK -->
+                    chapterTags = getChapterTags.await().toImmutableList(),
+                    chapterTagFilter = getChapterTagFilter.await(mangaId).toImmutableSet(),
+                    // KMK <--
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
                     dialog = null,
                     hideMissingChapters = libraryPreferences.hideMissingChapters().get(),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -135,6 +135,7 @@ import tachiyomi.domain.chapterTag.interactor.GetChapterTags
 import tachiyomi.domain.chapterTag.interactor.SetChapterTagFilter
 import tachiyomi.domain.chapterTag.interactor.SetChapterTags
 import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.domain.chapterTag.model.ChapterTagFilter
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors
 import tachiyomi.domain.libraryUpdateError.interactor.InsertLibraryUpdateErrors
@@ -447,8 +448,8 @@ class MangaScreenModel(
             getChapterTagFilter.subscribe(mangaId)
                 .flowWithLifecycle(lifecycle)
                 .distinctUntilChanged()
-                .collectLatest { tagIds ->
-                    updateSuccessState { it.copy(chapterTagFilter = tagIds.toImmutableSet()) }
+                .collectLatest { filter ->
+                    updateSuccessState { it.copy(chapterTagFilter = filter) }
                 }
         }
         // KMK <--
@@ -535,7 +536,7 @@ class MangaScreenModel(
                     excludedScanlators = getExcludedScanlators.await(mangaId).toImmutableSet(),
                     // KMK -->
                     chapterTags = getChapterTags.await().toImmutableList(),
-                    chapterTagFilter = getChapterTagFilter.await(mangaId).toImmutableSet(),
+                    chapterTagFilter = getChapterTagFilter.await(mangaId),
                     // KMK <--
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
                     dialog = null,
@@ -1764,7 +1765,7 @@ class MangaScreenModel(
         screenModelScope.launchNonCancellable {
             setMangaDefaultChapterFlags.await(manga)
             // KMK -->
-            setChapterTagFilter.await(mangaId, emptySet())
+            setChapterTagFilter.await(mangaId, ChapterTagFilter.Empty)
             // KMK <--
         }
     }
@@ -2050,9 +2051,9 @@ class MangaScreenModel(
         toggleAllSelection(false)
     }
 
-    fun setChapterTagFilter(tagIds: Set<Long>) {
+    fun setChapterTagFilter(included: Set<Long>, excluded: Set<Long>) {
         screenModelScope.launchIO {
-            setChapterTagFilter.await(mangaId, tagIds)
+            setChapterTagFilter.await(mangaId, ChapterTagFilter(included = included, excluded = excluded))
         }
     }
     // KMK <--
@@ -2130,7 +2131,7 @@ class MangaScreenModel(
              */
             val relatedMangaCollection: List<RelatedManga>? = null,
             val chapterTags: ImmutableList<ChapterTag> = persistentListOf(),
-            val chapterTagFilter: ImmutableSet<Long> = persistentSetOf(),
+            val chapterTagFilter: ChapterTagFilter = ChapterTagFilter.Empty,
             val seedColor: Color? = manga.asMangaCover().vibrantCoverColor?.let { Color(it) },
             // KMK <--
         ) : State {
@@ -2195,7 +2196,7 @@ class MangaScreenModel(
 
             // KMK -->
             val chapterTagFilterActive: Boolean
-                get() = chapterTagFilter.isNotEmpty()
+                get() = chapterTagFilter.isActive
             // KMK <--
 
             val filterActive: Boolean

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -85,6 +85,7 @@ import exh.util.nullIfEmpty
 import exh.util.trimOrNull
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CancellationException
@@ -128,6 +129,9 @@ import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.model.NoChaptersException
 import tachiyomi.domain.chapter.service.calculateChapterGap
 import tachiyomi.domain.chapter.service.getChapterSort
+import tachiyomi.domain.chapterTag.interactor.GetChapterTags
+import tachiyomi.domain.chapterTag.interactor.SetChapterTags
+import tachiyomi.domain.chapterTag.model.ChapterTag
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.libraryUpdateError.interactor.DeleteLibraryUpdateErrors
 import tachiyomi.domain.libraryUpdateError.interactor.InsertLibraryUpdateErrors
@@ -231,6 +235,8 @@ class MangaScreenModel(
     private val insertLibraryUpdateErrors: InsertLibraryUpdateErrors = Injekt.get(),
     private val insertLibraryUpdateErrorMessages: InsertLibraryUpdateErrorMessages = Injekt.get(),
     private val deleteChaptersFromDb: DeleteChapters = Injekt.get(),
+    private val getChapterTags: GetChapterTags = Injekt.get(),
+    private val setChapterTags: SetChapterTags = Injekt.get(),
     // KMK <--
 ) : StateScreenModel<MangaScreenModel.State>(State.Loading) {
 
@@ -268,6 +274,10 @@ class MangaScreenModel(
 
     private val selectedPositions: Array<Int> = arrayOf(-1, -1) // first and last selected index in list
     private val selectedChapterIds: HashSet<Long> = HashSet()
+
+    // KMK -->
+    private var chapterTagsByChapterId: Map<Long, List<ChapterTag>> = emptyMap()
+    // KMK <--
 
     internal var showTrackDialogAfterCategorySelection: Boolean = false
 
@@ -401,6 +411,24 @@ class MangaScreenModel(
                     }
                 }
         }
+
+        // KMK -->
+        screenModelScope.launchIO {
+            getChapterTags.subscribeByMangaId(mangaId)
+                .flowWithLifecycle(lifecycle)
+                .distinctUntilChanged()
+                .collectLatest { tagsByChapterId ->
+                    chapterTagsByChapterId = tagsByChapterId
+                    updateSuccessState { successState ->
+                        successState.copy(
+                            chapters = successState.chapters.map { item ->
+                                item.copy(tags = tagsByChapterId[item.id].orEmpty().toImmutableList())
+                            },
+                        )
+                    }
+                }
+        }
+        // KMK <--
 
         screenModelScope.launchIO {
             getAvailableScanlators.subscribe(mangaId)
@@ -1116,6 +1144,9 @@ class MangaScreenModel(
                 sourceName = source?.getNameForMangaInfo(),
                 showScanlator = !isExhManga,
                 // SY <--
+                // KMK -->
+                tags = chapterTagsByChapterId[chapter.id].orEmpty().toImmutableList(),
+                // KMK <--
             )
         }
     }
@@ -1903,6 +1934,11 @@ class MangaScreenModel(
 
         // KMK -->
         data object ClearManga : Dialog
+
+        data class ChangeChapterTags(
+            val chapters: List<Chapter>,
+            val initialSelection: ImmutableList<CheckboxState<ChapterTag>>,
+        ) : Dialog
         // KMK <--
 
         data object SettingsSheet : Dialog
@@ -1940,6 +1976,43 @@ class MangaScreenModel(
             setExcludedScanlators.await(mangaId, excludedScanlators)
         }
     }
+
+    // KMK -->
+    fun showChangeChapterTagsDialog(chapters: List<Chapter>) {
+        if (chapters.isEmpty()) return
+        screenModelScope.launchIO {
+            val tags = getChapterTags.await()
+            val tagIdsByChapterId = getChapterTags.awaitTagIdsByChapterIds(chapters.map { it.id })
+            val tagIdsPerChapter = chapters.map { chapter -> tagIdsByChapterId[chapter.id].orEmpty().toSet() }
+            val common = tagIdsPerChapter.reduce { acc, ids -> acc intersect ids }
+            val mix = tagIdsPerChapter.flatten().toSet() - common
+            val preselected = tags.map { tag ->
+                when (tag.id) {
+                    in common -> CheckboxState.State.Checked(tag)
+                    in mix -> CheckboxState.TriState.Exclude(tag)
+                    else -> CheckboxState.State.None(tag)
+                }
+            }.toImmutableList()
+            updateSuccessState { successState ->
+                successState.copy(dialog = Dialog.ChangeChapterTags(chapters, preselected))
+            }
+        }
+    }
+
+    fun setChapterTags(chapters: List<Chapter>, addTagIds: List<Long>, removeTagIds: List<Long>) {
+        screenModelScope.launchNonCancellable {
+            val currentTagIds = getChapterTags.awaitTagIdsByChapterIds(chapters.map { it.id })
+            chapters.forEach { chapter ->
+                val tagIds = currentTagIds[chapter.id].orEmpty()
+                    .subtract(removeTagIds.toSet())
+                    .plus(addTagIds)
+                    .toList()
+                setChapterTags.await(chapter.id, tagIds)
+            }
+        }
+        toggleAllSelection(false)
+    }
+    // KMK <--
 
     // SY -->
     fun showEditMangaInfoDialog() {
@@ -2123,6 +2196,9 @@ sealed class ChapterList {
         val sourceName: String?,
         val showScanlator: Boolean,
         // SY <--
+        // KMK -->
+        val tags: ImmutableList<ChapterTag> = persistentListOf(),
+        // KMK <--
     ) : ChapterList() {
         val id = chapter.id
         val isDownloaded = downloadState == Download.State.DOWNLOADED

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -86,6 +86,7 @@ import exh.util.trimOrNull
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CancellationException
@@ -129,7 +130,9 @@ import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.model.NoChaptersException
 import tachiyomi.domain.chapter.service.calculateChapterGap
 import tachiyomi.domain.chapter.service.getChapterSort
+import tachiyomi.domain.chapterTag.interactor.GetChapterTagFilter
 import tachiyomi.domain.chapterTag.interactor.GetChapterTags
+import tachiyomi.domain.chapterTag.interactor.SetChapterTagFilter
 import tachiyomi.domain.chapterTag.interactor.SetChapterTags
 import tachiyomi.domain.chapterTag.model.ChapterTag
 import tachiyomi.domain.library.service.LibraryPreferences
@@ -237,6 +240,8 @@ class MangaScreenModel(
     private val deleteChaptersFromDb: DeleteChapters = Injekt.get(),
     private val getChapterTags: GetChapterTags = Injekt.get(),
     private val setChapterTags: SetChapterTags = Injekt.get(),
+    private val getChapterTagFilter: GetChapterTagFilter = Injekt.get(),
+    private val setChapterTagFilter: SetChapterTagFilter = Injekt.get(),
     // KMK <--
 ) : StateScreenModel<MangaScreenModel.State>(State.Loading) {
 
@@ -426,6 +431,24 @@ class MangaScreenModel(
                             },
                         )
                     }
+                }
+        }
+
+        screenModelScope.launchIO {
+            getChapterTags.subscribe()
+                .flowWithLifecycle(lifecycle)
+                .distinctUntilChanged()
+                .collectLatest { tags ->
+                    updateSuccessState { it.copy(chapterTags = tags.toImmutableList()) }
+                }
+        }
+
+        screenModelScope.launchIO {
+            getChapterTagFilter.subscribe(mangaId)
+                .flowWithLifecycle(lifecycle)
+                .distinctUntilChanged()
+                .collectLatest { tagIds ->
+                    updateSuccessState { it.copy(chapterTagFilter = tagIds.toImmutableSet()) }
                 }
         }
         // KMK <--
@@ -1729,6 +1752,9 @@ class MangaScreenModel(
         val manga = successState?.manga ?: return
         screenModelScope.launchNonCancellable {
             setMangaDefaultChapterFlags.await(manga)
+            // KMK -->
+            setChapterTagFilter.await(mangaId, emptySet())
+            // KMK <--
         }
     }
 
@@ -2012,6 +2038,12 @@ class MangaScreenModel(
         }
         toggleAllSelection(false)
     }
+
+    fun setChapterTagFilter(tagIds: Set<Long>) {
+        screenModelScope.launchIO {
+            setChapterTagFilter.await(mangaId, tagIds)
+        }
+    }
     // KMK <--
 
     // SY -->
@@ -2086,6 +2118,8 @@ class MangaScreenModel(
              * a list of <keyword, related mangas>
              */
             val relatedMangaCollection: List<RelatedManga>? = null,
+            val chapterTags: ImmutableList<ChapterTag> = persistentListOf(),
+            val chapterTagFilter: ImmutableSet<Long> = persistentSetOf(),
             val seedColor: Color? = manga.asMangaCover().vibrantCoverColor?.let { Color(it) },
             // KMK <--
         ) : State {
@@ -2148,8 +2182,13 @@ class MangaScreenModel(
             val scanlatorFilterActive: Boolean
                 get() = excludedScanlators.intersect(availableScanlators).isNotEmpty()
 
+            // KMK -->
+            val chapterTagFilterActive: Boolean
+                get() = chapterTagFilter.isNotEmpty()
+            // KMK <--
+
             val filterActive: Boolean
-                get() = scanlatorFilterActive || manga.chaptersFiltered()
+                get() = scanlatorFilterActive || manga.chaptersFiltered() /* KMK --> */ || chapterTagFilterActive /* KMK <-- */
 
             /**
              * Applies the view filters to the list of chapters obtained from the database.

--- a/data/src/main/java/tachiyomi/data/chapterTag/ChapterTagMapper.kt
+++ b/data/src/main/java/tachiyomi/data/chapterTag/ChapterTagMapper.kt
@@ -1,0 +1,17 @@
+package tachiyomi.data.chapterTag
+
+import tachiyomi.domain.chapterTag.model.ChapterTag
+
+object ChapterTagMapper {
+
+    fun mapChapterTag(id: Long, name: String): ChapterTag = ChapterTag(
+        id = id,
+        name = name,
+    )
+
+    fun mapChapterTagWithChapterId(
+        chapterId: Long,
+        id: Long,
+        name: String,
+    ): Pair<Long, ChapterTag> = chapterId to ChapterTag(id = id, name = name)
+}

--- a/data/src/main/java/tachiyomi/data/chapterTag/ChapterTagRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapterTag/ChapterTagRepositoryImpl.kt
@@ -28,7 +28,15 @@ class ChapterTagRepositoryImpl(
     }
 
     override suspend fun delete(tagId: Long) {
-        handler.await { chapter_tagsQueries.delete(tagId = tagId) }
+        // The FK cascade would clean both junction tables on its own, but SQLDelight only notifies
+        // listeners of the tables named in the executed statement — queries watching the junctions
+        // (chapter list filter, per-manga filter selection, library tags-per-manga) would keep
+        // serving stale rows. Deleting them explicitly in the same transaction fixes that.
+        handler.await(inTransaction = true) {
+            chapter_tag_filtersQueries.deleteByTagId(tagId = tagId)
+            chapters_chapter_tagsQueries.deleteByTagId(tagId = tagId)
+            chapter_tagsQueries.delete(tagId = tagId)
+        }
     }
 
     override suspend fun getTagIdsByChapterIds(chapterIds: List<Long>): Map<Long, List<Long>> {
@@ -38,6 +46,15 @@ class ChapterTagRepositoryImpl(
         }
             .groupBy({ it.first }, { it.second })
     }
+
+    override suspend fun getTagsByMangaId(mangaId: Long): Map<Long, List<ChapterTag>> = handler
+        .awaitList {
+            chapter_tagsQueries.getChapterTagsByMangaId(
+                mangaId,
+                ChapterTagMapper::mapChapterTagWithChapterId,
+            )
+        }
+        .groupBy({ it.first }, { it.second })
 
     override fun getTagsByMangaIdAsFlow(mangaId: Long): Flow<Map<Long, List<ChapterTag>>> = handler
         .subscribeToList {
@@ -60,6 +77,10 @@ class ChapterTagRepositoryImpl(
             chapters_chapter_tagsQueries.getTagIdsPerManga { mangaId, tagId -> mangaId to tagId }
         }
         .map { rows -> rows.groupBy({ it.first }, { it.second }).mapValues { it.value.toSet() } }
+
+    override suspend fun getFilterTagIds(mangaId: Long): Set<Long> = handler
+        .awaitList { chapter_tag_filtersQueries.getFilterTagIdsByMangaId(mangaId) }
+        .toSet()
 
     override fun getFilterTagIdsAsFlow(mangaId: Long): Flow<Set<Long>> = handler
         .subscribeToList { chapter_tag_filtersQueries.getFilterTagIdsByMangaId(mangaId) }

--- a/data/src/main/java/tachiyomi/data/chapterTag/ChapterTagRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapterTag/ChapterTagRepositoryImpl.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import tachiyomi.data.DatabaseHandler
 import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.domain.chapterTag.model.ChapterTagFilter
 import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
 
 class ChapterTagRepositoryImpl(
@@ -72,24 +73,46 @@ class ChapterTagRepositoryImpl(
         }
     }
 
+    override suspend fun addChapterTags(chapterId: Long, tagIds: List<Long>) {
+        if (tagIds.isEmpty()) return
+        handler.await(inTransaction = true) {
+            tagIds.forEach { tagId -> chapters_chapter_tagsQueries.insert(chapterId, tagId) }
+        }
+    }
+
     override fun getTagIdsPerMangaAsFlow(): Flow<Map<Long, Set<Long>>> = handler
         .subscribeToList {
             chapters_chapter_tagsQueries.getTagIdsPerManga { mangaId, tagId -> mangaId to tagId }
         }
         .map { rows -> rows.groupBy({ it.first }, { it.second }).mapValues { it.value.toSet() } }
 
-    override suspend fun getFilterTagIds(mangaId: Long): Set<Long> = handler
-        .awaitList { chapter_tag_filtersQueries.getFilterTagIdsByMangaId(mangaId) }
-        .toSet()
+    override suspend fun getFilter(mangaId: Long): ChapterTagFilter = handler
+        .awaitList { chapter_tag_filtersQueries.getFilterByMangaId(mangaId, ::Pair) }
+        .toChapterTagFilter()
 
-    override fun getFilterTagIdsAsFlow(mangaId: Long): Flow<Set<Long>> = handler
-        .subscribeToList { chapter_tag_filtersQueries.getFilterTagIdsByMangaId(mangaId) }
-        .map { it.toSet() }
+    override fun getFilterAsFlow(mangaId: Long): Flow<ChapterTagFilter> = handler
+        .subscribeToList { chapter_tag_filtersQueries.getFilterByMangaId(mangaId, ::Pair) }
+        .map { it.toChapterTagFilter() }
 
-    override suspend fun setFilterTagIds(mangaId: Long, tagIds: Set<Long>) {
+    override suspend fun setFilter(mangaId: Long, filter: ChapterTagFilter) {
         handler.await(inTransaction = true) {
             chapter_tag_filtersQueries.deleteByMangaId(mangaId)
-            tagIds.forEach { tagId -> chapter_tag_filtersQueries.insert(mangaId, tagId) }
+            filter.included.forEach { tagId ->
+                chapter_tag_filtersQueries.insert(mangaId, tagId, exclude = false)
+            }
+            // A tag cannot be included and excluded at once, so excluded wins nothing here: the
+            // UI emits disjoint sets and the primary key would reject the second row anyway.
+            filter.excluded.forEach { tagId ->
+                chapter_tag_filtersQueries.insert(mangaId, tagId, exclude = true)
+            }
         }
+    }
+
+    private fun List<Pair<Long, Boolean>>.toChapterTagFilter(): ChapterTagFilter {
+        val (excluded, included) = partition { it.second }
+        return ChapterTagFilter(
+            included = included.mapTo(mutableSetOf()) { it.first },
+            excluded = excluded.mapTo(mutableSetOf()) { it.first },
+        )
     }
 }

--- a/data/src/main/java/tachiyomi/data/chapterTag/ChapterTagRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/chapterTag/ChapterTagRepositoryImpl.kt
@@ -1,0 +1,74 @@
+package tachiyomi.data.chapterTag
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import tachiyomi.data.DatabaseHandler
+import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+
+class ChapterTagRepositoryImpl(
+    private val handler: DatabaseHandler,
+) : ChapterTagRepository {
+
+    override suspend fun getAll(): List<ChapterTag> = handler.awaitList {
+        chapter_tagsQueries.getChapterTags(ChapterTagMapper::mapChapterTag)
+    }
+
+    override fun getAllAsFlow(): Flow<List<ChapterTag>> = handler.subscribeToList {
+        chapter_tagsQueries.getChapterTags(ChapterTagMapper::mapChapterTag)
+    }
+
+    override suspend fun insert(name: String): Long = handler.awaitOneExecutable(true) {
+        chapter_tagsQueries.insert(name = name)
+        chapter_tagsQueries.selectLastInsertedRowId()
+    }
+
+    override suspend fun rename(tagId: Long, name: String) {
+        handler.await { chapter_tagsQueries.rename(name = name, tagId = tagId) }
+    }
+
+    override suspend fun delete(tagId: Long) {
+        handler.await { chapter_tagsQueries.delete(tagId = tagId) }
+    }
+
+    override suspend fun getTagIdsByChapterIds(chapterIds: List<Long>): Map<Long, List<Long>> {
+        if (chapterIds.isEmpty()) return emptyMap()
+        return handler.awaitList {
+            chapters_chapter_tagsQueries.getTagIdsByChapterIds(chapterIds) { chapterId, tagId -> chapterId to tagId }
+        }
+            .groupBy({ it.first }, { it.second })
+    }
+
+    override fun getTagsByMangaIdAsFlow(mangaId: Long): Flow<Map<Long, List<ChapterTag>>> = handler
+        .subscribeToList {
+            chapter_tagsQueries.getChapterTagsByMangaId(
+                mangaId,
+                ChapterTagMapper::mapChapterTagWithChapterId,
+            )
+        }
+        .map { rows -> rows.groupBy({ it.first }, { it.second }) }
+
+    override suspend fun setChapterTags(chapterId: Long, tagIds: List<Long>) {
+        handler.await(inTransaction = true) {
+            chapters_chapter_tagsQueries.deleteByChapterId(chapterId)
+            tagIds.forEach { tagId -> chapters_chapter_tagsQueries.insert(chapterId, tagId) }
+        }
+    }
+
+    override fun getTagIdsPerMangaAsFlow(): Flow<Map<Long, Set<Long>>> = handler
+        .subscribeToList {
+            chapters_chapter_tagsQueries.getTagIdsPerManga { mangaId, tagId -> mangaId to tagId }
+        }
+        .map { rows -> rows.groupBy({ it.first }, { it.second }).mapValues { it.value.toSet() } }
+
+    override fun getFilterTagIdsAsFlow(mangaId: Long): Flow<Set<Long>> = handler
+        .subscribeToList { chapter_tag_filtersQueries.getFilterTagIdsByMangaId(mangaId) }
+        .map { it.toSet() }
+
+    override suspend fun setFilterTagIds(mangaId: Long, tagIds: Set<Long>) {
+        handler.await(inTransaction = true) {
+            chapter_tag_filtersQueries.deleteByMangaId(mangaId)
+            tagIds.forEach { tagId -> chapter_tag_filtersQueries.insert(mangaId, tagId) }
+        }
+    }
+}

--- a/data/src/main/sqldelight/tachiyomi/data/chapter_tag_filters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapter_tag_filters.sq
@@ -1,8 +1,13 @@
--- Komikku: per-manga "show only chapters carrying one of these tags" selection.
+import kotlin.Boolean;
+
+-- Komikku: per-manga chapter tag filter selection.
 -- No rows for a manga == filter disabled for that manga.
+-- exclude = 0 -> show only chapters carrying one of these tags.
+-- exclude = 1 -> hide chapters carrying one of these tags.
 CREATE TABLE chapter_tag_filters(
     manga_id INTEGER NOT NULL,
     tag_id INTEGER NOT NULL,
+    exclude INTEGER AS Boolean NOT NULL DEFAULT 0,
     PRIMARY KEY(manga_id, tag_id),
     FOREIGN KEY(manga_id) REFERENCES mangas (_id)
     ON DELETE CASCADE,
@@ -12,14 +17,14 @@ CREATE TABLE chapter_tag_filters(
 
 CREATE INDEX idx_chapter_tag_filters_tag_id ON chapter_tag_filters(tag_id);
 
-getFilterTagIdsByMangaId:
-SELECT tag_id
+getFilterByMangaId:
+SELECT tag_id, exclude
 FROM chapter_tag_filters
 WHERE manga_id = :mangaId;
 
 insert:
-INSERT OR IGNORE INTO chapter_tag_filters(manga_id, tag_id)
-VALUES (:mangaId, :tagId);
+INSERT OR IGNORE INTO chapter_tag_filters(manga_id, tag_id, exclude)
+VALUES (:mangaId, :tagId, :exclude);
 
 deleteByMangaId:
 DELETE FROM chapter_tag_filters

--- a/data/src/main/sqldelight/tachiyomi/data/chapter_tag_filters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapter_tag_filters.sq
@@ -1,0 +1,26 @@
+-- Komikku: per-manga "show only chapters carrying one of these tags" selection.
+-- No rows for a manga == filter disabled for that manga.
+CREATE TABLE chapter_tag_filters(
+    manga_id INTEGER NOT NULL,
+    tag_id INTEGER NOT NULL,
+    PRIMARY KEY(manga_id, tag_id),
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id)
+    ON DELETE CASCADE,
+    FOREIGN KEY(tag_id) REFERENCES chapter_tags (_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX idx_chapter_tag_filters_tag_id ON chapter_tag_filters(tag_id);
+
+getFilterTagIdsByMangaId:
+SELECT tag_id
+FROM chapter_tag_filters
+WHERE manga_id = :mangaId;
+
+insert:
+INSERT OR IGNORE INTO chapter_tag_filters(manga_id, tag_id)
+VALUES (:mangaId, :tagId);
+
+deleteByMangaId:
+DELETE FROM chapter_tag_filters
+WHERE manga_id = :mangaId;

--- a/data/src/main/sqldelight/tachiyomi/data/chapter_tag_filters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapter_tag_filters.sq
@@ -24,3 +24,9 @@ VALUES (:mangaId, :tagId);
 deleteByMangaId:
 DELETE FROM chapter_tag_filters
 WHERE manga_id = :mangaId;
+
+-- Run before deleting the tag itself: the FK cascade would remove these rows too, but SQLDelight
+-- only notifies listeners of the tables named in the executed statement.
+deleteByTagId:
+DELETE FROM chapter_tag_filters
+WHERE tag_id = :tagId;

--- a/data/src/main/sqldelight/tachiyomi/data/chapter_tags.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapter_tags.sq
@@ -1,0 +1,43 @@
+-- Komikku: user-created chapter tags (definitions).
+-- Assignments live in chapters_chapter_tags.sq, per-manga filter selection in chapter_tag_filters.sq.
+CREATE TABLE chapter_tags(
+    _id INTEGER NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+getChapterTags:
+SELECT
+_id AS id,
+name
+FROM chapter_tags
+ORDER BY name COLLATE NOCASE;
+
+getChapterTagsByMangaId:
+SELECT
+CCT.chapter_id AS chapterId,
+T._id AS id,
+T.name
+FROM chapters_chapter_tags CCT
+JOIN chapter_tags T
+ON T._id = CCT.tag_id
+JOIN chapters C
+ON C._id = CCT.chapter_id
+WHERE C.manga_id = :mangaId
+OR C.manga_id IN (SELECT merged.manga_id FROM merged WHERE merged.merge_id = :mangaId)
+ORDER BY T.name COLLATE NOCASE;
+
+insert:
+INSERT INTO chapter_tags(name)
+VALUES (:name);
+
+rename:
+UPDATE chapter_tags
+SET name = :name
+WHERE _id = :tagId;
+
+delete:
+DELETE FROM chapter_tags
+WHERE _id = :tagId;
+
+selectLastInsertedRowId:
+SELECT last_insert_rowid();

--- a/data/src/main/sqldelight/tachiyomi/data/chapter_tags.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapter_tags.sq
@@ -26,6 +26,17 @@ WHERE C.manga_id = :mangaId
 OR C.manga_id IN (SELECT merged.manga_id FROM merged WHERE merged.merge_id = :mangaId)
 ORDER BY T.name COLLATE NOCASE;
 
+-- Backup only: chapter tags are carried by name, so a restore can match them against whatever
+-- tags already exist on the target device instead of relying on row ids lining up.
+getChapterTagNamesByMangaId:
+SELECT C.url AS chapterUrl, T.name AS tagName
+FROM chapters_chapter_tags CCT
+JOIN chapter_tags T
+ON T._id = CCT.tag_id
+JOIN chapters C
+ON C._id = CCT.chapter_id
+WHERE C.manga_id = :mangaId;
+
 insert:
 INSERT INTO chapter_tags(name)
 VALUES (:name);

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -73,14 +73,20 @@ AND (
         ES.scanlator IS NULL
         AND ((M.chapter_flags & :bookmarkUnmask) = 0 OR C.bookmark = 0)
         AND ((M.chapter_flags & :bookmarkMask) = 0 OR C.bookmark = 1)
-        AND (
-            NOT EXISTS (SELECT 1 FROM chapter_tag_filters CTF WHERE CTF.manga_id = :mangaId)
-            OR EXISTS (
+        -- No included tag may be missing from the chapter (vacuously true with nothing included)
+        AND NOT EXISTS (
+            SELECT 1 FROM chapter_tag_filters CTF
+            WHERE CTF.manga_id = :mangaId AND CTF.exclude = 0
+            AND NOT EXISTS (
                 SELECT 1 FROM chapters_chapter_tags CCT
-                JOIN chapter_tag_filters CTF2
-                ON CTF2.tag_id = CCT.tag_id AND CTF2.manga_id = :mangaId
-                WHERE CCT.chapter_id = C._id
+                WHERE CCT.chapter_id = C._id AND CCT.tag_id = CTF.tag_id
             )
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM chapters_chapter_tags CCT3
+            JOIN chapter_tag_filters CTF3
+            ON CTF3.tag_id = CCT3.tag_id AND CTF3.manga_id = :mangaId AND CTF3.exclude = 1
+            WHERE CCT3.chapter_id = C._id
         )
     )
     -- KMK <--
@@ -129,14 +135,20 @@ AND (
         ES.scanlator IS NULL
         AND ((MA.chapter_flags & :bookmarkUnmask) = 0 OR C.bookmark = 0)
         AND ((MA.chapter_flags & :bookmarkMask) = 0 OR C.bookmark = 1)
-        AND (
-            NOT EXISTS (SELECT 1 FROM chapter_tag_filters CTF WHERE CTF.manga_id = :mangaId)
-            OR EXISTS (
+        -- No included tag may be missing from the chapter (vacuously true with nothing included)
+        AND NOT EXISTS (
+            SELECT 1 FROM chapter_tag_filters CTF
+            WHERE CTF.manga_id = :mangaId AND CTF.exclude = 0
+            AND NOT EXISTS (
                 SELECT 1 FROM chapters_chapter_tags CCT
-                JOIN chapter_tag_filters CTF2
-                ON CTF2.tag_id = CCT.tag_id AND CTF2.manga_id = :mangaId
-                WHERE CCT.chapter_id = C._id
+                WHERE CCT.chapter_id = C._id AND CCT.tag_id = CTF.tag_id
             )
+        )
+        AND NOT EXISTS (
+            SELECT 1 FROM chapters_chapter_tags CCT3
+            JOIN chapter_tag_filters CTF3
+            ON CTF3.tag_id = CCT3.tag_id AND CTF3.manga_id = :mangaId AND CTF3.exclude = 1
+            WHERE CCT3.chapter_id = C._id
         )
     )
     -- KMK <--

--- a/data/src/main/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters.sq
@@ -73,6 +73,15 @@ AND (
         ES.scanlator IS NULL
         AND ((M.chapter_flags & :bookmarkUnmask) = 0 OR C.bookmark = 0)
         AND ((M.chapter_flags & :bookmarkMask) = 0 OR C.bookmark = 1)
+        AND (
+            NOT EXISTS (SELECT 1 FROM chapter_tag_filters CTF WHERE CTF.manga_id = :mangaId)
+            OR EXISTS (
+                SELECT 1 FROM chapters_chapter_tags CCT
+                JOIN chapter_tag_filters CTF2
+                ON CTF2.tag_id = CCT.tag_id AND CTF2.manga_id = :mangaId
+                WHERE CCT.chapter_id = C._id
+            )
+        )
     )
     -- KMK <--
 );
@@ -120,6 +129,15 @@ AND (
         ES.scanlator IS NULL
         AND ((MA.chapter_flags & :bookmarkUnmask) = 0 OR C.bookmark = 0)
         AND ((MA.chapter_flags & :bookmarkMask) = 0 OR C.bookmark = 1)
+        AND (
+            NOT EXISTS (SELECT 1 FROM chapter_tag_filters CTF WHERE CTF.manga_id = :mangaId)
+            OR EXISTS (
+                SELECT 1 FROM chapters_chapter_tags CCT
+                JOIN chapter_tag_filters CTF2
+                ON CTF2.tag_id = CCT.tag_id AND CTF2.manga_id = :mangaId
+                WHERE CCT.chapter_id = C._id
+            )
+        )
     )
     -- KMK <--
 )

--- a/data/src/main/sqldelight/tachiyomi/data/chapters_chapter_tags.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters_chapter_tags.sq
@@ -1,0 +1,38 @@
+-- Komikku: chapter <-> chapter_tag assignments.
+CREATE TABLE chapters_chapter_tags(
+    chapter_id INTEGER NOT NULL,
+    tag_id INTEGER NOT NULL,
+    PRIMARY KEY(chapter_id, tag_id),
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id)
+    ON DELETE CASCADE,
+    FOREIGN KEY(tag_id) REFERENCES chapter_tags (_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX idx_chapters_chapter_tags_tag_id ON chapters_chapter_tags(tag_id);
+
+insert:
+INSERT OR IGNORE INTO chapters_chapter_tags(chapter_id, tag_id)
+VALUES (:chapterId, :tagId);
+
+deleteByChapterId:
+DELETE FROM chapters_chapter_tags
+WHERE chapter_id = :chapterId;
+
+getTagIdsByChapterIds:
+SELECT chapter_id AS chapterId, tag_id AS tagId
+FROM chapters_chapter_tags
+WHERE chapter_id IN :chapterIds;
+
+getTagIdsPerManga:
+SELECT C.manga_id AS mangaId, CCT.tag_id AS tagId
+FROM chapters_chapter_tags CCT
+JOIN chapters C
+ON C._id = CCT.chapter_id
+UNION
+SELECT ME.merge_id AS mangaId, CCT.tag_id AS tagId
+FROM chapters_chapter_tags CCT
+JOIN chapters C
+ON C._id = CCT.chapter_id
+JOIN merged ME
+ON ME.manga_id = C.manga_id;

--- a/data/src/main/sqldelight/tachiyomi/data/chapters_chapter_tags.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/chapters_chapter_tags.sq
@@ -19,6 +19,12 @@ deleteByChapterId:
 DELETE FROM chapters_chapter_tags
 WHERE chapter_id = :chapterId;
 
+-- Run before deleting the tag itself: the FK cascade would remove these rows too, but SQLDelight
+-- only notifies listeners of the tables named in the executed statement.
+deleteByTagId:
+DELETE FROM chapters_chapter_tags
+WHERE tag_id = :tagId;
+
 getTagIdsByChapterIds:
 SELECT chapter_id AS chapterId, tag_id AS tagId
 FROM chapters_chapter_tags

--- a/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
@@ -19,6 +19,7 @@ CREATE INDEX IF NOT EXISTS idx_chapters_chapter_tags_tag_id ON chapters_chapter_
 CREATE TABLE IF NOT EXISTS chapter_tag_filters(
     manga_id INTEGER NOT NULL,
     tag_id INTEGER NOT NULL,
+    exclude INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY(manga_id, tag_id),
     FOREIGN KEY(manga_id) REFERENCES mangas (_id)
     ON DELETE CASCADE,

--- a/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/47.sqm
@@ -1,0 +1,29 @@
+-- Komikku: user-created chapter tags, chapter assignments and per-manga tag filter selection
+CREATE TABLE IF NOT EXISTS chapter_tags(
+    _id INTEGER NOT NULL PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS chapters_chapter_tags(
+    chapter_id INTEGER NOT NULL,
+    tag_id INTEGER NOT NULL,
+    PRIMARY KEY(chapter_id, tag_id),
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id)
+    ON DELETE CASCADE,
+    FOREIGN KEY(tag_id) REFERENCES chapter_tags (_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_chapters_chapter_tags_tag_id ON chapters_chapter_tags(tag_id);
+
+CREATE TABLE IF NOT EXISTS chapter_tag_filters(
+    manga_id INTEGER NOT NULL,
+    tag_id INTEGER NOT NULL,
+    PRIMARY KEY(manga_id, tag_id),
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id)
+    ON DELETE CASCADE,
+    FOREIGN KEY(tag_id) REFERENCES chapter_tags (_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_chapter_tag_filters_tag_id ON chapter_tag_filters(tag_id);

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/CreateChapterTagWithName.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/CreateChapterTagWithName.kt
@@ -1,0 +1,27 @@
+package tachiyomi.domain.chapterTag.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+
+class CreateChapterTagWithName(
+    private val chapterTagRepository: ChapterTagRepository,
+) {
+
+    suspend fun await(name: String): Result = withNonCancellableContext {
+        try {
+            val id = chapterTagRepository.insert(name = name)
+            Result.Success(ChapterTag(id = id, name = name))
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    sealed interface Result {
+        data class Success(val chapterTag: ChapterTag) : Result
+        data class InternalError(val error: Throwable) : Result
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/DeleteChapterTag.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/DeleteChapterTag.kt
@@ -1,0 +1,42 @@
+package tachiyomi.domain.chapterTag.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+import tachiyomi.domain.library.service.LibraryPreferences
+
+class DeleteChapterTag(
+    private val chapterTagRepository: ChapterTagRepository,
+    private val libraryPreferences: LibraryPreferences,
+) {
+
+    suspend fun await(tagId: Long) = withNonCancellableContext {
+        try {
+            chapterTagRepository.delete(tagId)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+
+        // DB rows referencing the tag (assignments + per-manga filters) are removed by FK cascade;
+        // only the library-filter preferences need scrubbing.
+        val tagPreferences = listOf(
+            libraryPreferences.filterChapterTagsInclude(),
+            libraryPreferences.filterChapterTagsExclude(),
+        )
+        val tagIdString = tagId.toString()
+        tagPreferences.forEach { preference ->
+            val ids = preference.get()
+            if (tagIdString !in ids) return@forEach
+            preference.set(ids.minus(tagIdString))
+        }
+
+        Result.Success
+    }
+
+    sealed interface Result {
+        data object Success : Result
+        data class InternalError(val error: Throwable) : Result
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/DeleteChapterTag.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/DeleteChapterTag.kt
@@ -19,8 +19,8 @@ class DeleteChapterTag(
             return@withNonCancellableContext Result.InternalError(e)
         }
 
-        // DB rows referencing the tag (assignments + per-manga filters) are removed by FK cascade;
-        // only the library-filter preferences need scrubbing.
+        // DB rows referencing the tag (assignments + per-manga filters) are removed by the repository
+        // in the same transaction; only the library-filter preferences need scrubbing.
         val tagPreferences = listOf(
             libraryPreferences.filterChapterTagsInclude(),
             libraryPreferences.filterChapterTagsExclude(),

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTagFilter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTagFilter.kt
@@ -1,13 +1,14 @@
 package tachiyomi.domain.chapterTag.interactor
 
 import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.chapterTag.model.ChapterTagFilter
 import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
 
 class GetChapterTagFilter(
     private val chapterTagRepository: ChapterTagRepository,
 ) {
 
-    fun subscribe(mangaId: Long): Flow<Set<Long>> = chapterTagRepository.getFilterTagIdsAsFlow(mangaId)
+    fun subscribe(mangaId: Long): Flow<ChapterTagFilter> = chapterTagRepository.getFilterAsFlow(mangaId)
 
-    suspend fun await(mangaId: Long): Set<Long> = chapterTagRepository.getFilterTagIds(mangaId)
+    suspend fun await(mangaId: Long): ChapterTagFilter = chapterTagRepository.getFilter(mangaId)
 }

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTagFilter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTagFilter.kt
@@ -8,4 +8,6 @@ class GetChapterTagFilter(
 ) {
 
     fun subscribe(mangaId: Long): Flow<Set<Long>> = chapterTagRepository.getFilterTagIdsAsFlow(mangaId)
+
+    suspend fun await(mangaId: Long): Set<Long> = chapterTagRepository.getFilterTagIds(mangaId)
 }

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTagFilter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTagFilter.kt
@@ -1,0 +1,11 @@
+package tachiyomi.domain.chapterTag.interactor
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+
+class GetChapterTagFilter(
+    private val chapterTagRepository: ChapterTagRepository,
+) {
+
+    fun subscribe(mangaId: Long): Flow<Set<Long>> = chapterTagRepository.getFilterTagIdsAsFlow(mangaId)
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTags.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTags.kt
@@ -15,6 +15,9 @@ class GetChapterTags(
     fun subscribeByMangaId(mangaId: Long): Flow<Map<Long, List<ChapterTag>>> =
         chapterTagRepository.getTagsByMangaIdAsFlow(mangaId)
 
+    suspend fun awaitByMangaId(mangaId: Long): Map<Long, List<ChapterTag>> =
+        chapterTagRepository.getTagsByMangaId(mangaId)
+
     suspend fun awaitTagIdsByChapterIds(chapterIds: List<Long>): Map<Long, List<Long>> =
         chapterTagRepository.getTagIdsByChapterIds(chapterIds)
 }

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTags.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTags.kt
@@ -1,0 +1,20 @@
+package tachiyomi.domain.chapterTag.interactor
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+
+class GetChapterTags(
+    private val chapterTagRepository: ChapterTagRepository,
+) {
+
+    fun subscribe(): Flow<List<ChapterTag>> = chapterTagRepository.getAllAsFlow()
+
+    suspend fun await(): List<ChapterTag> = chapterTagRepository.getAll()
+
+    fun subscribeByMangaId(mangaId: Long): Flow<Map<Long, List<ChapterTag>>> =
+        chapterTagRepository.getTagsByMangaIdAsFlow(mangaId)
+
+    suspend fun awaitTagIdsByChapterIds(chapterIds: List<Long>): Map<Long, List<Long>> =
+        chapterTagRepository.getTagIdsByChapterIds(chapterIds)
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTagsPerManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/GetChapterTagsPerManga.kt
@@ -1,0 +1,11 @@
+package tachiyomi.domain.chapterTag.interactor
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+
+class GetChapterTagsPerManga(
+    private val chapterTagRepository: ChapterTagRepository,
+) {
+
+    fun subscribe(): Flow<Map<Long, Set<Long>>> = chapterTagRepository.getTagIdsPerMangaAsFlow()
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/RenameChapterTag.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/RenameChapterTag.kt
@@ -1,0 +1,27 @@
+package tachiyomi.domain.chapterTag.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+
+class RenameChapterTag(
+    private val chapterTagRepository: ChapterTagRepository,
+) {
+
+    suspend fun await(chapterTag: ChapterTag, name: String) = withNonCancellableContext {
+        try {
+            chapterTagRepository.rename(chapterTag.id, name)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    sealed interface Result {
+        data object Success : Result
+        data class InternalError(val error: Throwable) : Result
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/SetChapterTagFilter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/SetChapterTagFilter.kt
@@ -1,0 +1,18 @@
+package tachiyomi.domain.chapterTag.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+
+class SetChapterTagFilter(
+    private val chapterTagRepository: ChapterTagRepository,
+) {
+
+    suspend fun await(mangaId: Long, tagIds: Set<Long>) {
+        try {
+            chapterTagRepository.setFilterTagIds(mangaId, tagIds)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+        }
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/SetChapterTagFilter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/SetChapterTagFilter.kt
@@ -2,15 +2,16 @@ package tachiyomi.domain.chapterTag.interactor
 
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapterTag.model.ChapterTagFilter
 import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
 
 class SetChapterTagFilter(
     private val chapterTagRepository: ChapterTagRepository,
 ) {
 
-    suspend fun await(mangaId: Long, tagIds: Set<Long>) {
+    suspend fun await(mangaId: Long, filter: ChapterTagFilter) {
         try {
-            chapterTagRepository.setFilterTagIds(mangaId, tagIds)
+            chapterTagRepository.setFilter(mangaId, filter)
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
         }

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/SetChapterTags.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/SetChapterTags.kt
@@ -1,0 +1,18 @@
+package tachiyomi.domain.chapterTag.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapterTag.repository.ChapterTagRepository
+
+class SetChapterTags(
+    private val chapterTagRepository: ChapterTagRepository,
+) {
+
+    suspend fun await(chapterId: Long, tagIds: List<Long>) {
+        try {
+            chapterTagRepository.setChapterTags(chapterId, tagIds)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+        }
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/SetChapterTags.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/interactor/SetChapterTags.kt
@@ -15,4 +15,16 @@ class SetChapterTags(
             logcat(LogPriority.ERROR, e)
         }
     }
+
+    /**
+     * Adds tags without dropping the ones the chapter already carries. Used when restoring a
+     * backup, where the tags on disk should be merged into the device's state rather than replace it.
+     */
+    suspend fun awaitAdd(chapterId: Long, tagIds: List<Long>) {
+        try {
+            chapterTagRepository.addChapterTags(chapterId, tagIds)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+        }
+    }
 }

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/model/ChapterTag.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/model/ChapterTag.kt
@@ -1,0 +1,8 @@
+package tachiyomi.domain.chapterTag.model
+
+import java.io.Serializable
+
+data class ChapterTag(
+    val id: Long,
+    val name: String,
+) : Serializable

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/model/ChapterTagFilter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/model/ChapterTagFilter.kt
@@ -1,0 +1,19 @@
+package tachiyomi.domain.chapterTag.model
+
+/**
+ * Per-manga chapter tag filter selection.
+ *
+ * A chapter is kept when it carries every [included] tag (vacuously true when nothing is
+ * included) and none of the [excluded] tags.
+ */
+data class ChapterTagFilter(
+    val included: Set<Long> = emptySet(),
+    val excluded: Set<Long> = emptySet(),
+) {
+    val isActive: Boolean
+        get() = included.isNotEmpty() || excluded.isNotEmpty()
+
+    companion object {
+        val Empty = ChapterTagFilter()
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/repository/ChapterTagRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/repository/ChapterTagRepository.kt
@@ -2,6 +2,7 @@ package tachiyomi.domain.chapterTag.repository
 
 import kotlinx.coroutines.flow.Flow
 import tachiyomi.domain.chapterTag.model.ChapterTag
+import tachiyomi.domain.chapterTag.model.ChapterTagFilter
 
 interface ChapterTagRepository {
 
@@ -25,12 +26,15 @@ interface ChapterTagRepository {
 
     suspend fun setChapterTags(chapterId: Long, tagIds: List<Long>)
 
+    /** Adds [tagIds] to a chapter without dropping tags it already carries. */
+    suspend fun addChapterTags(chapterId: Long, tagIds: List<Long>)
+
     fun getTagIdsPerMangaAsFlow(): Flow<Map<Long, Set<Long>>>
 
     // Per-manga filter selection
-    suspend fun getFilterTagIds(mangaId: Long): Set<Long>
+    suspend fun getFilter(mangaId: Long): ChapterTagFilter
 
-    fun getFilterTagIdsAsFlow(mangaId: Long): Flow<Set<Long>>
+    fun getFilterAsFlow(mangaId: Long): Flow<ChapterTagFilter>
 
-    suspend fun setFilterTagIds(mangaId: Long, tagIds: Set<Long>)
+    suspend fun setFilter(mangaId: Long, filter: ChapterTagFilter)
 }

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/repository/ChapterTagRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/repository/ChapterTagRepository.kt
@@ -1,0 +1,32 @@
+package tachiyomi.domain.chapterTag.repository
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.chapterTag.model.ChapterTag
+
+interface ChapterTagRepository {
+
+    // Tag definitions
+    suspend fun getAll(): List<ChapterTag>
+
+    fun getAllAsFlow(): Flow<List<ChapterTag>>
+
+    suspend fun insert(name: String): Long
+
+    suspend fun rename(tagId: Long, name: String)
+
+    suspend fun delete(tagId: Long)
+
+    // Assignments
+    suspend fun getTagIdsByChapterIds(chapterIds: List<Long>): Map<Long, List<Long>>
+
+    fun getTagsByMangaIdAsFlow(mangaId: Long): Flow<Map<Long, List<ChapterTag>>>
+
+    suspend fun setChapterTags(chapterId: Long, tagIds: List<Long>)
+
+    fun getTagIdsPerMangaAsFlow(): Flow<Map<Long, Set<Long>>>
+
+    // Per-manga filter selection
+    fun getFilterTagIdsAsFlow(mangaId: Long): Flow<Set<Long>>
+
+    suspend fun setFilterTagIds(mangaId: Long, tagIds: Set<Long>)
+}

--- a/domain/src/main/java/tachiyomi/domain/chapterTag/repository/ChapterTagRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapterTag/repository/ChapterTagRepository.kt
@@ -19,6 +19,8 @@ interface ChapterTagRepository {
     // Assignments
     suspend fun getTagIdsByChapterIds(chapterIds: List<Long>): Map<Long, List<Long>>
 
+    suspend fun getTagsByMangaId(mangaId: Long): Map<Long, List<ChapterTag>>
+
     fun getTagsByMangaIdAsFlow(mangaId: Long): Flow<Map<Long, List<ChapterTag>>>
 
     suspend fun setChapterTags(chapterId: Long, tagIds: List<Long>)
@@ -26,6 +28,8 @@ interface ChapterTagRepository {
     fun getTagIdsPerMangaAsFlow(): Flow<Map<Long, Set<Long>>>
 
     // Per-manga filter selection
+    suspend fun getFilterTagIds(mangaId: Long): Set<Long>
+
     fun getFilterTagIdsAsFlow(mangaId: Long): Flow<Set<Long>>
 
     suspend fun setFilterTagIds(mangaId: Long, tagIds: Set<Long>)

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -130,6 +130,21 @@ class LibraryPreferences(
     fun filterCategoriesInclude() = preferenceStore.getStringSet(FILTER_LIBRARY_CATEGORIES_INCLUDE_PREF_KEY, emptySet())
 
     fun filterCategoriesExclude() = preferenceStore.getStringSet(FILTER_LIBRARY_CATEGORIES_EXCLUDE_PREF_KEY, emptySet())
+
+    fun filterChapterTags() = preferenceStore.getBoolean(
+        "pref_filter_library_chapter_tags",
+        false,
+    )
+
+    fun filterChapterTagsInclude() = preferenceStore.getStringSet(
+        FILTER_LIBRARY_CHAPTER_TAGS_INCLUDE_PREF_KEY,
+        emptySet(),
+    )
+
+    fun filterChapterTagsExclude() = preferenceStore.getStringSet(
+        FILTER_LIBRARY_CHAPTER_TAGS_EXCLUDE_PREF_KEY,
+        emptySet(),
+    )
     // KMK <--
 
     fun filterTracking(id: Int) = preferenceStore.getEnum(
@@ -290,6 +305,8 @@ class LibraryPreferences(
         // KMK -->
         private const val FILTER_LIBRARY_CATEGORIES_INCLUDE_PREF_KEY = "pref_filter_library_categories_include"
         private const val FILTER_LIBRARY_CATEGORIES_EXCLUDE_PREF_KEY = "pref_filter_library_categories_exclude"
+        private const val FILTER_LIBRARY_CHAPTER_TAGS_INCLUDE_PREF_KEY = "pref_filter_library_chapter_tags_include"
+        private const val FILTER_LIBRARY_CHAPTER_TAGS_EXCLUDE_PREF_KEY = "pref_filter_library_chapter_tags_exclude"
         // KMK <--
 
         val categoryPreferenceKeys = setOf(

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -250,4 +250,5 @@
     <string name="action_edit_chapter_tags">Edit tags</string>
     <string name="information_empty_chapter_tags_dialog">You have no chapter tags. Use the edit button to create one.</string>
     <string name="action_filter_chapter_tags">Filter by tag</string>
+    <string name="pref_library_filter_chapter_tags_details">Entries with at least one chapter carrying the included tags will be shown</string>
 </resources>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -238,4 +238,13 @@
     <string name="pref_discord_show_download_button_summary">Displays a button to download the app</string>
     <string name="pref_discord_show_discord_button">Show Discord Button</string>
     <string name="pref_discord_show_discord_button_summary">Displays a button to join the Discord server</string>
+    <!-- Chapter tags -->
+    <string name="chapter_tags">Chapter tags</string>
+    <string name="pref_chapter_tags_summary">Create tags to organize individual chapters</string>
+    <string name="action_add_chapter_tag">Add tag</string>
+    <string name="action_rename_chapter_tag">Rename tag</string>
+    <string name="delete_chapter_tag">Delete tag</string>
+    <string name="delete_chapter_tag_confirmation">Do you wish to delete the tag %1$s?</string>
+    <string name="error_chapter_tag_exists">A tag with this name already exists!</string>
+    <string name="information_empty_chapter_tags">You have no chapter tags. Tap the plus button to create one.</string>
 </resources>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -249,4 +249,5 @@
     <string name="information_empty_chapter_tags">You have no chapter tags. Tap the plus button to create one.</string>
     <string name="action_edit_chapter_tags">Edit tags</string>
     <string name="information_empty_chapter_tags_dialog">You have no chapter tags. Use the edit button to create one.</string>
+    <string name="action_filter_chapter_tags">Filter by tag</string>
 </resources>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -249,6 +249,7 @@
     <string name="information_empty_chapter_tags">You have no chapter tags. Tap the plus button to create one.</string>
     <string name="action_edit_chapter_tags">Edit tags</string>
     <string name="information_empty_chapter_tags_dialog">You have no chapter tags. Use the edit button to create one.</string>
+    <string name="information_empty_chapter_tags_filter">You don\'t have any chapter tags yet.</string>
     <string name="action_filter_chapter_tags">Filter by tag</string>
-    <string name="pref_library_filter_chapter_tags_details">Entries with at least one chapter carrying the included tags will be shown</string>
+    <string name="pref_library_filter_chapter_tags_details">Entries whose chapters carry all of the included tags will be shown. Entries with an excluded tag will not be shown even if they also carry an included tag.</string>
 </resources>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -247,4 +247,6 @@
     <string name="delete_chapter_tag_confirmation">Do you wish to delete the tag %1$s?</string>
     <string name="error_chapter_tag_exists">A tag with this name already exists!</string>
     <string name="information_empty_chapter_tags">You have no chapter tags. Tap the plus button to create one.</string>
+    <string name="action_edit_chapter_tags">Edit tags</string>
+    <string name="information_empty_chapter_tags_dialog">You have no chapter tags. Use the edit button to create one.</string>
 </resources>

--- a/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-kmk/src/commonMain/moko-resources/base/strings.xml
@@ -252,4 +252,5 @@
     <string name="information_empty_chapter_tags_filter">You don\'t have any chapter tags yet.</string>
     <string name="action_filter_chapter_tags">Filter by tag</string>
     <string name="pref_library_filter_chapter_tags_details">Entries whose chapters carry all of the included tags will be shown. Entries with an excluded tag will not be shown even if they also carry an included tag.</string>
+    <string name="pref_filter_chapter_tags_details">Chapters carrying all of the included tags will be shown. Chapters with an excluded tag will not be shown even if they also carry an included tag.</string>
 </resources>


### PR DESCRIPTION
Adds user-created chapter tags: arbitrary labels you can assign to individual chapters, then filter by in both manga details and the library.

### What's included

- **Schema** — `chapter_tags`, `chapters_chapter_tags` and `chapter_tag_filters` tables, migration `47.sqm`, and SQL-level filtering so the library query stays a single statement.
- **Domain layer** — `ChapterTag` / `ChapterTagFilter` models, `ChapterTagRepository`, and interactors for create/rename/delete/assign plus filter get/set.
- **Tag management screen** — reachable from Settings → Library, for creating, renaming and deleting tags.
- **Assignment** — select chapters in manga details and assign tags from the bottom action menu; assigned tags render on the chapter list item.
- **Filtering** — per-manga filtering from the chapter settings dialog, and library-wide filtering from the library settings dialog. Both support include *and* exclude: an entry/chapter must carry **all** included tags, and any excluded tag hides it outright.
- **Backup & restore** — tags round-trip through backups. Assignments reference tags by name rather than id, so they survive a transfer between devices.

### Notes

- Backup proto numbers: `611` on `Backup`, `900` on `BackupChapter` (following the existing convention, e.g. `BackupCategory.hidden`).
- When a source replaces a chapter (`SyncChaptersWithSource`), tags are carried over to the recognized replacement chapter so they aren't lost on refresh.
- Branch is based directly on master @ 936e25b. If another migration lands first, `47.sqm` needs renumbering.
- Claude opus/fable were used for the development of this feature.

### Images
| Tag management | Assign tags | Chapter list | Chapter filter | Library filter |
| :---: | :---: | :---: | :---: | :---: |
| <img width="180" src="https://github.com/user-attachments/assets/ed49a892-af55-4d78-bbde-0fa59f85e2cb" /> | <img width="180" src="https://github.com/user-attachments/assets/aa35be1b-b329-4932-b9cb-1e70b1726e73" /> | <img width="180" src="https://github.com/user-attachments/assets/ff26e62f-7c6f-48d3-857b-674346a85ba9" /> | <img width="180" src="https://github.com/user-attachments/assets/eef512de-f606-42aa-85b3-91bb2e707f9b" /> | <img width="180" src="https://github.com/user-attachments/assets/f4408678-ed56-4e2e-918b-5c73d109398a" /> |

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Introduce user-defined chapter tags, with UI to manage and assign them, and integrate tag-based filtering into manga chapter views, the library, backup/restore, and chapter sync.

New Features:
- Add chapter tag domain models, repository, interactors, and persistence schema for defining tags and assigning them to chapters.
- Provide a chapter tag management screen in settings for creating, renaming, and deleting tags.
- Allow bulk editing of chapter tags from the manga chapter action menu and display assigned tags in chapter list items.
- Add per-manga chapter tag filters in the chapter settings dialog and library-wide chapter tag filters in library settings, supporting include and exclude semantics.

Enhancements:
- Wire chapter tag data into manga and library screen models so tag assignments and filters reactively update UI state.
- Extend chapter sync logic to carry tags from removed recognized chapters to their replacements so tags are preserved across updates.

Documentation:
- Document chapter tag usage and filtering behavior via new localized strings in the app UI.

Chores:
- Integrate chapter tag backup and restore, including tag definitions and per-chapter tag assignments keyed by tag name, into the existing backup infrastructure.