### PR TITLE
feat(manga-screen): Add Reindex Downloads to manga overflow menu

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -199,6 +199,7 @@ fun MangaScreen(
     onClickSourceSettingsClicked: (() -> Unit)?,
     onClearManga: () -> Unit,
     onOpenMangaFolder: (() -> Unit)?,
+    onReindexDownloads: () -> Unit,
     onRelatedMangasScreenClick: () -> Unit,
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
@@ -268,6 +269,7 @@ fun MangaScreen(
             onClickSourceSettingsClicked = onClickSourceSettingsClicked,
             onClearManga = onClearManga,
             onOpenMangaFolder = onOpenMangaFolder,
+            onReindexDownloads = onReindexDownloads,
             onRelatedMangasScreenClick = onRelatedMangasScreenClick,
             onRelatedMangaClick = onRelatedMangaClick,
             onRelatedMangaLongClick = onRelatedMangaLongClick,
@@ -330,6 +332,7 @@ fun MangaScreen(
             onClickSourceSettingsClicked = onClickSourceSettingsClicked,
             onClearManga = onClearManga,
             onOpenMangaFolder = onOpenMangaFolder,
+            onReindexDownloads = onReindexDownloads,
             onRelatedMangasScreenClick = onRelatedMangasScreenClick,
             onRelatedMangaClick = onRelatedMangaClick,
             onRelatedMangaLongClick = onRelatedMangaLongClick,
@@ -409,6 +412,7 @@ private fun MangaScreenSmallImpl(
     onClickSourceSettingsClicked: (() -> Unit)?,
     onClearManga: () -> Unit,
     onOpenMangaFolder: (() -> Unit)?,
+    onReindexDownloads: () -> Unit,
     onRelatedMangasScreenClick: () -> Unit,
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
@@ -493,6 +497,7 @@ private fun MangaScreenSmallImpl(
                 onClickSourceSettings = onClickSourceSettingsClicked,
                 onClearManga = onClearManga,
                 onOpenMangaFolder = onOpenMangaFolder,
+                onReindexDownloads = onReindexDownloads,
                 onClickRelatedMangas = onRelatedMangasScreenClick.takeIf {
                     !expandRelatedMangas &&
                         showRelatedMangasInOverflow &&
@@ -873,6 +878,7 @@ private fun MangaScreenLargeImpl(
     onClickSourceSettingsClicked: (() -> Unit)?,
     onClearManga: () -> Unit,
     onOpenMangaFolder: (() -> Unit)?,
+    onReindexDownloads: () -> Unit,
     onRelatedMangasScreenClick: () -> Unit,
     onRelatedMangaClick: (Manga) -> Unit,
     onRelatedMangaLongClick: (Manga) -> Unit,
@@ -949,6 +955,7 @@ private fun MangaScreenLargeImpl(
                 onClickSourceSettings = onClickSourceSettingsClicked,
                 onClearManga = onClearManga,
                 onOpenMangaFolder = onOpenMangaFolder,
+                onReindexDownloads = onReindexDownloads,
                 onClickRelatedMangas = onRelatedMangasScreenClick.takeIf {
                     !expandRelatedMangas &&
                         showRelatedMangasInOverflow &&

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -55,6 +55,7 @@ fun MangaToolbar(
     onClickSourceSettings: (() -> Unit)?,
     onClearManga: () -> Unit,
     onOpenMangaFolder: (() -> Unit)?,
+    onReindexDownloads: () -> Unit,
     // KMK <--
     onClickRecommend: (() -> Unit)?,
     onClickMerge: (() -> Unit)?,
@@ -235,6 +236,12 @@ fun MangaToolbar(
                     }
                     // SY <--
                     // KMK -->
+                    add(
+                        AppBar.OverflowAction(
+                            title = stringResource(MR.strings.pref_invalidate_download_cache),
+                            onClick = onReindexDownloads,
+                        ),
+                    )
                     if (onOpenMangaFolder != null) {
                         add(
                             AppBar.OverflowAction(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -412,6 +412,12 @@ class MangaScreen(
                 }
             }.takeIf { isConfigurableSource },
             onClearManga = { screenModel.showClearMangaDialog() },
+            // KMK -->
+            onReindexDownloads = {
+                screenModel.reindexDownloads()
+                context.toast(MR.strings.download_cache_invalidated)
+            },
+            // KMK <--
             onOpenMangaFolder = {
                 if (successState.mergedData == null) {
                     screenModel.openMangaFolder(screenModel.source, screenModel.manga)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -1970,6 +1970,10 @@ class MangaScreenModel(
     fun showClearMangaDialog() {
         updateSuccessState { it.copy(dialog = Dialog.ClearManga) }
     }
+
+    fun reindexDownloads() {
+        downloadCache.invalidateCache()
+    }
     // KMK <--
 
     sealed interface State {


### PR DESCRIPTION
## Description

Adds a manual **Reindex Downloads** button to the `⋮` overflow menu on the manga detail screen, mirroring the identical entry already present in the library overflow menu (added in v1.13.3 by @Tsukuyoumii) and in Settings → Advanced.

### Why

When the download cache renewal interval is set to **Manual**, or when chapter files are added/moved/deleted outside the app (e.g. via a file manager or sideloading), there is currently no quick way to force a cache refresh from within a specific manga's screen. You have to navigate away to the library menu or deep into Advanced settings.

### What changed

- `MangaScreenModel`: add `reindexDownloads()` calling `downloadCache.invalidateCache()`
- `MangaToolbar`: add `onReindexDownloads` param and `OverflowAction` item
- `MangaScreen` (presentation): propagate param through top-level, `SmallImpl`, and `LargeImpl`
- `MangaScreen` (navigator): wire callback with toast feedback

No new strings — reuses `MR.strings.pref_invalidate_download_cache` ("Reindex downloads") and `MR.strings.download_cache_invalidated` toast, both already from Mihon upstream.

### Notes

This change was authored with the help of an AI coding agent ([Arena.ai](https://arena.ai)) and **has not been locally compiled or run** due to lack of a local Android build environment. CI compilation and user testing would be needed to verify.

## Summary by Sourcery

Enable manual download cache reindexing directly from the manga detail screen.

New Features:
- Add a Reindex Downloads action to the manga detail screen overflow menu.

Enhancements:
- Provide toast feedback after manually invalidating the download cache.