### PR TITLE
Update default user agent

### DIFF
--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkPreferences.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkPreferences.kt
@@ -18,7 +18,7 @@ class NetworkPreferences(
     fun defaultUserAgent(): Preference<String> {
         return preferenceStore.getString(
             "default_user_agent",
-            "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Mobile Safari/537.36",
         )
     }
 }


### PR DESCRIPTION
Why is this not automated in the first place? Maybe an action should be created for this.

## Summary by Sourcery

Enhancements:
- Update the default network user agent to identify as Chrome 152.