### PR TITLE
CI: Dependency Review step aborts the whole PR build on forks without Dependency graph

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -35,6 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Dependency Review
+        if: github.repository == 'komikku-app/komikku'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
 
       - name: Validate Gradle Wrapper


### PR DESCRIPTION
`.github/workflows/build_pull_request.yml` runs `actions/dependency-review-action` unconditionally. On a fork where Dependency graph is off (the GitHub default for forks) the step fails with:

```
Dependency review is not supported on this repository. Please ensure that Dependency graph is enabled
```

Every later step (wrapper validation, JDK setup, spotless, build, unit tests) never runs, so a contributor gets no CI signal at all on their fork before opening a PR here. I hit this on the fork behind #1845.

This guards the step so it only runs on this repository:

```yaml
      - name: Dependency Review
        if: github.repository == 'komikku-app/komikku'
        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
```

`continue-on-error: true` would also work but hides real dependency findings on the main repo, so the `if:` is the better shape.

## Summary by Sourcery

Limit dependency review to the upstream repository so fork-based pull requests can complete the remaining CI checks.

Bug Fixes:
- Prevent dependency review failures on forked repositories from blocking the remainder of pull request CI.

CI:
- Run dependency review only in the upstream repository while preserving enforcement there.