### PR TITLE
Hotfix(sync): stream the backup upload to avoid OutOfMemoryError

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncDataJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/SyncDataJob.kt
@@ -55,6 +55,12 @@ class SyncDataJob(private val context: Context, workerParams: WorkerParameters) 
         return try {
             SyncManager(context).syncData()
             Result.success()
+        } catch (e: OutOfMemoryError) {
+            // Backup creation/merge happens before doSync, so an OOM there never reaches
+            // SyncYomiSyncService's handler. Report instead of crashing silently.
+            logcat(LogPriority.ERROR) { "Out of memory syncing: ${e.message}" }
+            notifier.showSyncError("Not enough memory to sync this library")
+            Result.success() // try again next time
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
             notifier.showSyncError(e.message)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/BackupRequestBody.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/BackupRequestBody.kt
@@ -1,0 +1,60 @@
+package eu.kanade.tachiyomi.data.sync.service
+
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.protobuf.ProtoNumber
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.BufferedSink
+
+/**
+ * A streaming [RequestBody] for a protobuf-encoded backup.
+ *
+ * Serialising the whole backup with `ProtoBuf.encodeToByteArray` needs a single contiguous
+ * buffer that kotlinx.serialization grows by doubling and copying, so a large library peaks
+ * at roughly twice its serialized size and can throw [OutOfMemoryError] on devices with a
+ * small heap even though the library itself fits in memory.
+ *
+ * This body instead writes one length-delimited `backupManga` (field 1) record per manga
+ * followed by the backup's other fields ([metaBytes]). Concatenating a repeated protobuf
+ * field's records is valid (successive messages of the same type merge), so the result
+ * decodes to the same [eu.kanade.tachiyomi.data.backup.models.Backup] while peak memory is
+ * bounded by the largest single manga instead of the whole library. The payload has no
+ * known length, so it is sent with chunked transfer-encoding.
+ */
+class BackupRequestBody(
+    private val protoBuf: ProtoBuf,
+    private val manga: Iterable<BackupManga>,
+    private val metaBytes: ByteArray,
+    private val contentType: MediaType?,
+) : RequestBody() {
+
+    override fun contentType(): MediaType? = contentType
+
+    // Unknown length: OkHttp falls back to chunked transfer-encoding.
+    override fun contentLength(): Long = -1L
+
+    override fun writeTo(sink: BufferedSink) {
+        // The manga records go first so the streamed payload is byte-for-byte identical to
+        // ProtoBuf.encodeToByteArray(Backup.serializer(), backup): Backup declares
+        // backupManga (field 1) before its other fields.
+        val serializer = MangaChunk.serializer()
+        for (entry in manga) {
+            sink.write(protoBuf.encodeToByteArray(serializer, MangaChunk(entry)))
+        }
+
+        sink.write(metaBytes)
+    }
+
+    /**
+     * Emits a single `backupManga` field record (field 1, wire type 2). Its encoding is
+     * identical to one element of
+     * [eu.kanade.tachiyomi.data.backup.models.Backup.backupManga], which is what makes the
+     * concatenated stream a valid Backup message.
+     */
+    @Serializable
+    private class MangaChunk(
+        @ProtoNumber(1) val manga: BackupManga,
+    )
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/sync/service/SyncYomiSyncService.kt
@@ -103,6 +103,13 @@ class SyncYomiSyncService(
             notifier.showSyncError(e.message)
             reportSyncEvent(SyncEventStatus.SYNC_ERROR, e.message)
             return null
+        } catch (e: OutOfMemoryError) {
+            // OutOfMemoryError is an Error, not an Exception, so without this it would
+            // escape the worker and leave the sync stuck on "running" with no error shown.
+            logcat(LogPriority.ERROR) { "Out of memory syncing: ${e.message}" }
+            notifier.showSyncError("Not enough memory to sync this library")
+            reportSyncEvent(SyncEventStatus.SYNC_ERROR, "OutOfMemoryError")
+            return null
         }
     }
 
@@ -180,11 +187,21 @@ class SyncYomiSyncService(
         }
         val headers = headersBuilder.build()
 
-        val byteArray = protoBuf.encodeToByteArray(Backup.serializer(), backup)
-        if (byteArray.isEmpty()) {
+        // Encode the metadata once and stream the manga list, so a large library is never
+        // held as a single contiguous ByteArray (which is prone to OutOfMemoryError).
+        val metaBytes = protoBuf.encodeToByteArray(
+            Backup.serializer(),
+            backup.copy(backupManga = emptyList()),
+        )
+        if (metaBytes.isEmpty() && backup.backupManga.isEmpty()) {
             throw IllegalStateException(context.stringResource(MR.strings.empty_backup_error))
         }
-        val body = byteArray.toRequestBody("application/octet-stream".toMediaType())
+        val body = BackupRequestBody(
+            protoBuf = protoBuf,
+            manga = backup.backupManga,
+            metaBytes = metaBytes,
+            contentType = "application/octet-stream".toMediaType(),
+        )
 
         val uploadRequest = PUT(
             url = uploadUrl,

--- a/app/src/test/java/eu/kanade/tachiyomi/data/sync/service/BackupRequestBodyTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/sync/service/BackupRequestBodyTest.kt
@@ -1,0 +1,85 @@
+package eu.kanade.tachiyomi.data.sync.service
+
+import eu.kanade.tachiyomi.data.backup.models.Backup
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import eu.kanade.tachiyomi.data.backup.models.BackupManga
+import kotlinx.serialization.protobuf.ProtoBuf
+import okhttp3.MediaType.Companion.toMediaType
+import okio.Buffer
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BackupRequestBodyTest {
+
+    private val protoBuf: ProtoBuf = ProtoBuf
+
+    @Test
+    fun `streams a backup that decodes back to the same data`() {
+        val backup = Backup(
+            backupManga = listOf(
+                BackupManga(source = 1L, url = "/manga/a", title = "A"),
+                BackupManga(source = 2L, url = "/manga/b", title = "B", notes = "note"),
+            ),
+            backupCategories = listOf(BackupCategory(name = "Cat", order = 1L)),
+        )
+
+        val decoded = writeAndDecode(backup)
+
+        assertEquals(backup.backupManga.map { it.comparable() }, decoded.backupManga.map { it.comparable() })
+        assertEquals(
+            backup.backupCategories.map { it.name to it.order },
+            decoded.backupCategories.map { it.name to it.order },
+        )
+    }
+
+    @Test
+    fun `concatenates one record per manga in order`() {
+        val backup = Backup(
+            backupManga = (1L..25L).map {
+                BackupManga(source = 1L, url = "/manga/$it", title = "Manga $it")
+            },
+        )
+
+        val decoded = writeAndDecode(backup)
+
+        assertEquals(backup.backupManga.map { it.url }, decoded.backupManga.map { it.url })
+    }
+
+    @Test
+    fun `is byte-for-byte identical to encoding the whole backup`() {
+        val backup = Backup(
+            backupManga = (1L..5L).map {
+                BackupManga(source = 1L, url = "/manga/$it", title = "Manga $it")
+            },
+            backupCategories = listOf(BackupCategory(name = "Cat", order = 1L)),
+        )
+
+        val expected = protoBuf.encodeToByteArray(Backup.serializer(), backup)
+        val buffer = Buffer()
+        buildBody(backup).writeTo(buffer)
+
+        assertArrayEquals(expected, buffer.readByteArray())
+    }
+
+    private fun writeAndDecode(backup: Backup): Backup {
+        val buffer = Buffer()
+        buildBody(backup).writeTo(buffer)
+        return protoBuf.decodeFromByteArray(Backup.serializer(), buffer.readByteArray())
+    }
+
+    private fun BackupManga.comparable() = Triple(url, title, notes)
+
+    private fun buildBody(backup: Backup): BackupRequestBody {
+        val metaBytes = protoBuf.encodeToByteArray(
+            Backup.serializer(),
+            backup.copy(backupManga = emptyList()),
+        )
+        return BackupRequestBody(
+            protoBuf = protoBuf,
+            manga = backup.backupManga,
+            metaBytes = metaBytes,
+            contentType = "application/octet-stream".toMediaType(),
+        )
+    }
+}


### PR DESCRIPTION
Only a hotfix: Once [this PR to SY](https://github.com/jobobby04/TachiyomiSY/pull/1648) is merged, the problem should go away just by virtue of far smaller deltas.

---

Serialising a whole backup with ProtoBuf.encodeToByteArray needs a single contiguous buffer that kotlinx.serialization grows by doubling and copying, so a large library peaks at roughly twice its serialized size and throws OutOfMemoryError on devices with a small heap even though the library itself fits in memory.

Write the top-level Backup as its non-manga fields followed by one length-delimited backupManga (field 1) record per manga instead. Splitting a repeated protobuf field into several records is valid, so the payload decodes identically while peak memory is bounded by the largest single manga. The body has no known length and is sent chunked.

Also handle OutOfMemoryError explicitly in SyncYomiSyncService.doSync and SyncDataJob.doWork. It is an Error, not an Exception, so the previous handlers missed it: no error was shown and the sync stayed stuck on "running" on the server.

<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.

  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/komikku-app/komikku/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

## Summary by Sourcery

Stream large backup uploads and report out-of-memory sync failures reliably.

New Features:
- Stream backup uploads as chunked protobuf request bodies to support large libraries without allocating the entire serialized backup.

Bug Fixes:
- Handle OutOfMemoryError during synchronization so users receive an error and server-side syncs do not remain stuck in a running state.

Tests:
- Add coverage verifying streamed backups decode correctly, preserve manga order, and match whole-backup protobuf encoding.