### PR TITLE
fix(widget): resolve CompositionLocal crash in empty and locked states

### DIFF
--- a/presentation-widget/src/main/java/tachiyomi/presentation/widget/components/LockedWidget.kt
+++ b/presentation-widget/src/main/java/tachiyomi/presentation/widget/components/LockedWidget.kt
@@ -16,8 +16,8 @@ import androidx.glance.text.TextAlign
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import tachiyomi.core.common.Constants
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.i18n.MR
-import tachiyomi.presentation.core.i18n.stringResource
 
 @Composable
 fun LockedWidget(
@@ -34,7 +34,10 @@ fun LockedWidget(
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = stringResource(MR.strings.appwidget_unavailable_locked),
+            // Use the plain Context.stringResource() extension, not presentation-core's
+            // Compose-UI variant: Glance composables don't provide the standard
+            // androidx.compose.ui.platform.LocalContext, only androidx.glance.LocalContext.
+            text = LocalContext.current.stringResource(MR.strings.appwidget_unavailable_locked),
             style = TextStyle(
                 color = foreground,
                 fontSize = 12.sp,

--- a/presentation-widget/src/main/java/tachiyomi/presentation/widget/components/UpdatesWidget.kt
+++ b/presentation-widget/src/main/java/tachiyomi/presentation/widget/components/UpdatesWidget.kt
@@ -24,9 +24,9 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import kotlinx.collections.immutable.ImmutableList
 import tachiyomi.core.common.Constants
+import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.manga.model.MangaCover
 import tachiyomi.i18n.MR
-import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.widget.util.calculateRowAndColumnCount
 
 @Composable
@@ -45,7 +45,10 @@ fun UpdatesWidget(
             CircularProgressIndicator(color = contentColor)
         } else if (data.isEmpty()) {
             Text(
-                text = stringResource(MR.strings.information_no_recent),
+                // Use the plain Context.stringResource() extension, not presentation-core's
+                // Compose-UI variant: Glance composables don't provide the standard
+                // androidx.compose.ui.platform.LocalContext, only androidx.glance.LocalContext.
+                text = LocalContext.current.stringResource(MR.strings.information_no_recent),
                 style = TextStyle(color = contentColor),
             )
         } else {


### PR DESCRIPTION
# Problem
`UpdatesWidget` and `LockedWidget` crashed when rendering their text-only states (no recent updates, app-lock enabled).

Both composables called presentation-core's `stringResource()`, which depends on `androidx.compose.ui.platform.LocalContext`. Glance compositions never provide that CompositionLocal, they only provide `androidx.glance.LocalContext`, so hitting either code path threw: “IllegalStateException: CompositionLocal LocalContext not present”

From the launcher's perspective this made the widget fail to render its content, falling back to Android's generic "Couldn't load widget" placeholder.

## Fix
Switch both call sites to `core:common`'s plain `Context.stringResource()` extension, invoked via `LocalContext.current` (Glance's `LocalContext`), which has no dependency on Compose UI's context provider.

## Main changes
- `LockedWidget.kt`: replace `tachiyomi.presentation.core.i18n.stringResource`  import with `tachiyomi.core.common.i18n.stringResource`; update the  `appwidget_unavailable_locked` text call accordingly.
- `UpdatesWidget.kt`: same swap for the `information_no_recent` text  call in the empty-updates state.
- Added inline comments explaining why the plain `Context` extension  is required instead of the Compose-UI variant, to prevent regressions when the code is next touched.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Fix widget text rendering for locked and empty-updates states.

Bug Fixes:
- Prevent widget rendering crashes in locked and empty-updates states by using Glance-compatible localized string resolution.

Enhancements:
- Document the required context-based localization approach to avoid regressions.